### PR TITLE
Declare the supported Python floor, and prove it in CI

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -1,0 +1,58 @@
+# The four checks AGENTS.md requires, run on every combination this
+# repository claims to support.
+#
+# Versions: 3.9 is the floor `install.py` enforces via MIN_PYTHON. 3.11 is
+# the first release with stdlib `tomllib`, so the two sides of the
+# install.py import guard both get exercised. 3.13 is current. 3.10 and
+# 3.12 add no distinct code path -- each sits on the same side of that
+# guard as a version already here.
+#
+# `git diff --check` is the one required check deliberately absent: it
+# inspects the working tree, which a fresh checkout leaves clean by
+# construction, so here it could pass but never fail. It stays a
+# pre-commit check.
+name: checks
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+permissions:
+  contents: read
+
+# A newer push to the same branch makes an in-flight run irrelevant.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  checks:
+    name: py${{ matrix.python-version }} / ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      # Every leg reports. A red 3.9 must not hide the state of Windows.
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+        python-version: ['3.9', '3.11', '3.13']
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: python tools/validate.py
+        run: python tools/validate.py
+
+      - name: python -m unittest discover -s tests -v
+        run: python -m unittest discover -s tests -v
+
+      # Neither host CLI is on a runner's PATH, so this exits early without
+      # planning anything -- a smoke test of argument handling and import,
+      # not of the installer. The planner itself is covered in full by
+      # tests/test_installer.py, which does run on every leg above.
+      - name: python install.py --dry-run
+        run: python install.py --dry-run

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,7 +27,10 @@ the request; if none fits, continue without orchflows. On user request,
 
 Resolve the interpreter verified for this host first — e.g. `uv run
 --no-project python` where bare `python` is a Windows Store stub — and
-run each command below through it in place of `python`.
+run each command below through it in place of `python`. It must be
+Python 3.9 or newer: that is the floor `install.py` enforces and CI
+proves on 3.9, 3.11 and 3.13 across Linux, macOS and Windows. A result
+recorded on an older interpreter says nothing about this repository.
 
 python tools/validate.py
 python -m unittest discover -s tests -v

--- a/install.py
+++ b/install.py
@@ -62,9 +62,24 @@ from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from pathlib import Path, PurePath
 
+# The floor this installer is written to and CI proves. Enforced here
+# because install.py is the only file a user runs directly -- the shell
+# wrappers just resolve an interpreter and hand it this script. Kept at 3.9
+# deliberately: install.sh falls through to `python3`, which on a stock
+# macOS is 3.9, and nothing in the tree needs newer syntax.
+MIN_PYTHON = (3, 9)
+if sys.version_info < MIN_PYTHON:
+    _running = ".".join(str(part) for part in sys.version_info[:3])
+    raise SystemExit(
+        f"error: orchflows needs Python {MIN_PYTHON[0]}.{MIN_PYTHON[1]} or "
+        f"newer, but {sys.executable} is {_running}. Point a newer "
+        f"interpreter at this script, or run `uv run --no-project python "
+        f"install.py`."
+    )
+
 try:
     import tomllib
-except ModuleNotFoundError:  # Python 3.10 remains supported.
+except ModuleNotFoundError:  # tomllib is 3.11+; MIN_PYTHON is lower.
     tomllib = None
 
 REPO_ROOT = Path(__file__).resolve().parent

--- a/tests/test_installer.py
+++ b/tests/test_installer.py
@@ -10,6 +10,8 @@ import io
 import json
 import re
 import shutil
+import subprocess
+import sys
 import tempfile
 import unittest
 from contextlib import redirect_stdout
@@ -1100,6 +1102,57 @@ class TestBootstrapWrappers(unittest.TestCase):
             text,
             r'where python[^\n]*\n(?:.*\n)*?\s*python "%target%" %\*',
         )
