### PR TITLE
Rule 11: caller-armed lane re-check + tracked external arms

### DIFF
--- a/rules/delegation.md
+++ b/rules/delegation.md
@@ -58,4 +58,15 @@
     (glue, rule 2 — primary work stays forbidden by rule 4) records it
     in the run's worklog (`contracts/worklog.md`, `orch-worklog`) at
     dispatch time, so depth-2 work is visible to the caller through run
-    state, never only through transport.
+    state, never only through transport. A lane is watched by its
+    caller, not by its transport: at dispatch the caller arms its own
+    re-check of the lane's durable run state — through the host's
+    scheduler, or a bounded wait loop where it has none — at a cadence
+    it states when arming, never coarser than the lane's bound, and
+    judges each reading by this rule. A dispatch that launches an
+    external process whose outcome its return depends on either holds
+    its turn until that outcome lands in durable state, or records the
+    process and its expected artifact in the run's worklog at launch,
+    as helper lanes are recorded, so the caller's re-check covers it;
+    a turn ending with such a process recorded nowhere is child
+    under-delivered at the join.


### PR DESCRIPTION
## What

Two additions to `rules/delegation.md` rule 11, from the 2026-07-20 overnight-stalls mining cycle (proposal `2026-07-20-delegation-open-lane-recheck`, 7 friction entries across 3 sessions / 2 projects):

1. **Caller-armed re-check**: at dispatch, the caller of an open lane arms its own re-check of the lane's durable run state (host scheduler, or bounded wait loop on pull-only hosts) at a stated cadence never coarser than the lane's bound. Detection becomes pull-based; lost wake/completion notifications change nothing.
2. **Tracked external arms**: a dispatch launching an external process its return depends on either holds its turn until the outcome lands in durable state, or records the process + expected artifact in the run's worklog (as helper lanes already are); a turn ending with it recorded nowhere is child under-delivered at the join.

## Why

- BenchMaker `wfb-g1`: child idled with its background `claude -p` arm live; the arm completed 3 min later and the wake was lost — lane stalled 8h, found only by user prompt. Matches a confirmed, closed-as-not-planned Claude Code race (anthropics/claude-code#39632): completion notifications enqueued after idle can sit indefinitely.
- BenchDocs six-case finale: supervisor tree died ~20s into a `concurrent-smoke` dispatch; docker-side work completed ownerless, undetected for ~9h.
- Codex has no push channel at all (`wait_agent` is a blocking pull; liveness is an open request, openai/codex#14194 / #16900) — hence the pull-compatible phrasing.

Either clause alone leaves a hole: an unarmed check never fires; an armed check is blind to unrecorded arms.

## Verification

- Gated through independent `orch-critique` (library lens), corrected once: cadence made an explicit stated act (the earlier draft defaulted it to the bound, silently reproducing the 8h blind window); coined terms replaced with plain prose; redundant transport-silence restatement deleted. orch-frontier's "never on a schedule of rounds" adjudicated compatible (it governs dispatch, this governs watching; a re-check finding a landed result is an event).
- `tools/validate.py` exit 0 (3 pre-existing WARNs, unrelated files); `unittest discover` 317 tests OK; `install.py --dry-run` exit 0; `git diff --check` clean — run in both the source worktree and a worktree of this repo.

Queued follow-up (separate owner): host block template gains the concrete Claude Code binding (CronCreate beat, Monitor for background arms; no hook exists for background Bash completion).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
