### PR TITLE
Let the test suite run wherever the installer already runs

### DIFF
--- a/tests/test_installer.py
+++ b/tests/test_installer.py
@@ -1,5 +1,10 @@
 """Installer receipts and conservative uninstall behavior."""
 
+# install.py runs on every interpreter from 3.9 up -- it carries this same
+# future import and guards its own optional tomllib. These tests are held to
+# the same floor, so the suite runs wherever the installer it covers does.
+from __future__ import annotations
+
 import hashlib
 import io
 import json
@@ -12,6 +17,13 @@ from pathlib import Path, PurePosixPath
 from unittest.mock import patch
 
 import install
+
+
+requires_tomllib = unittest.skipIf(
+    install.tomllib is None,
+    "reading back generated TOML requires tomllib (Python 3.11+); "
+    "install.py guards its own use and still runs here",
+)
 
 
 def digest(path: Path) -> str:
@@ -243,6 +255,7 @@ class TestScopedHostConfiguration(unittest.TestCase):
             with self.assertRaisesRegex(ValueError, "invalid Codex agent_type"):
                 install.load_role_profiles(profiles)
 
+    @requires_tomllib
     def test_codex_role_agent_names_follow_spawn_identifier_grammar(self):
         with tempfile.TemporaryDirectory() as tmp:
             home = Path(tmp)
@@ -261,6 +274,7 @@ class TestScopedHostConfiguration(unittest.TestCase):
                 self.assertEqual(dest.stem, parsed["name"])
                 self.assertIsNotNone(re.fullmatch(r"[a-z0-9_]+", parsed["name"]))
 
+    @requires_tomllib
     def test_user_plan_merges_limits_and_writes_native_role_agents(self):
         with tempfile.TemporaryDirectory() as tmp:
             home = Path(tmp)
@@ -402,7 +416,11 @@ class TestScopedHostConfiguration(unittest.TestCase):
             self.assertEqual(2, len(plan.blocks))
             dests = {block.dest for block in plan.blocks}
             self.assertEqual({project / "CLAUDE.md", project / "AGENTS.md"}, dests)
-            user_lib = str((home / ".orchflows" / "lib").resolve())
+            # Unresolved, matching what _lib_home renders into the block.
+            # Resolving here would only agree with the rendered text on a
+            # host whose temp dir has no symlink in it -- macOS resolves
+            # /var to /private/var and the comparison fails for no reason.
+            user_lib = str(home / ".orchflows" / "lib")
             for block in plan.blocks:
                 self.assertIn(user_lib, block.content)
                 self.assertNotIn(str(project), block.content)
@@ -473,6 +491,7 @@ class TestScopedHostConfiguration(unittest.TestCase):
             self.assertEqual({home / ".claude" / "agents"}, {dest.parent for dest, _ in plan.claude_agents})
             self.assertEqual({home / ".codex" / "agents"}, {dest.parent for dest, _ in plan.codex_agents})
 
+    @requires_tomllib
     def test_codex_limit_merge_handles_dotted_agent_keys(self):
         rendered, details = install.render_codex_agent_limits(
             "agents.max_threads = 3\nagents.max_depth = 2\n\n[other]\nvalue = true\n"

--- a/tests/test_suite_check.py
+++ b/tests/test_suite_check.py
@@ -9,6 +9,7 @@ synthetic ``tests/`` directory in a tempdir — never the real suite.
 from __future__ import annotations
 
 import json
+import os
 import subprocess
 import sys
 import tempfile
@@ -109,6 +110,11 @@ class TestHashAndSnapshot(unittest.TestCase):
         # A junction inside a watched tree can point anywhere on the
         # filesystem (e.g. a pnpm/rush build-path-shortener junction).
         # Walking into it must not escape `root` or crash `relative_to`.
+        # Junctions exist only on Windows, and `cmd` is not on PATH
+        # anywhere else -- the POSIX half of this property is covered by
+        # the symlink test below, which runs everywhere.
+        if os.name != "nt":
+            self.skipTest("junctions are Windows-only; see the symlink test for POSIX")
         with tempfile.TemporaryDirectory() as td:
             root = Path(td) / "watched"
             root.mkdir()
@@ -123,6 +129,29 @@ class TestHashAndSnapshot(unittest.TestCase):
             )
             if result.returncode != 0:
                 self.skipTest("mklink /J unavailable on this host: " + result.stderr.strip())
