### PR TITLE
Detect installed host CLIs from PATH

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,8 +80,8 @@ bricks either way.
 
 The wrapper resolves an interpreter (uv → python3 → python; any
 Python 3 works) and
-auto-detects your harnesses — Claude Code (`~/.claude`), Codex
-(`~/.codex`) — configuring whichever exists. Update: `git pull`,
+auto-detects your harnesses from runnable CLIs on `PATH` — `claude`,
+`codex` — configuring whichever is installed. Update: `git pull`,
 rerun. Committable per-project routing block: `python install.py
 --project PATH`. Uninstall: `python install.py --user --uninstall`
 removes only what it generated; `--dry-run` previews either.

--- a/install.py
+++ b/install.py
@@ -3,9 +3,9 @@
 
 Stdlib-only, cross-platform (Windows + POSIX), pathlib throughout, never
 symlinks. User scope is primary and auto-detects which host(s) to
-configure: the Claude half runs only when ``~/.claude`` exists, the Codex
-half only when ``~/.codex`` exists; if neither is found the installer
-warns and exits successfully without writing anything.
+configure: the Claude half runs only when a Claude CLI is on ``PATH``, and
+the Codex half only when a Codex CLI is on ``PATH``. If neither is found,
+the installer warns and exits successfully without writing anything.
 
 - ``~/.orchflows/`` (library, scripts, receipt, the rendered
   ``host-block.md``). The library also carries a flat, host-agnostic
@@ -15,14 +15,14 @@ warns and exits successfully without writing anything.
   pointer never copies the body, so it carries no relative links — an agent
   follows it to the tiered file, where every ``references/`` and
   ``../../../`` link resolves from its authored location.
-- Claude Code (when ``~/.claude`` exists): ``~/.claude/skills/<name>/SKILL.md``
+- Claude Code (when a Claude CLI is on ``PATH``): ``~/.claude/skills/<name>/SKILL.md``
   adapter stubs (frontmatter plus an ``@``-include of the library body),
   role agents, concurrency setting. The always-on instruction layer is
   rendered once to ``~/.orchflows/host-block.md`` (wholly installer-owned)
   and referenced from ``~/.claude/CLAUDE.md`` by one appended ``@<path>``
   import line — idempotent, migrating any legacy inline marker block found
   there from an older install.
-- Codex (when ``~/.codex`` exists): prompts, four redirect skill stubs
+- Codex (when a Codex CLI is on ``PATH``): prompts, four redirect skill stubs
   (``~/.codex/skills/<name>/SKILL.md`` for ``orch-spec``, ``orch-task``,
   ``orch-fix``, ``orch-build``) that point at the library instead of
   duplicating it, role agents, agent-limits config. The always-on layer
@@ -78,6 +78,8 @@ CANONICAL_DIRS = (
     "templates",
 )
 SCRIPT_NAMES = ("friction.py", "tickets.py", "trace.py")
+CLAUDE_CLI_CANDIDATES = ("claude", "claude.exe", "claude.cmd")
+CODEX_CLI_CANDIDATES = ("codex", "codex.exe", "codex.cmd")
 PROFILES_MD = REPO_ROOT / "skills" / "kernel" / "orch-delegate" / "references" / "profiles.md"
 HOST_BLOCK_TEMPLATE = REPO_ROOT / "templates" / "host-block.md"
 CODEX_LIMITS_START = "# BEGIN ORCHFLOWS AGENT LIMITS"
@@ -642,8 +644,8 @@ class Plan:
     claude_import: ImportPlan | None = None              # CLAUDE.md import line, user scope only
     warnings: list = field(default_factory=list)         # preflight, informational only
     manage_host_surfaces: bool = True                    # False for thin project plans
-    claude_enabled: bool = True                          # user scope: ~/.claude was detected
-    codex_enabled: bool = True                           # user scope: ~/.codex was detected
+    claude_enabled: bool = True                          # user scope: a Claude CLI was detected
+    codex_enabled: bool = True                           # user scope: a Codex CLI was detected
 
 
 _BUILD_ARTIFACT_SUFFIXES = (".pyc", ".pyo")
@@ -709,12 +711,17 @@ def _build_project_plan(project_root: Path) -> Plan:
 
 
 def detect_hosts(home: Path | None = None) -> tuple[bool, bool]:
