### PR TITLE
Delegation: reply_to field for return routing

### DIFF
--- a/contracts/delegation.md
+++ b/contracts/delegation.md
@@ -1,10 +1,10 @@
 # Delegation contract
 
 The packet every dispatch carries — the one dispatch currency.
-`orch-delegate` requires all five parts below and refuses a dispatch
+`orch-delegate` requires all six parts below and refuses a dispatch
 missing any. A [work item](work-item.md) extends this packet: packet
 parts ⊕ completion test ⊕ lifecycle ⊕ graph position — and a work-item
-dispatch may supply the five parts by reference to the ticket path.
+dispatch may supply the six parts by reference to the ticket path.
 
 - `objective` — one explicit outcome; a child with two objectives is two
   dispatches.
@@ -32,12 +32,20 @@ dispatch may supply the five parts by reference to the ticket path.
   pointing to it, per rules/delegation.md §10; a packet naming no
   durable artifact contracts for a message-only return; nothing else
   crosses back.
+- `reply_to` — the literal identifier the child's closing message must
+  address, computed once from the dispatcher's own identity: its own
+  assigned name where the dispatcher is itself a named child, `main`
+  where the dispatcher is the top-level orchestrator. Never left for
+  the child to infer — nothing in a child's own context reveals who
+  dispatched it, and a spawn surface whose return travels only by an
+  addressed message (references/profiles.md) turns a missing `reply_to`
+  into a silently misdirected return, not a loud refusal.
 
-A sixth, optional part: `profile` — an explicit role override per
+A seventh, optional part: `profile` — an explicit role override per
 rules/roles.md §4, binding only the dispatch naming it (one-shot) and
 never propagating to a descendant dispatch; its absence defers role
 resolution to rules/roles.md §4's remaining order. Only a missing part
-among the five refuses a dispatch; a missing `profile` never does.
+among the six refuses a dispatch; a missing `profile` never does.
 
 Blame rule, recorded at every failed join: a failure traceable to a
 missing or false packet field is the caller's defect; a failure to

--- a/skills/engines/orch-frontier/SKILL.md
+++ b/skills/engines/orch-frontier/SKILL.md
@@ -11,11 +11,17 @@ for an ad-hoc set.
 Open by dispatching the whole ready frontier — every ticket whose
 `depends_on` are all `complete` — in parallel through `orch-task`, one
 dispatch per ticket, no two sharing a write scope; a ticket waiting on
-a dependency stays `pending`. Then recompute on every event — a result
-landing, a suspension parking its item, a claim's lease expiring —
-never on a schedule of rounds: record what landed in the worklog —
-the tickets alone are the record when the run keeps none; reclaim
-stale claims per [rules/delegation.md](../../../rules/delegation.md)
+a dependency stays `pending`. Arm the caller's own re-check of every
+open ticket's durable file at dispatch, per
+[rules/delegation.md](../../../rules/delegation.md) §11 — a child's
+closing message is a courtesy, never the signal this engine waits on;
+a lost or misdirected message costs one re-check interval, nothing
+more. Then recompute on every event — a result landing (by message or
+by that re-check reading a ticket `complete`), a suspension parking
+its item, a claim's lease expiring — never on a schedule of rounds:
+record what landed in the worklog — the tickets alone are the record
+when the run keeps none; reclaim stale claims per
+[rules/delegation.md](../../../rules/delegation.md)
 §11 (a parked item's claim never goes stale); promote
 each `pending` ticket whose `depends_on` are now all `complete` to
 `ready`; set each `pending` ticket depending on a `failed`, `blocked`,

--- a/skills/kernel/orch-delegate/SKILL.md
+++ b/skills/kernel/orch-delegate/SKILL.md
@@ -6,8 +6,8 @@ role: none
 
 Require: a complete [delegation packet](../../../contracts/delegation.md) —
 objective, inputs, authority (a subset of your own), bounds, return
-contract — supplied directly, or by reference to a ticket path. Refuse
-a dispatch missing any part; name the missing part.
+contract, reply_to — supplied directly, or by reference to a ticket
+path. Refuse a dispatch missing any part; name the missing part.
 
 Resolve the role per [rules/roles.md](../../../rules/roles.md) §4.
 
@@ -15,13 +15,17 @@ Choose the cheapest capable rung of the ladder per
 [rules/delegation.md](../../../rules/delegation.md) §2, bindings per
 [references/profiles.md](references/profiles.md).
 
-Spawn one fresh child carrying the packet verbatim. Select the profile's
-native agent type and compatible fork mode per the profiles reference;
-the child task name never selects the profile. Name the child by normalized
-base-model-effort per that reference.
+Spawn one fresh child carrying the packet verbatim, `reply_to` set to
+your own name where you are yourself a named child, or `main` where
+you are the top-level orchestrator — computed here, at the dispatcher,
+never guessed by the child. Select the profile's native agent type and
+compatible fork mode per the profiles reference; the child task name
+never selects the profile. Name the child by normalized base-model-effort
+per that reference.
 
 Never: widen scope; dispatch two objectives in one packet; let a child
-re-dispatch its primary work; substitute a blocked profile silently.
+re-dispatch its primary work; substitute a blocked profile silently;
+omit `reply_to` or leave a child to infer its own return address.
 
 Return: executor, child name, profile, and the child's contracted result
 verbatim.

--- a/skills/kernel/orch-delegate/references/profiles.md
+++ b/skills/kernel/orch-delegate/references/profiles.md
@@ -27,5 +27,10 @@ keeps its name.
 
 On Claude Code, a named child's return travels only by explicit
 SendMessage to the spawner; plain final text is undelivered. The
-durable artifact remains the return per
+spawner's own name — or `main` when the spawner is the top-level
+orchestrator — travels down as the packet's `reply_to`
+([contracts/delegation.md](../../../../contracts/delegation.md)),
+fixed once at dispatch; a child never infers it, since nothing in a
+child's own context names who dispatched it. The durable artifact
+remains the return per
 [rules/delegation.md](../../../../rules/delegation.md) §10.


### PR DESCRIPTION
## What

Add `reply_to` as a sixth required delegation-packet field (`contracts/delegation.md`) — the literal identifier a child's closing message must address, computed once by the dispatcher from its own identity (its own name where the dispatcher is itself a named child, `main` where the dispatcher is the top-level orchestrator). `orch-delegate` now requires and sets it at spawn; `profiles.md` closes the sentence that previously left this ambiguous. `orch-frontier` is widened to treat rule 11's caller-armed re-check (merged in #2) as the primary detection signal rather than only the stale-claim path — a child's closing message is now explicitly a courtesy, never the signal the engine waits on.

## Why

A live two-tier BenchOF delivery (`orch-goal`: orchestrator → orch-planner → ~27 ticket workers) hit this repeatedly. Ticket workers spawned by a named orch-planner (not the top-level orchestrator) kept `SendMessage`-ing their results to `"main"` instead of their actual spawner — nothing in their delegation packet named who had dispatched them, and `main` is the one recipient a child can always guess, since the host's own `SendMessage` tool documents it as a standing meta-recipient. Six manual relays across one delivery, each costing a turn.

The design already anticipated silent/misrouted transport (rule 10's artifact primacy, rule 11's caller-armed re-check merged yesterday in #2) — but nothing computed and handed down the one piece of information (`reply_to`) that would have prevented the misroute outright, and `orch-frontier`'s own text only invoked rule 11 for stale-claim reclaiming, not the general "haven't heard yet" case.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>