### PR TITLE
Handle missing Codex and Claude hosts gracefully

### DIFF
--- a/install.py
+++ b/install.py
@@ -5,7 +5,7 @@ Stdlib-only, cross-platform (Windows + POSIX), pathlib throughout, never
 symlinks. User scope is primary and auto-detects which host(s) to
 configure: the Claude half runs only when ``~/.claude`` exists, the Codex
 half only when ``~/.codex`` exists; if neither is found the installer
-refuses with guidance instead of guessing.
+warns and exits successfully without writing anything.
 
 - ``~/.orchflows/`` (library, scripts, receipt, the rendered
   ``host-block.md``). The library also carries a flat, host-agnostic
@@ -724,9 +724,19 @@ def _build_user_plan() -> Plan:
     home = Path.home()
     claude_enabled, codex_enabled = detect_hosts(home)
     if not claude_enabled and not codex_enabled:
-        raise ValueError(
-            "neither ~/.claude nor ~/.codex was found; install Claude Code or the "
-            "Codex CLI first, then rerun this installer."
+        return Plan(
+            scope="user",
+            project_root=None,
+            lib_home=lib_home,
+            scope_home=scope_home,
+            bin_dir=bin_dir,
+            receipt_path=scope_home / "receipt.json",
+            warnings=[
+                "warning: neither Claude Code (~/.claude) nor Codex (~/.codex) "
+                "was detected; nothing was installed."
+            ],
+            claude_enabled=False,
+            codex_enabled=False,
         )
 
     lib_copies = []
@@ -1517,6 +1527,9 @@ def main(argv=None) -> int:
 
     for warning in plan.warnings:
         print(warning)
+
+    if scope == "user" and not plan.claude_enabled and not plan.codex_enabled:
+        return 0
 
     if args.dry_run:
         print_plan(plan)

--- a/tests/test_installer.py
+++ b/tests/test_installer.py
@@ -467,7 +467,7 @@ class TestScopedHostConfiguration(unittest.TestCase):
 
 class TestHostAutoDetection(unittest.TestCase):
     """Criterion 2: configure the Claude half only when ``~/.claude`` exists,
-    the Codex half only when ``~/.codex`` exists; error with guidance when
+    the Codex half only when ``~/.codex`` exists; warn and write nothing when
     neither does."""
 
     def test_detect_hosts_reads_presence_of_each_dir(self):
@@ -479,12 +479,31 @@ class TestHostAutoDetection(unittest.TestCase):
             (home / ".codex").mkdir()
             self.assertEqual((True, True), install.detect_hosts(home))
 
-    def test_neither_host_present_raises_with_guidance(self):
+    def test_neither_host_present_returns_success_with_no_writes(self):
         with tempfile.TemporaryDirectory() as tmp:
             home = Path(tmp)
             with patch.object(install.Path, "home", return_value=home):
-                with self.assertRaisesRegex(ValueError, "neither ~/.claude nor ~/.codex"):
-                    install.build_plan("user", None)
+                buffer = io.StringIO()
+                with redirect_stdout(buffer):
+                    result = install.main(["--user", "--yes"])
+
+            self.assertEqual(0, result)
+            self.assertIn("warning:", buffer.getvalue())
+            self.assertIn("nothing was installed", buffer.getvalue())
+            self.assertEqual([], list(home.iterdir()))
+
+    def test_neither_host_present_dry_run_returns_success_with_no_writes(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            home = Path(tmp)
+            with patch.object(install.Path, "home", return_value=home):
+                buffer = io.StringIO()
+                with redirect_stdout(buffer):
+                    result = install.main(["--user", "--dry-run"])
+
+            self.assertEqual(0, result)
+            self.assertIn("warning:", buffer.getvalue())
+            self.assertIn("nothing was installed", buffer.getvalue())
+            self.assertEqual([], list(home.iterdir()))
 
     def test_only_claude_present_builds_claude_half_only(self):
         with tempfile.TemporaryDirectory() as tmp:


### PR DESCRIPTION
## What changed

- Exit successfully with a warning when neither Codex nor Claude Code is detected.
- Avoid writing shared artifacts or a receipt in the zero-host case.
- Preserve host-specific installation when exactly one supported host is detected.
- Add normal and dry-run regression coverage.

## Why

The user installer previously treated the absence of both host directories as a fatal error. It should instead be a safe no-op, while continuing to install to whichever supported host is present.

## Validation

- `python tools/validate.py`
- `python -m unittest discover -s tests -v` (343 tests)
- `python install.py --dry-run`
- `git diff --check`
- Independent zero-host, Claude-only, and Codex-only behavior checks