-    """(claude_enabled, codex_enabled) from whether ``~/.claude`` and
-    ``~/.codex`` exist. Presence of the directory is the whole signal — not
-    whether a CLI binary happens to be on PATH."""
+    """Return host enablement from runnable CLI presence on ``PATH``.
 
-    home = home if home is not None else Path.home()
-    return (home / ".claude").is_dir(), (home / ".codex").is_dir()
+    ``home`` remains accepted for caller compatibility, but state/config
+    directories under it are deliberately not installation signals.
+    """
+
+    del home
+    return (
+        any(shutil.which(candidate) for candidate in CLAUDE_CLI_CANDIDATES),
+        any(shutil.which(candidate) for candidate in CODEX_CLI_CANDIDATES),
+    )
 
 
 def _build_user_plan() -> Plan:
@@ -732,8 +739,8 @@ def _build_user_plan() -> Plan:
             bin_dir=bin_dir,
             receipt_path=scope_home / "receipt.json",
             warnings=[
-                "warning: neither Claude Code (~/.claude) nor Codex (~/.codex) "
-                "was detected; nothing was installed."
+                "warning: neither a Claude Code CLI nor a Codex CLI was found "
+                "on PATH; nothing was installed."
             ],
             claude_enabled=False,
             codex_enabled=False,
@@ -901,8 +908,8 @@ def print_plan(plan: Plan) -> None:
     if plan.project_root is not None:
         print(f"project root: {plan.project_root}")
     if plan.scope == "user":
-        print(f"detected Claude Code (~/.claude): {'yes' if plan.claude_enabled else 'no'}")
-        print(f"detected Codex (~/.codex): {'yes' if plan.codex_enabled else 'no'}")
+        print(f"detected Claude Code CLI: {'yes' if plan.claude_enabled else 'no'}")
+        print(f"detected Codex CLI: {'yes' if plan.codex_enabled else 'no'}")
     print(f"source commit: {resolve_source_commit() or 'unknown'}")
     print(f"library home: {plan.lib_home}")
     print(f"bin dir: {plan.bin_dir}")
@@ -1247,8 +1254,8 @@ def print_summary(plan: Plan) -> None:
         print(f"  receipt:     {plan.receipt_path}")
         return
     if plan.scope == "user":
-        print(f"  detected Claude Code (~/.claude): {'yes' if plan.claude_enabled else 'no'}")
-        print(f"  detected Codex (~/.codex): {'yes' if plan.codex_enabled else 'no'}")
+        print(f"  detected Claude Code CLI: {'yes' if plan.claude_enabled else 'no'}")
+        print(f"  detected Codex CLI: {'yes' if plan.codex_enabled else 'no'}")
     print(f"  library:     {plan.lib_home}  ({len(plan.lib_copies)} files)")
     if plan.by_name:
         print(f"  flat index:  {plan.lib_home / 'by-name'}  ({len(plan.by_name)} names)")

--- a/tests/test_installer.py
+++ b/tests/test_installer.py
@@ -18,6 +18,18 @@ def digest(path: Path) -> str:
     return hashlib.sha256(path.read_bytes()).hexdigest()
 
 
