### PR TITLE
install: honor CLAUDE_CONFIG_DIR and CODEX_HOME

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -41,9 +41,11 @@ dependencies point. Terms: `docs/vocabulary.md`.
   teardown, and the friction logger. The root wrappers resolve an
   interpreter (uv → python3 → python, never hardcoded) and pass
   arguments through to `install.py`. `install.py --user` auto-detects
-  which host halves to configure — Claude Code only when `~/.claude`
-  exists (lib copy, `~/.claude/skills/` adapter stubs, role agents,
-  concurrency setting), Codex only when `~/.codex` exists (prompts,
+  which host halves to configure — Claude Code only when a Claude CLI is
+  on `PATH` (lib copy, `~/.claude/skills/` adapter stubs, role agents,
+  concurrency setting; `CLAUDE_CONFIG_DIR` replaces `~/.claude`
+  throughout, matching the CLI), Codex only when a Codex CLI is on
+  `PATH` (prompts,
   four redirect skill stubs, role agents, agent-limits config, hooks
   warning) — erroring with guidance when neither is present. The
   always-on layer is one appended `@`-import line in the user

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -43,11 +43,11 @@ dependencies point. Terms: `docs/vocabulary.md`.
   arguments through to `install.py`. `install.py --user` auto-detects
   which host halves to configure — Claude Code only when a Claude CLI is
   on `PATH` (lib copy, `~/.claude/skills/` adapter stubs, role agents,
-  concurrency setting; `CLAUDE_CONFIG_DIR` replaces `~/.claude`
-  throughout, matching the CLI), Codex only when a Codex CLI is on
-  `PATH` (prompts,
-  four redirect skill stubs, role agents, agent-limits config, hooks
-  warning) — erroring with guidance when neither is present. The
+  concurrency setting), Codex only when a Codex CLI is on `PATH`
+  (prompts, four redirect skill stubs, role agents, agent-limits config,
+  hooks warning) — erroring with guidance when neither is present.
+  `CLAUDE_CONFIG_DIR` and `CODEX_HOME` replace `~/.claude` and
+  `~/.codex` throughout, matching each CLI. The
   always-on layer is one appended `@`-import line in the user
   `CLAUDE.md`/`AGENTS.md` pointing at installer-owned
   `~/.orchflows/host-block.md`, idempotent, replacing any legacy marker

--- a/install.py
+++ b/install.py
@@ -26,7 +26,8 @@ the installer warns and exits successfully without writing anything.
 - Codex (when a Codex CLI is on ``PATH``): prompts, four redirect skill stubs
   (``~/.codex/skills/<name>/SKILL.md`` for ``orch-spec``, ``orch-task``,
   ``orch-fix``, ``orch-build``) that point at the library instead of
-  duplicating it, role agents, agent-limits config. The always-on layer
+  duplicating it, role agents, agent-limits config. ``CODEX_HOME`` replaces
+  ``~/.codex`` throughout, matching the CLI. The always-on layer
   stays an inline marker block upserted into ``~/.codex/AGENTS.md`` — a
   read-only probe (``codex debug prompt-input`` against a scratch repo,
   installed CLI 0.144.0) found ``@file`` imports do not expand there, so
@@ -177,7 +178,9 @@ def _claude_agents_dir(scope: str, project_root: Path | None) -> Path:
 def _codex_user_home() -> Path:
     # Codex prompts have no project-local equivalent. Native role agents and
     # config use ``_codex_scope_home`` and therefore follow the selected scope.
-    return Path.home() / ".codex"
+    # ``CODEX_HOME`` overrides the ``~/.codex`` default, as the Codex CLI reads it.
+    override = os.environ.get("CODEX_HOME", "").strip()
+    return Path(override).expanduser() if override else Path.home() / ".codex"
 
 
 def _codex_scope_home(scope: str, project_root: Path | None) -> Path:
@@ -196,7 +199,7 @@ def _codex_agents_dir(scope: str, project_root: Path | None) -> Path:
 
 def _codex_agents_path(scope: str, project_root: Path | None) -> Path:
     if scope == "user":