+
+
+class TestDeclaredPythonFloor(unittest.TestCase):
+    """The supported floor lives in two places that have to agree:
+    `install.MIN_PYTHON`, which enforces it at the one file a user runs
+    directly, and AGENTS.md, which is what a contributor reads before
+    running the checks. When they disagree a result gets recorded on an
+    interpreter nobody supports and read as if it meant something, so the
+    agreement is pinned rather than trusted."""
+
+    def test_agents_md_states_the_floor_install_py_enforces(self):
+        text = (install.REPO_ROOT / "AGENTS.md").read_text(encoding="utf-8")
+        # Whitespace-normalized on purpose: AGENTS.md hard-wraps near 70
+        # columns, so a line-anchored match reports failure on correct text
+        # the moment someone rewraps the paragraph.
+        flat = " ".join(text.split())
+        stated = re.search(r"Python (\d+)\.(\d+) or newer", flat)
+        self.assertIsNotNone(stated, "AGENTS.md names no minimum Python version")
+        self.assertEqual(
+            install.MIN_PYTHON,
+            (int(stated.group(1)), int(stated.group(2))),
+            "AGENTS.md and install.MIN_PYTHON disagree about the floor",
+        )
+
+    def test_floor_turns_an_unsupported_interpreter_away(self):
+        # The guard runs at import time, so the only way to watch it fire is
+        # a copy of the script whose floor sits above whatever is running
+        # this test. Without this the constant is never demonstrated to stop
+        # anything -- it is just a tuple nobody reads.
+        source = (install.REPO_ROOT / "install.py").read_text(encoding="utf-8")
+        unreachable = (sys.version_info[0], sys.version_info[1] + 1)
+        mutated = source.replace(
+            "MIN_PYTHON = %r" % (install.MIN_PYTHON,),
+            "MIN_PYTHON = %r" % (unreachable,),
+            1,
+        )
+        self.assertNotEqual(source, mutated, "no MIN_PYTHON literal to raise")
+        with tempfile.TemporaryDirectory() as td:
+            script = Path(td) / "install.py"
+            script.write_text(mutated, encoding="utf-8")
+            proc = subprocess.run(
+                [sys.executable, str(script), "--dry-run"],
+                capture_output=True,
+                text=True,
+            )
+        self.assertNotEqual(0, proc.returncode)
+        message = proc.stdout + proc.stderr
+        self.assertIn(f"{unreachable[0]}.{unreachable[1]} or newer", message)
+        # Naming what is actually running is the difference between a
+        # message someone can act on and one they have to investigate.
+        self.assertIn(".".join(str(p) for p in sys.version_info[:3]), message)
 
 
 class TestPluginSubsystemRemoved(unittest.TestCase):

--- a/tools/suite_check.py
+++ b/tools/suite_check.py
@@ -31,6 +31,7 @@ import hashlib
 import json
 import os
 import re
+import stat
 import subprocess
 import sys
 from pathlib import Path
@@ -88,7 +89,23 @@ def _is_link_like(path: Path) -> bool:
     if path.is_symlink():
         return True
     isjunction = getattr(os.path, "isjunction", None)
-    return bool(isjunction and isjunction(path))
+    if isjunction is not None:
+        return bool(isjunction(path))
+    # os.path.isjunction is 3.12+. Below it the getattr above returned
+    # None and every junction read as an ordinary directory, so os.walk
+    # descended through it and out of the watched root -- the exact escape
+    # this function exists to prevent, silently unguarded on Windows for
+    # every supported interpreter below 3.12. This is what CPython's own
+    # isjunction does, copied so the answer does not depend on the version:
+    # a junction is precisely a mount-point reparse point, and Windows
+    # lstat results have carried st_reparse_tag since 3.8.
+    mount_point = getattr(stat, "IO_REPARSE_TAG_MOUNT_POINT", None)
+    if mount_point is None:
+        return False
+    try:
+        return os.lstat(path).st_reparse_tag == mount_point
+    except (AttributeError, OSError, ValueError):
+        return False
 
 
 def snapshot_tree(root: Path) -> dict[str, str]:


### PR DESCRIPTION
## What was wrong

The repository stated its supported Python version in exactly one place: a comment on the `tomllib` fallback at `install.py:67`. No `pyproject.toml`, no `requires-python`, no `.python-version`, and `AGENTS.md`'s required-checks block named a bare `python` with no version at all.

That gap has already cost something. A baseline of 24 failing tests was recorded on whatever `python3` was first on PATH — 3.9.6 — and carried into #11's risk section as a macOS platform problem. On a supported interpreter the same tree had **2** failures. Nothing in the repo could have told the difference.

## The floor is 3.9, and it was already true

Not a new constraint — a description of what the code already does:

- `install.sh:11` falls through to `python3` when uv and Homebrew are absent, which on a stock macOS is **3.9.6**. That is the path a new user takes.
- All 46 PEP 604 annotation sites in the tree already sit behind `from __future__ import annotations`; `tomllib` is already guarded; there is not one `match` statement or runtime union anywhere.
- `install.py --dry-run`, `tools/validate.py`, `scripts/tickets.py` and the full suite are green on 3.9.6 as of #11.

Raising the floor to 3.11 would delete the `tomllib` guard and three skips, at the cost of breaking install on a stock Mac. Not worth it.

## What changed

| | |
| --- | --- |
| `install.py` | `MIN_PYTHON = (3, 9)`, checked above the `tomllib` guard so it fires before the script does anything. Names both the floor and the interpreter that fell short. |
| `AGENTS.md` | States the version in the block a contributor reads before running the checks — where the missing information actually was. |
| `tests/test_installer.py` | Two tests: the two statements must agree, and the guard must actually turn an old interpreter away. |
| `.github/workflows/checks.yml` | 3.9 / 3.11 / 3.13 × Linux / macOS / Windows. |
| `tools/suite_check.py` | A live bug the matrix found on its first run — see below. |

The pin test matches **whitespace-normalized**. `AGENTS.md` hard-wraps near 70 columns, and a line-anchored match reports failure on correct text the moment someone rewraps the paragraph — that exact failure was logged as friction during #10.

The guard test mutates a **copy** of `install.py` in a temp dir rather than the tree, so an interrupted run cannot leave a raised floor behind.

## What CI found on its first run

Windows went red on 3.9 and 3.11 — and passed on 3.13. That split is the tell.

`os.path.isjunction` arrived in **Python 3.12**. Below it, the `getattr(os.path, "isjunction", None)` in `_is_link_like` returned `None`, so every junction answered `False`, and `os.walk` descended through it and out of the watched root:

```
FAIL: test_snapshot_tree_does_not_follow_junction_out_of_root
AssertionError: 'dir' == 'dir'
```

That is precisely the escape the function's own docstring promises to prevent — *"junctions that point anywhere on the filesystem, including outside the watched root — these must be recorded but never descended into"* — silently unguarded on Windows for every supported interpreter below 3.12.

Fixed by falling back to what CPython's own `isjunction` does internally: a junction is a mount-point reparse point, and Windows `lstat` results have carried `st_reparse_tag` since 3.8. Copying the implementation rather than approximating it keeps the answer identical on both sides of 3.12.

Worth stating plainly: **that test had never executed anywhere.** No Windows runner existed and it skips on every other platform, so it could have asserted anything at all. Its first real run found a live bug in shipped code.

## Why these versions

3.9 is the floor. 3.11 is the first release with stdlib `tomllib`, so both sides of the `install.py:65` import guard get exercised. 3.13 is current. 3.10 and 3.12 add no distinct path — each sits on the same side of that guard as a version already in the matrix.

`fail-fast` is off, which is why one run reported the state of all nine legs instead of stopping at the first red.

`git diff --check` is the one required check deliberately **not** in CI: it reads the working tree, which a fresh checkout leaves clean by construction, so there it could pass but never fail. It stays a pre-commit check.

`install.py --dry-run` in CI is a smoke test only — neither host CLI is on a runner's PATH, so the planner exits early. Real cross-platform installer coverage comes from `tests/test_installer.py`, which does run in full on every leg.

## Verified

**All 9 legs green** — 3.9 / 3.11 / 3.13 × ubuntu / macos / windows.

Non-vacuity shown for every new check, by observed failure rather than assertion:

- pin test — with `install.MIN_PYTHON` patched to `(3, 11)`: `FAILED`, `AGENTS.md and install.MIN_PYTHON disagree about the floor`.
- guard test — it *is* the demonstration; it raises the floor in a copied script and asserts the non-zero exit.
- junction fix — the strongest of the three: the test was observed failing on real Windows 3.9 and 3.11 before the fix, and passing after.

Locally, 343 tests (341 + the 2 new), `OK` on 3.9.6, 3.12.13 and 3.13.6. Identity comparison against `fa9ac04` at method granularity: **nothing dropped**, exactly two added. `tools/validate.py` exit 0 with 0 ERROR; `git diff --check` exit 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)