+def mock_host_clis(*hosts: str):
+    """Return a deterministic PATH lookup patch for selected host CLIs."""
+
+    installed = set(hosts)
+
+    def lookup(candidate: str) -> str | None:
+        host = candidate.split(".", 1)[0]
+        return str(Path("mock-bin") / candidate) if host in installed else None
+
+    return patch.object(install.shutil, "which", side_effect=lookup)
+
+
 class TestScriptNames(unittest.TestCase):
     """Behavioral replacement: SCRIPT_NAMES only matters if every named
     script actually reaches the installed bin dir with matching content --
@@ -28,7 +40,7 @@ class TestScriptNames(unittest.TestCase):
         with tempfile.TemporaryDirectory() as tmp:
             home = Path(tmp)
             (home / ".claude").mkdir(parents=True)
-            with patch.object(install.Path, "home", return_value=home):
+            with patch.object(install.Path, "home", return_value=home), mock_host_clis("claude"):
                 plan = install.build_plan("user", None)
                 install.apply_plan(plan)
 
@@ -235,7 +247,7 @@ class TestScopedHostConfiguration(unittest.TestCase):
         with tempfile.TemporaryDirectory() as tmp:
             home = Path(tmp)
             (home / ".codex").mkdir(parents=True)
-            with patch.object(install.Path, "home", return_value=home):
+            with patch.object(install.Path, "home", return_value=home), mock_host_clis("codex"):
                 plan = install.build_plan("user", None)
 
             parsed_agents = [
@@ -264,7 +276,9 @@ class TestScopedHostConfiguration(unittest.TestCase):
                 encoding="utf-8",
             )
 
-            with patch.object(install.Path, "home", return_value=home):
+            with patch.object(install.Path, "home", return_value=home), mock_host_clis(
+                "claude", "codex"
+            ):
                 plan = install.build_plan("user", None)
 
             configs = {config.kind: config for config in plan.configs}
@@ -294,7 +308,9 @@ class TestScopedHostConfiguration(unittest.TestCase):
             home = Path(tmp)
             (home / ".claude").mkdir(parents=True)
             (home / ".codex").mkdir(parents=True)
-            with patch.object(install.Path, "home", return_value=home):
+            with patch.object(install.Path, "home", return_value=home), mock_host_clis(
+                "claude", "codex"
+            ):
                 plan = install.build_plan("user", None)
 
             self.assertEqual(len(install.discover_packages()), len(plan.claude_adapters))
@@ -327,7 +343,9 @@ class TestScopedHostConfiguration(unittest.TestCase):
             home = Path(tmp)
             (home / ".claude").mkdir(parents=True)
             (home / ".codex").mkdir(parents=True)
-            with patch.object(install.Path, "home", return_value=home):
+            with patch.object(install.Path, "home", return_value=home), mock_host_clis(
+                "claude", "codex"
+            ):
                 plan = install.build_plan("user", None)
 
             by_name_root = (home / ".orchflows" / "lib" / "by-name").resolve()
@@ -355,7 +373,7 @@ class TestScopedHostConfiguration(unittest.TestCase):
         with tempfile.TemporaryDirectory() as tmp:
             home = Path(tmp)
             (home / ".codex").mkdir(parents=True)
-            with patch.object(install.Path, "home", return_value=home):
+            with patch.object(install.Path, "home", return_value=home), mock_host_clis("codex"):
                 plan = install.build_plan("user", None)
             self.assertEqual([], plan.claude_adapters)
             self.assertEqual(len(install.discover_packages()), len(plan.by_name))
@@ -443,7 +461,9 @@ class TestScopedHostConfiguration(unittest.TestCase):
             home = Path(tmp)
             (home / ".claude").mkdir(parents=True)
             (home / ".codex").mkdir(parents=True)
-            with patch.object(install.Path, "home", return_value=home):
+            with patch.object(install.Path, "home", return_value=home), mock_host_clis(
+                "claude", "codex"
+            ):
                 plan = install.build_plan("user", None)
 
             self.assertEqual(
@@ -466,23 +486,64 @@ class TestScopedHostConfiguration(unittest.TestCase):
 
 
 class TestHostAutoDetection(unittest.TestCase):
-    """Criterion 2: configure the Claude half only when ``~/.claude`` exists,
-    the Codex half only when ``~/.codex`` exists; warn and write nothing when
-    neither does."""
+    """Configure only hosts whose runnable CLI is discoverable on PATH."""
 
-    def test_detect_hosts_reads_presence_of_each_dir(self):
+    def test_state_directories_are_not_installation_signals(self):
+        with tempfile.TemporaryDirectory() as tmp, mock_host_clis():
+            home = Path(tmp)
+            (home / ".claude").mkdir()
+            (home / ".codex").mkdir()
+
+            self.assertEqual((False, False), install.detect_hosts(home))
+
+    def test_each_cross_platform_cli_candidate_enables_its_host(self):
+        cases = (
+            ("claude", (True, False)),
+            ("claude.exe", (True, False)),
+            ("claude.cmd", (True, False)),
+            ("codex", (False, True)),
+            ("codex.exe", (False, True)),
+            ("codex.cmd", (False, True)),
+        )
+        for executable, expected in cases:
+            with self.subTest(executable=executable), patch.object(
+                install.shutil,
+                "which",
+                side_effect=lambda candidate, executable=executable: (
+                    str(Path("mock-bin") / candidate) if candidate == executable else None
+                ),
+            ):
+                self.assertEqual(expected, install.detect_hosts())
+
+    def test_both_clis_enable_both_hosts_before_state_directories_exist(self):
+        with mock_host_clis("claude", "codex"):
+            self.assertEqual((True, True), install.detect_hosts(Path("missing-home")))
+
+    def test_protected_stale_codex_directory_is_ignored_without_codex_cli(self):
         with tempfile.TemporaryDirectory() as tmp:
             home = Path(tmp)
-            self.assertEqual((False, False), install.detect_hosts(home))
-            (home / ".claude").mkdir()
-            self.assertEqual((True, False), install.detect_hosts(home))
-            (home / ".codex").mkdir()
-            self.assertEqual((True, True), install.detect_hosts(home))
+            stale_codex = home / ".codex"
+            stale_codex.mkdir()
+            real_mkdir = Path.mkdir
+
+            def reject_codex_writes(path, *args, **kwargs):
+                if path == stale_codex or stale_codex in path.parents:
+                    raise PermissionError(13, "Permission denied", str(path))
+                return real_mkdir(path, *args, **kwargs)
+
+            with patch.object(install.Path, "home", return_value=home), mock_host_clis(
+                "claude"
+            ), patch.object(Path, "mkdir", autospec=True, side_effect=reject_codex_writes):
+                result = install.main(["--user", "--yes"])
+
+            self.assertEqual(0, result)
+            self.assertFalse((stale_codex / "prompts").exists())
+            self.assertTrue((home / ".claude" / "CLAUDE.md").is_file())
 
     def test_neither_host_present_returns_success_with_no_writes(self):
         with tempfile.TemporaryDirectory() as tmp:
             home = Path(tmp)
-            with patch.object(install.Path, "home", return_value=home):
+            with patch.object(install.Path, "home", return_value=home), mock_host_clis():
                 buffer = io.StringIO()
                 with redirect_stdout(buffer):
                     result = install.main(["--user", "--yes"])
@@ -495,7 +556,7 @@ class TestHostAutoDetection(unittest.TestCase):
     def test_neither_host_present_dry_run_returns_success_with_no_writes(self):
         with tempfile.TemporaryDirectory() as tmp:
             home = Path(tmp)
-            with patch.object(install.Path, "home", return_value=home):
+            with patch.object(install.Path, "home", return_value=home), mock_host_clis():
                 buffer = io.StringIO()
                 with redirect_stdout(buffer):
                     result = install.main(["--user", "--dry-run"])
@@ -509,7 +570,7 @@ class TestHostAutoDetection(unittest.TestCase):
         with tempfile.TemporaryDirectory() as tmp:
             home = Path(tmp)
             (home / ".claude").mkdir(parents=True)
-            with patch.object(install.Path, "home", return_value=home):
+            with patch.object(install.Path, "home", return_value=home), mock_host_clis("claude"):
                 plan = install.build_plan("user", None)
 
             self.assertTrue(plan.claude_enabled)
@@ -529,7 +590,7 @@ class TestHostAutoDetection(unittest.TestCase):
         with tempfile.TemporaryDirectory() as tmp:
             home = Path(tmp)
             (home / ".codex").mkdir(parents=True)
-            with patch.object(install.Path, "home", return_value=home):
+            with patch.object(install.Path, "home", return_value=home), mock_host_clis("codex"):
                 plan = install.build_plan("user", None)
 
             self.assertFalse(plan.claude_enabled)
@@ -547,15 +608,15 @@ class TestHostAutoDetection(unittest.TestCase):
         with tempfile.TemporaryDirectory() as tmp:
             home = Path(tmp)
             (home / ".claude").mkdir(parents=True)
-            with patch.object(install.Path, "home", return_value=home):
+            with patch.object(install.Path, "home", return_value=home), mock_host_clis("claude"):
                 plan = install.build_plan("user", None)
                 buffer = io.StringIO()
                 with redirect_stdout(buffer):
                     install.print_plan(plan)
 
             output = buffer.getvalue()
-            self.assertIn("detected Claude Code (~/.claude): yes", output)
-            self.assertIn("detected Codex (~/.codex): no", output)
+            self.assertIn("detected Claude Code CLI: yes", output)
+            self.assertIn("detected Codex CLI: no", output)
 
 
 class TestClaudeAlwaysOnImport(unittest.TestCase):
@@ -601,7 +662,9 @@ class TestClaudeAlwaysOnImport(unittest.TestCase):
             home = Path(tmp)
             (home / ".claude").mkdir(parents=True)
             (home / ".codex").mkdir(parents=True)
-            with patch.object(install.Path, "home", return_value=home):
+            with patch.object(install.Path, "home", return_value=home), mock_host_clis(
+                "claude", "codex"
+            ):
                 plan = install.build_plan("user", None)
 
             self.assertEqual(home / ".orchflows" / "host-block.md", plan.host_block.dest)
@@ -622,7 +685,9 @@ class TestClaudeAlwaysOnImport(unittest.TestCase):
             home = Path(tmp)
             (home / ".claude").mkdir(parents=True)
             (home / ".codex").mkdir(parents=True)
-            with patch.object(install.Path, "home", return_value=home):
+            with patch.object(install.Path, "home", return_value=home), mock_host_clis(
+                "claude", "codex"
+            ):
                 plan = install.build_plan("user", None)
                 install.apply_plan(plan)
 
@@ -644,7 +709,7 @@ class TestClaudeAlwaysOnImport(unittest.TestCase):
         with tempfile.TemporaryDirectory() as tmp:
             home = Path(tmp)
             (home / ".claude").mkdir(parents=True)
-            with patch.object(install.Path, "home", return_value=home):
+            with patch.object(install.Path, "home", return_value=home), mock_host_clis("claude"):
                 plan = install.build_plan("user", None)
                 install.apply_plan(plan)
                 plan2 = install.build_plan("user", None)
@@ -666,7 +731,7 @@ class TestClaudeAlwaysOnImport(unittest.TestCase):
                 f"# personal notes\n{start_marker}\nold rendered block\n{end_marker}\n", encoding="utf-8"
             )
 
-            with patch.object(install.Path, "home", return_value=home):
+            with patch.object(install.Path, "home", return_value=home), mock_host_clis("claude"):
                 plan = install.build_plan("user", None)
                 install.apply_plan(plan)
 
@@ -956,9 +1021,9 @@ class TestSourceCommit(unittest.TestCase):
             home = Path(tmp)
             (home / ".claude").mkdir(parents=True)
 
-            with patch.object(install.Path, "home", return_value=home), patch.object(
-                install, "resolve_source_commit", side_effect=["sha1", "sha2"]
-            ):
+            with patch.object(install.Path, "home", return_value=home), mock_host_clis(
+                "claude"
+            ), patch.object(install, "resolve_source_commit", side_effect=["sha1", "sha2"]):
                 first = io.StringIO()
                 with redirect_stdout(first):
                     code1 = install.main(["--user", "--yes"])
@@ -1377,7 +1442,7 @@ class TestCodexHooksPreflight(unittest.TestCase):
                 encoding="utf-8",
             )
 
-            with patch.object(install.Path, "home", return_value=home):
+            with patch.object(install.Path, "home", return_value=home), mock_host_clis("codex"):
                 plan = install.build_plan("user", None)
 
             self.assertEqual(1, len(plan.warnings))


### PR DESCRIPTION
## What changed

- Detect Claude Code and Codex from runnable CLI executables on `PATH`.
- Ignore stale `~/.claude` and `~/.codex` state directories as installation signals.
- Preserve host-specific installation and the zero-host no-op warning.
- Add deterministic cross-platform host detection coverage and a protected stale `~/.codex` regression.
- Update installer and README documentation.

## Why

A stale, protected `~/.codex` directory was mistaken for an installed Codex CLI. The installer then attempted to create `~/.codex/prompts` and failed on macOS with `Errno 13`, even though Codex was not installed.

## Validation

- `python tools/validate.py`
- `python -m unittest discover -s tests -v` (346 tests)
- `python install.py --dry-run`
- `git diff --check`
- Replayed the prior directory-based detector against the new regression and reproduced the original `Errno 13` failure