-        return Path.home() / ".codex" / "AGENTS.md"
+        return _codex_user_home() / "AGENTS.md"
     return _require_project_root(project_root) / "AGENTS.md"
 
 
@@ -1294,9 +1297,9 @@ def print_summary(plan: Plan) -> None:
 
 def _uninstall_boundary(path: Path, scope: str, project_root: Path | None) -> Path:
     """Codex prompts live under the user home even for project installs, and a
-    ``CLAUDE_CONFIG_DIR`` install lives outside it entirely."""
+    ``CLAUDE_CONFIG_DIR`` / ``CODEX_HOME`` install lives outside it entirely."""
 
-    roots = [_claude_user_home()]
+    roots = [_claude_user_home(), _codex_user_home()]
     if scope == "project":
         roots.insert(0, _require_project_root(project_root))
     for root in roots:
@@ -1322,7 +1325,7 @@ def _auto_remove_path_is_safe(
             _require_project_root(project_root) if scope == "project" else _claude_user_home()
         )
     else:
-        scope_boundary = Path.home()
+        scope_boundary = _codex_user_home()
     try:
         path.absolute().relative_to(boundary.absolute())
         boundary.resolve().relative_to(scope_boundary.resolve())

--- a/install.py
+++ b/install.py
@@ -17,7 +17,8 @@ the installer warns and exits successfully without writing anything.
   ``../../../`` link resolves from its authored location.
 - Claude Code (when a Claude CLI is on ``PATH``): ``~/.claude/skills/<name>/SKILL.md``
   adapter stubs (frontmatter plus an ``@``-include of the library body),
-  role agents, concurrency setting. The always-on instruction layer is
+  role agents, concurrency setting. ``CLAUDE_CONFIG_DIR`` replaces ``~/.claude``
+  throughout, matching the CLI. The always-on instruction layer is
   rendered once to ``~/.orchflows/host-block.md`` (wholly installer-owned)
   and referenced from ``~/.claude/CLAUDE.md`` by one appended ``@<path>``
   import line — idempotent, migrating any legacy inline marker block found
@@ -55,6 +56,7 @@ from __future__ import annotations
 import argparse
 import hashlib
 import json
+import os
 import re
 import shutil
 import sys
@@ -142,15 +144,25 @@ def _runtime_dirs(scope: str, project_root: Path | None) -> list[Path]:
     ]
 
 
+def _claude_user_home() -> Path:
+    """Claude Code's user config directory. ``CLAUDE_CONFIG_DIR`` overrides the
+    ``~/.claude`` default, and the CLI reads only that env var — a relocated
+    config directory has no project-local equivalent, so project scope is
+    unaffected."""
+
+    override = os.environ.get("CLAUDE_CONFIG_DIR", "").strip()
+    return Path(override).expanduser() if override else Path.home() / ".claude"
+
+
 def _claude_scope_home(scope: str, project_root: Path | None) -> Path:
     if scope == "user":
-        return Path.home() / ".claude"
+        return _claude_user_home()
     return _require_project_root(project_root) / ".claude"
 
 
 def _claude_md_path(scope: str, project_root: Path | None) -> Path:
     if scope == "user":
-        return Path.home() / ".claude" / "CLAUDE.md"
+        return _claude_user_home() / "CLAUDE.md"
     return _require_project_root(project_root) / "CLAUDE.md"
 
 
@@ -1281,15 +1293,18 @@ def print_summary(plan: Plan) -> None:
 
 
 def _uninstall_boundary(path: Path, scope: str, project_root: Path | None) -> Path:
-    """Codex prompts live under the user home even for project installs."""
+    """Codex prompts live under the user home even for project installs, and a
+    ``CLAUDE_CONFIG_DIR`` install lives outside it entirely."""
 
+    roots = [_claude_user_home()]
     if scope == "project":
-        root = _require_project_root(project_root)
+        roots.insert(0, _require_project_root(project_root))
+    for root in roots:
         try:
             path.resolve().relative_to(root.resolve())
             return root
         except (OSError, ValueError):
-            pass
+            continue
     return Path.home()
 
 
@@ -1302,11 +1317,12 @@ def _auto_remove_path_is_safe(
         boundary = _codex_user_home() / "skills"
     else:
         boundary = _codex_user_home() / "prompts"
-    scope_boundary = (
-        _require_project_root(project_root)
-        if kind == "adapter" and scope == "project"
-        else Path.home()
-    )
+    if kind == "adapter":
+        scope_boundary = (
+            _require_project_root(project_root) if scope == "project" else _claude_user_home()
+        )
+    else:
+        scope_boundary = Path.home()
     try:
         path.absolute().relative_to(boundary.absolute())
         boundary.resolve().relative_to(scope_boundary.resolve())

--- a/tests/test_installer.py
+++ b/tests/test_installer.py
@@ -18,11 +18,13 @@ _ENV_GUARD = patch.dict(os.environ)
 
 
 def setUpModule():
-    """Every test here fakes a home dir; a real ``CLAUDE_CONFIG_DIR`` in the
-    developer's environment would send user-scope writes outside that fake."""
+    """Every test here fakes a home dir; a real ``CLAUDE_CONFIG_DIR`` or
+    ``CODEX_HOME`` in the developer's environment would send user-scope writes
+    outside that fake."""
 
     _ENV_GUARD.start()
     os.environ.pop("CLAUDE_CONFIG_DIR", None)