+            snap = suite_check.snapshot_tree(root)
+            self.assertIn("link", snap)
+            self.assertNotEqual(snap["link"], "dir")
+            self.assertNotIn(str(Path("link") / "secret.txt"), snap)
+
+    def test_snapshot_tree_does_not_follow_symlink_out_of_root(self):
+        # The same property as the junction test above, on the side of the
+        # `_is_link_like` branch that POSIX can reach: a link is recorded
+        # as `link`, never as `dir`, and nothing behind it enters the
+        # snapshot. Without this the escape guard is untested on every
+        # non-Windows host.
+        with tempfile.TemporaryDirectory() as td:
+            root = Path(td) / "watched"
+            root.mkdir()
+            escape_target = Path(td) / "escape"
+            escape_target.mkdir()
+            (escape_target / "secret.txt").write_text("outside", encoding="utf-8")
+            link = root / "link"
+            try:
+                link.symlink_to(escape_target, target_is_directory=True)
+            except (OSError, NotImplementedError) as error:
+                # Windows only permits this under Developer Mode or admin.
+                self.skipTest("cannot create a directory symlink here: %s" % error)
             snap = suite_check.snapshot_tree(root)
             self.assertIn("link", snap)
             self.assertNotEqual(snap["link"], "dir")


### PR DESCRIPTION
## What

The suite failed 24 of 340 tests on a stock macOS `python3` (3.9.6) and 2 on every interpreter. All 26 were test-side. `install.py` already carries `from __future__ import annotations` and already guards its optional `tomllib`; its tests never did. This holds them to the same floor.

No product file changes — the diff is two test files.

## The four causes

| Cause | Effect | Fix |
|---|---|---|
| `tests/test_installer.py` had no future-annotations import, so the PEP 604 annotation on `mock_host_clis`'s inner `lookup` evaluated at definition time | 21 errors below 3.10 | add the import `install.py` already has |
| Four unguarded `install.tomllib.loads` calls; `install.py` sets `tomllib = None` below 3.11 | 2 errors below 3.11 | the three enclosing tests skip, naming the requirement |
| `subprocess.run(["cmd", "/c", "mklink", "/J", ...])` handled only a non-zero returncode — off Windows the exec itself raises | 1 error everywhere but Windows | skip on `os.name != "nt"`, and cover the property on POSIX (below) |
| One assertion `.resolve()`d its expected path while `install.py` renders an unresolved one | 1 failure on macOS only (`/var` → `/private/var`) | compare what the product actually renders |

## The one behavioural gain

`snapshot_tree` must record a link that escapes the watched root and never descend it. That property was tested **only** through a Windows junction, so on macOS and Linux it had no coverage at all. A symlink counterpart now exercises the same `_is_link_like` branch everywhere.

It is non-vacuous: with `_is_link_like` stubbed to return `False` at runtime — no edit to the tree under test — the new test fails on `assertNotEqual(snap["link"], "dir")`.

## Verification

| Interpreter | Before | After |
|---|---|---|
| 3.9.6 (`/usr/bin/python3`, stock macOS) | 24 failed / 340 | **OK**, 341, 4 skipped |
| 3.12.13 (Homebrew) | 2 failed / 340 | **OK**, 341, 1 skipped |
| 3.13.6 (`uv`) | 2 failed / 340 | **OK**, 341, 1 skipped |

Test identities are a strict superset of the baseline — nothing removed, one added. The only removed line in the whole diff is the `.resolve()` swap; no assertion weakened, no test deleted.

Other required checks on 3.9.6: `tools/validate.py` exit 0, 0 ERROR, the 3 pre-existing WARNs; `install.py --dry-run` exit 0; `git diff --check` exit 0.

**Not verified:** Windows was not executed — no host available. The junction test's Windows path is unchanged apart from the guard, and the new symlink test skips cleanly where directory symlinks need Developer Mode. 3.10 and 3.11 were not executed either; `uv` could not fetch them through this network. 3.9.6 passing covers the annotation cause for both, and 3.9.6's `tomllib is None` path is the same one 3.10 takes.

Ticket: `.orch/tickets/orchflows-maint-2026-07-27/M2.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)