### PR TITLE
Routing hint: ad-hoc cuts prefer pre-existing oracles, inline execution

### DIFF
--- a/rules/topology.md
+++ b/rules/topology.md
@@ -10,14 +10,16 @@
    first: a direct answer from evidence already in context; a one-off
    bounded route to `orch-task` through an ad-hoc ticket — any request
    that fits one executor's context and bound routes here, named
-   acceptance criteria included; one lane answering a bounded question →
+   acceptance criteria included, oracles concretely specified at cut
+   time — `pre-existing` provenance, independence and inline law per
+   [rules/verification.md](verification.md) §10 and
+   [rules/delegation.md](delegation.md) §2; one lane answering a bounded question →
    `orch-investigate`; independent one-offs: dispatch each packet in
    parallel through the delegation boundary, every result crossing the
    join; dependent one-offs: cut the ad-hoc set with edges, name its
    run bound, and run `orch-frontier` over it — the ticket files are
    the durable state, no spec and no worklog; independence enters per
-   [rules/verification.md](verification.md) §10 through per-item
-   checkers; else — only when the work
+   [rules/verification.md](verification.md) §10; else — only when the work
    needs a frozen spec: lanes at scale, an assembly, or resumption
    across sessions — a pattern, stamped by shape of done, each with
    one entrypoint: acceptance met once → deliver (`orch-deliver`) —

--- a/templates/host-block.md
+++ b/templates/host-block.md
@@ -12,7 +12,10 @@ defines.
 - Route smallest-first: a direct answer from evidence already in
   context; one one-off bounded task to an ad-hoc ticket and
   `orch-task` — any request that fits one executor's context and
-  bound routes here, named acceptance criteria included; one lane
+  bound routes here, named acceptance criteria included, oracles
+  concretely specified at cut time — `pre-existing` provenance,
+  independence and inline law per rules/verification.md §10 and
+  rules/delegation.md §2; one lane
   answering a bounded question routes to `orch-investigate`;
   independent one-offs: dispatch each packet in parallel through
   `orch-delegate`, every result crossing `orch-integrate`; dependent


### PR DESCRIPTION
Small requests routed through the ad-hoc `orch-task` path were paying full ceremony — authored-here oracles dragging in an `orch-check` spawn, work spawned to a child — when the law already permits a faster lawful shape. This makes intake prefer it.

## Changes

- **`rules/topology.md` §2** (canonical) and **`templates/host-block.md`** (installed mirror): the one-off `orch-task` branch now steers cuts to name concrete oracles at cut time — `pre-existing` provenance — with independence and inline consequence linked to their owners (verification §10, delegation §2) rather than restated.
- **`rules/topology.md` §2**, dependent-one-offs branch: dropped "through per-item checkers", which wrongly narrowed §10's source menu to one of its four sources and diverged from the host-block mirror.

## Provenance

Driven by a logged friction entry (small changes in an external project routed through full orch-task ceremony, far slower than bare execution). Amendment made under `orch-build`; gated through an independent `orch-critique` pass with the library lens — the initial wording dropped §10's *all-oracles* quantifier (would have licensed skipping the checker on mixed-provenance tickets) and restated owned law; corrected once to the link-form clause per verification §9.

## Verification

- `tools/validate.py` — clean diff-wise (three pre-existing WARNs on untouched skills)
- `unittest discover -s tests` — 317 tests OK
- `install.py --dry-run` — OK
- `git diff --check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)