+    os.environ.pop("CODEX_HOME", None)
 
 
 def tearDownModule():
@@ -1529,6 +1531,95 @@ class TestClaudeConfigDir(unittest.TestCase):
 
             for dest, _ in plan.claude_adapters:
                 self.assertEqual(home / ".claude" / "skills", dest.parent.parent)
+
+
+class TestCodexHome(unittest.TestCase):
+    """``CODEX_HOME`` relocates the Codex CLI's config directory the same way
+    ``CLAUDE_CONFIG_DIR`` relocates Claude Code's."""
+
+    def test_user_plan_writes_every_codex_surface_under_codex_home(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            home = Path(tmp) / "home"
+            home.mkdir()
+            codex_home = Path(tmp) / "elsewhere" / "codex"
+            codex_home.mkdir(parents=True)
+
+            with patch.object(install.Path, "home", return_value=home), patch.dict(
+                os.environ, {"CODEX_HOME": str(codex_home)}
+            ), mock_host_clis("codex"):
+                plan = install.build_plan("user", None)
+                install.apply_plan(plan)
+
+            self.assertTrue(plan.codex_prompts)
+            for dest, _ in plan.codex_prompts:
+                self.assertEqual(codex_home / "prompts", dest.parent)
+            self.assertTrue(plan.codex_skills)
+            for dest, _ in plan.codex_skills:
+                self.assertEqual(codex_home / "skills", dest.parent.parent)
+            self.assertTrue(plan.codex_agents)
+            for dest, _ in plan.codex_agents:
+                self.assertEqual(codex_home / "agents", dest.parent)
+            self.assertTrue((codex_home / "config.toml").is_file())
+            self.assertTrue((codex_home / "AGENTS.md").is_file())
+            self.assertFalse((home / ".codex").exists())
+
+    def test_uninstall_removes_codex_skills_installed_under_codex_home(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            home = Path(tmp) / "home"
+            home.mkdir()
+            codex_home = Path(tmp) / "elsewhere" / "codex"
+            codex_home.mkdir(parents=True)
+
+            with patch.object(install.Path, "home", return_value=home), patch.dict(
+                os.environ, {"CODEX_HOME": str(codex_home)}
+            ), mock_host_clis("codex"):
+                plan = install.build_plan("user", None)
+                install.apply_plan(plan)
+                report = install.run_uninstall("user", None, dry_run=False)
+
+            installed = {str(dest) for dest, _ in plan.codex_prompts + plan.codex_skills}
+            removed = {
+                action["path"]
+                for action in report["skill_actions"]
+                if action["action"] == "removed unchanged skill"
+            }
+            self.assertTrue(installed)
+            self.assertTrue(installed <= removed)
+            for path in installed:
+                self.assertIn(codex_home, Path(path).parents)
+            self.assertFalse((codex_home / "skills").exists())
+            self.assertFalse((codex_home / "prompts").exists())
+
+    def test_hooks_warning_reads_relocated_codex_home(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            home = Path(tmp) / "home"
+            home.mkdir()
+            codex_home = Path(tmp) / "elsewhere" / "codex"
+            codex_home.mkdir(parents=True)
+            (codex_home / "hooks.json").write_text(
+                json.dumps({"command": [str(codex_home / "orch-missing" / "x.py")]}),
+                encoding="utf-8",
+            )
+
+            with patch.object(install.Path, "home", return_value=home), patch.dict(
+                os.environ, {"CODEX_HOME": str(codex_home)}
+            ), mock_host_clis("codex"):
+                plan = install.build_plan("user", None)
+
+            self.assertEqual(1, len(plan.warnings))
+            self.assertIn("orch-missing", plan.warnings[0])
+
+    def test_blank_codex_home_falls_back_to_home(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            home = Path(tmp)
+            (home / ".codex").mkdir(parents=True)
+            with patch.object(install.Path, "home", return_value=home), patch.dict(
+                os.environ, {"CODEX_HOME": "  "}
+            ), mock_host_clis("codex"):
+                plan = install.build_plan("user", None)
+
+            for dest, _ in plan.codex_skills:
+                self.assertEqual(home / ".codex" / "skills", dest.parent.parent)
 
 
 if __name__ == "__main__":

--- a/tests/test_installer.py
+++ b/tests/test_installer.py
@@ -3,6 +3,7 @@
 import hashlib
 import io
 import json
+import os
 import re
 import shutil
 import tempfile
@@ -12,6 +13,20 @@ from pathlib import Path, PurePosixPath
 from unittest.mock import patch
 
 import install
+
+_ENV_GUARD = patch.dict(os.environ)
+
+
+def setUpModule():
+    """Every test here fakes a home dir; a real ``CLAUDE_CONFIG_DIR`` in the
+    developer's environment would send user-scope writes outside that fake."""
+
+    _ENV_GUARD.start()
+    os.environ.pop("CLAUDE_CONFIG_DIR", None)
+
+
+def tearDownModule():
+    _ENV_GUARD.stop()
 
 
 def digest(path: Path) -> str:
@@ -1447,6 +1462,73 @@ class TestCodexHooksPreflight(unittest.TestCase):
 
             self.assertEqual(1, len(plan.warnings))
             self.assertIn("orch-missing", plan.warnings[0])
+
+
+class TestClaudeConfigDir(unittest.TestCase):
+    """``CLAUDE_CONFIG_DIR`` relocates Claude Code's user config directory, so
+    every user-scope Claude surface follows it instead of ``~/.claude`` — the
+    same override Claude Code itself reads."""
+
+    def test_user_plan_writes_every_claude_surface_under_claude_config_dir(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            home = Path(tmp) / "home"
+            home.mkdir()
+            config_dir = Path(tmp) / "elsewhere" / "claude"
+            config_dir.mkdir(parents=True)
+
+            with patch.object(install.Path, "home", return_value=home), patch.dict(
+                os.environ, {"CLAUDE_CONFIG_DIR": str(config_dir)}
+            ), mock_host_clis("claude"):
+                plan = install.build_plan("user", None)
+                install.apply_plan(plan)
+
+            self.assertTrue(plan.claude_adapters)
+            for dest, _ in plan.claude_adapters:
+                self.assertEqual(config_dir / "skills", dest.parent.parent)
+            self.assertTrue(plan.claude_agents)
+            for dest, _ in plan.claude_agents:
+                self.assertEqual(config_dir / "agents", dest.parent)
+            self.assertTrue((config_dir / "settings.json").is_file())
+            self.assertTrue((config_dir / "CLAUDE.md").is_file())
+            self.assertFalse((home / ".claude").exists())
+
+    def test_uninstall_removes_adapter_installed_under_claude_config_dir(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            home = Path(tmp) / "home"
+            home.mkdir()
+            config_dir = Path(tmp) / "elsewhere" / "claude"
+            config_dir.mkdir(parents=True)
+
+            with patch.object(install.Path, "home", return_value=home), patch.dict(
+                os.environ, {"CLAUDE_CONFIG_DIR": str(config_dir)}
+            ), mock_host_clis("claude"):
+                plan = install.build_plan("user", None)
+                install.apply_plan(plan)
+                report = install.run_uninstall("user", None, dry_run=False)
+
+            adapters = {str(dest) for dest, _ in plan.claude_adapters}
+            removed = {
+                action["path"]
+                for action in report["skill_actions"]
+                if action["action"] == "removed unchanged skill"
+            }
+            self.assertTrue(adapters)
+            self.assertTrue(adapters <= removed)
+            for path in adapters:
+                self.assertEqual(config_dir / "skills", Path(path).parent.parent)
+            self.assertFalse((config_dir / "skills").exists())
+
+    def test_blank_claude_config_dir_falls_back_to_home(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            home = Path(tmp)
+            (home / ".claude").mkdir(parents=True)
+            with patch.object(install.Path, "home", return_value=home), patch.dict(
+                os.environ, {"CLAUDE_CONFIG_DIR": "  "}
+            ), mock_host_clis("claude"):
+                plan = install.build_plan("user", None)
+
+            for dest, _ in plan.claude_adapters:
+                self.assertEqual(home / ".claude" / "skills", dest.parent.parent)
 
 
 if __name__ == "__main__":

--- a/tests/test_suite_check.py
+++ b/tests/test_suite_check.py
@@ -59,19 +59,23 @@ class TestAuditSkips(unittest.TestCase):
 
 
 class TestHashAndSnapshot(unittest.TestCase):
-    def test_collect_snapshot_watches_relocated_claude_config_dir(self):
+    def test_collect_snapshot_watches_relocated_host_config_dirs(self):
         # A leak into a relocated config dir is the same leak; the guard must
-        # follow CLAUDE_CONFIG_DIR or report a clean tree that isn't.
-        with tempfile.TemporaryDirectory() as td:
-            root = Path(td)
-            config_dir = root / "elsewhere" / "claude"
-            (config_dir / "skills").mkdir(parents=True)
-            (config_dir / "skills" / "SKILL.md").write_text("leaked\n", encoding="utf-8")
+        # follow CLAUDE_CONFIG_DIR / CODEX_HOME or report a clean tree that isn't.
+        for env_var, tree_name in (
+            ("CLAUDE_CONFIG_DIR", "claude_home"),
+            ("CODEX_HOME", "codex_home"),
+        ):
+            with self.subTest(env_var=env_var), tempfile.TemporaryDirectory() as td:
+                root = Path(td)
+                config_dir = root / "elsewhere" / tree_name
+                (config_dir / "skills").mkdir(parents=True)
+                (config_dir / "skills" / "SKILL.md").write_text("leaked\n", encoding="utf-8")
 
-            with mock.patch.dict(os.environ, {"CLAUDE_CONFIG_DIR": str(config_dir)}):
-                snapshot = suite_check.collect_snapshot(root, root / "home", watch_home=True)
+                with mock.patch.dict(os.environ, {env_var: str(config_dir)}):
+                    snapshot = suite_check.collect_snapshot(root, root / "home", watch_home=True)
 
-            self.assertIn(str(Path("skills") / "SKILL.md"), snapshot["trees"]["claude_home"])
+                self.assertIn(str(Path("skills") / "SKILL.md"), snapshot["trees"][tree_name])
 
     def test_hash_file_is_deterministic(self):
         with tempfile.TemporaryDirectory() as td:

--- a/tests/test_suite_check.py
+++ b/tests/test_suite_check.py
@@ -9,12 +9,14 @@ synthetic ``tests/`` directory in a tempdir — never the real suite.
 from __future__ import annotations
 
 import json
+import os
 import subprocess
 import sys
 import tempfile
 import textwrap
 import unittest
 from pathlib import Path
+from unittest import mock
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
 sys.path.insert(0, str(REPO_ROOT))
@@ -57,6 +59,20 @@ class TestAuditSkips(unittest.TestCase):
 
 
 class TestHashAndSnapshot(unittest.TestCase):
+    def test_collect_snapshot_watches_relocated_claude_config_dir(self):
+        # A leak into a relocated config dir is the same leak; the guard must
+        # follow CLAUDE_CONFIG_DIR or report a clean tree that isn't.
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td)
+            config_dir = root / "elsewhere" / "claude"
+            (config_dir / "skills").mkdir(parents=True)
+            (config_dir / "skills" / "SKILL.md").write_text("leaked\n", encoding="utf-8")
+
+            with mock.patch.dict(os.environ, {"CLAUDE_CONFIG_DIR": str(config_dir)}):
+                snapshot = suite_check.collect_snapshot(root, root / "home", watch_home=True)
+
+            self.assertIn(str(Path("skills") / "SKILL.md"), snapshot["trees"]["claude_home"])
+
     def test_hash_file_is_deterministic(self):
         with tempfile.TemporaryDirectory() as td:
             path = Path(td) / "a.jsonl"

--- a/tools/suite_check.py
+++ b/tools/suite_check.py
@@ -177,6 +177,14 @@ HOME_WATCH_DIRS = (
 )
 
 
+def _watch_dir(home: Path, name: str, dirname: str) -> Path:
+    """``CLAUDE_CONFIG_DIR`` relocates Claude Code's config directory, so the
+    guard must watch the relocated one or miss writes it exists to catch."""
+
+    override = os.environ.get("CLAUDE_CONFIG_DIR", "").strip() if name == "claude_home" else ""
+    return Path(override).expanduser() if override else home / dirname
+
+
 def collect_snapshot(repo_root: Path, home: Path, watch_home: bool) -> dict:
     snapshot = {
         "friction_hashes": snapshot_friction_hashes(repo_root),
@@ -184,7 +192,7 @@ def collect_snapshot(repo_root: Path, home: Path, watch_home: bool) -> dict:
     }
     if watch_home:
         for name, dirname in HOME_WATCH_DIRS:
-            snapshot["trees"][name] = snapshot_tree(home / dirname)
+            snapshot["trees"][name] = snapshot_tree(_watch_dir(home, name, dirname))
     return snapshot
 
 

--- a/tools/suite_check.py
+++ b/tools/suite_check.py
@@ -171,17 +171,18 @@ def build_stripped_path(executable: str) -> str:
 
 
 HOME_WATCH_DIRS = (
-    ("claude_home", ".claude"),
-    ("codex_home", ".codex"),
-    ("orchflows_home", ".orchflows"),
+    ("claude_home", ".claude", "CLAUDE_CONFIG_DIR"),
+    ("codex_home", ".codex", "CODEX_HOME"),
+    ("orchflows_home", ".orchflows", None),
 )
 
 
-def _watch_dir(home: Path, name: str, dirname: str) -> Path:
-    """``CLAUDE_CONFIG_DIR`` relocates Claude Code's config directory, so the
-    guard must watch the relocated one or miss writes it exists to catch."""
+def _watch_dir(home: Path, dirname: str, env_var: str | None) -> Path:
+    """``CLAUDE_CONFIG_DIR`` and ``CODEX_HOME`` relocate a host's config
+    directory, so the guard must watch the relocated one or miss the writes it
+    exists to catch."""
 
-    override = os.environ.get("CLAUDE_CONFIG_DIR", "").strip() if name == "claude_home" else ""
+    override = os.environ.get(env_var, "").strip() if env_var else ""
     return Path(override).expanduser() if override else home / dirname
 
 
@@ -191,8 +192,8 @@ def collect_snapshot(repo_root: Path, home: Path, watch_home: bool) -> dict:
         "trees": {"orch": snapshot_tree(repo_root / ".orch")},
     }
     if watch_home:
-        for name, dirname in HOME_WATCH_DIRS:
-            snapshot["trees"][name] = snapshot_tree(_watch_dir(home, name, dirname))
+        for name, dirname, env_var in HOME_WATCH_DIRS:
+            snapshot["trees"][name] = snapshot_tree(_watch_dir(home, dirname, env_var))
     return snapshot
 
 


### PR DESCRIPTION
## Problem

Both host CLIs let a user relocate their config directory, and `install.py` honored neither:

- Claude Code reads `CLAUDE_CONFIG_DIR` in place of `~/.claude`.
- The Codex CLI reads `CODEX_HOME` in place of `~/.codex` (verified against installed `codex-cli 0.145.0`, which refuses to start with `CODEX_HOME points to "/tmp/codexprobe", but that path does not exist`, and documents `$CODEX_HOME/<name>.config.toml` in `--help`).

With either set, a user-scope install wrote its adapters, prompts, redirect skill stubs, role agents, `settings.json` / `config.toml`, and the `CLAUDE.md` / `AGENTS.md` always-on layer into a directory the CLI never reads. The install reported success and had no effect. `tools/live_codex_profiles.py` already honored `CODEX_HOME`, so the installer was inconsistent with its own sibling tool.

## Change

- One `_claude_user_home()` helper, mirroring the existing `_codex_user_home()` shape, and `CODEX_HOME` support added to `_codex_user_home()` itself. Every user-scope host path routes through them, so the override reaches adapters, prompts, redirect skills, role agents, host config files, the instruction import/block, and the `hooks.json` preflight. `_codex_agents_path()` now routes through the helper instead of rebuilding `~/.codex` by hand.
- Project scope is unchanged: neither override has a project-local equivalent.
- Uninstall boundaries (`_uninstall_boundary`, `_auto_remove_path_is_safe`) accept a relocated host home. Without this, a relocated install fails its own boundary check and can never be uninstalled — every entry degrades to "outside its verified install boundary; not removed".
- `tools/suite_check.py`: `HOME_WATCH_DIRS` carries each host's env var, so the no-leak guard watches the relocated directory rather than reporting a clean `~/.claude` that was never written to.
- Blank/whitespace values fall back to the default, so an exported-but-empty variable does not resolve to the current directory.
- `ARCHITECTURE.md` documents both variables. Same paragraph, the host-detection sentence still described the pre-#8 behaviour ("Claude Code only when `~/.claude` exists"); it now matches `detect_hosts`, which keys on a CLI being on `PATH`.

## Tests

Eight new tests, each run red before the corresponding fix and green after:

- `TestClaudeConfigDir` / `TestCodexHome` in `tests/test_installer.py` — every host surface lands under the relocated directory, nothing is written under `~`, an install there uninstalls cleanly, the hooks preflight reads the relocated `hooks.json`, and a blank value falls back.
- `tests/test_suite_check.py` — the snapshot guard sees a leak into a relocated directory, one subtest per host.

`setUpModule` in `tests/test_installer.py` clears both variables, so a maintainer who has one exported does not have user-scope tests escape their faked home.

## Checks

`python -m unittest discover -s tests -v`, `python tools/validate.py`, `python install.py --dry-run`, and `git diff --check` all run. The suite goes from 346 to 354 tests with the same two failures before and after, both environmental on this macOS host and present on an unmodified `main` checkout: `test_snapshot_tree_does_not_follow_junction_out_of_root` (shells out to `cmd /c mklink`) and `test_project_plan_writes_only_instruction_blocks_and_minimal_receipt` (`/var` vs `/private/var` symlink resolution under `TMPDIR`).

End-to-end, with both variables set:

```
write: /tmp/cfgdir-probe/skills/orch-task/SKILL.md
Claude Code concurrency settings: /tmp/cfgdir-probe/settings.json
write: /tmp/codexprobe-dir/prompts/orch-spec.md
Codex agent limits: /tmp/codexprobe-dir/config.toml
```
