### PR TITLE
Measure green against the baseline, and say each fact where it can be checked

### DIFF
--- a/contracts/delegation.md
+++ b/contracts/delegation.md
@@ -6,6 +6,8 @@ missing any. A [work item](work-item.md) extends this packet: packet
 parts ⊕ completion test ⊕ lifecycle ⊕ graph position — and a work-item
 dispatch may supply the six parts by reference to the ticket path.
 
+A packet says what to do. Only `inputs` says what is true.
+
 - `objective` — one explicit outcome; a child with two objectives is two
   dispatches.
 - `inputs` — the fixed evidence the child works from, by identity; the

--- a/packs/orch-code-pack/references/oracles.md
+++ b/packs/orch-code-pack/references/oracles.md
@@ -10,5 +10,7 @@ All classes deterministic unless a criterion is explicitly judged.
 | standards shape | the workspace's linter or validator | deterministic |
 | readability/design | the lens's shape rubric ([lens.md](lens.md)) via `orch-verify` | judged |
 
-Green means: every deterministic oracle exits zero at the result
-revision; the judged row is settled at the gate, fresh from the spec.
+Green means: every deterministic oracle is no worse at the result
+revision than at the workspace's recorded baseline, compared by failure
+identity and never by count; the judged row is settled at the gate,
+fresh from the spec.

--- a/packs/orch-code-pack/references/slicing.md
+++ b/packs/orch-code-pack/references/slicing.md
@@ -7,8 +7,8 @@ frontier carries the riskiest seam's tracer.
 
 - Each ticket: one observable behavior, provable by runnable checks from
   the spec's acceptance; a write scope overlapping only siblings it is
-  dependency-ordered with; dependency edges only where one ticket's seam
-  is another's input.
+  dependency-ordered with and sufficient for its own completion test;
+  dependency edges only where one ticket's seam is another's input.
 - Item extensions beyond the core: the runnable check commands verbatim;
   the standards owner pointer; the pack's craft reference by path.
 - No terminal assembly item: merged, green revisions are the assembled

--- a/packs/orch-design-pack/references/oracles.md
+++ b/packs/orch-design-pack/references/oracles.md
@@ -12,6 +12,8 @@ captures only.
 | visual regression | the spec's diff command against the spec's golden captures; a view with no golden establishes its baseline — establishment is never a PASS, the row decides from the next revision | deterministic |
 | design quality | the lens ([lens.md](lens.md)) via `orch-verify`, over fresh captures | judged |
 
-Green means: every deterministic oracle exits zero at the result
-revision with every covered identity captured. Loop policy: the judged
-row draws only from fresh captures, never a stale capture.
+Green means: every deterministic oracle is no worse at the result
+revision than at the workspace's recorded baseline, compared by failure
+identity and never by count, with every covered identity captured. Loop
+policy: the judged row draws only from fresh captures, never a stale
+capture.

--- a/rules/verification.md
+++ b/rules/verification.md
@@ -19,8 +19,8 @@
 7. Verification evidence is reusable at a join while everything it
    covers is unchanged; a covered identity changing invalidates exactly
    the entries that cover it.
-8. An oracle must be able to fail: a check that cannot FAIL on a wrong
-   result decides nothing, and its PASS is void.
+8. An oracle must be able to fail: a check that cannot FAIL when the
+   claim it stands for is false decides nothing, and its PASS is void.
 9. A correction consumes causes, not findings: one fix per shared
    cause, the smallest set that closes the validated findings,
    preferring the fix that simplifies. A cause whose coherent fix

--- a/skills/workflows/orch-spec/SKILL.md
+++ b/skills/workflows/orch-spec/SKILL.md
@@ -11,7 +11,6 @@ Gather the facts a spec depends on through `orch-investigate` — one
 bounded question: what exists, what constrains, what the request
 actually touches. Settle the decisions only the user can make through
 `orch-elicit`; synthesize settled decisions without re-interviewing.
-Verify cheap claims; mark the rest assumptions.
 
 Draft the spec per [contracts/spec.md](../../../contracts/spec.md),
 holding its two hard lines: the objective is one observable end state,

--- a/tests/pins.json
+++ b/tests/pins.json
@@ -1,5 +1,5 @@
 {
-  "delegation.md": "4e04f7ef234fb05b57071ffa69308bc70f5bd8d3a606de6c5b7b8a10f501ea96",
+  "delegation.md": "e2443685f708a884f4f0060f4779de9522d50116fdf0e2fb9f7dd3ad9c10ff8a",
   "pack-signature.md": "860ed46fc00a8152af87ee329d03d9aae03d6fd247d42e7b2ec0f437831d5f44",
   "spec.md": "b70e801d416686abdf0e15326b7de15f84967b9e37e9fc39265006cde7dabb24",
   "verdict.md": "bdebd6c4183f206eaa4e61a206769a2d672407ad972a97459dc8335ad3907055",

--- a/tests/test_roles.py
+++ b/tests/test_roles.py
@@ -60,9 +60,6 @@ ROLE_TABLE = {
 
 
 class TestFrozenRoleTable(unittest.TestCase):
-    def test_table_has_37_entries(self):
-        self.assertEqual(37, len(ROLE_TABLE))
-
     def test_table_covers_exactly_every_skill(self):
         packages = validate.discover_packages()
         skill_names = {pkg["path"].name for pkg in packages if not pkg["is_pack"]}


### PR DESCRIPTION
Five amendments drawn from the friction record and the run worklogs of the
three repositories this library drove between 2026-07-25 and 2026-08-02:
273 friction entries over 11 sessions, ten `.orch/runs/` worklogs, and the
two improvement-cycle ledgers.

Net **+11 / −11 lines** across five files. Two of the five changes are
deletions of a fact the library already states somewhere better.

## What is here

**`0d9f214` — carried, not new.** The 2026-08-01 improvement cycle's two
rules were committed locally and never pushed. This PR carries them because
the third commit below is the deletion half of one of those proposals and is
incoherent without its additive half.

**Let the role table's size be told by the skills that exist.** Deletes
`test_table_has_37_entries`. Its sibling already asserts `ROLE_TABLE`'s key
set equals what discovery finds — strictly stronger, and it survives a skill
being added or removed. Removing `orch-goal` in #10 already paid the hand-edit
a frozen count demands, in both places it is written.

**State the packet's fact rule once, where every packet is checked.** Deletes
`orch-spec`'s "Verify cheap claims; mark the rest assumptions." `0d9f214` put
the general form in `contracts/delegation.md`, binding every dispatch rather
than one skill. The skill's own Never list already forbids restating a
standard its owner states.

**Green is measured against the baseline, not against zero.** Both the code
and design packs promised "every deterministic oracle exits zero at the result
revision." No workspace in the run record ever produced it — the typecheck
command of the repository these packs drove reported 483, 524, 532, 540, 545,
868 and 921 errors across five sessions, under three invocations with three
different passing states. Twenty-two friction entries across four sessions are
executors reinterpreting that absolute differently each time. Compared by
failure identity, never by count: the replay behind this change measured 532
at base and 532 at result, and only the identity sets showed no error had been
substituted for another.

**A write scope that cannot reach its own completion test is a mis-cut.**
Every clause about write scope in the code pack's slicing constrained overlap
with siblings; none constrained sufficiency. Nineteen entries, and the
terminal stanza of `claude-plugins-2026-07-31` names it as that run's own
cause — four green tickets left the feature inert because no ticket owned the
seam between them.

## Verification

Baseline recorded at `0d9f214` before the first edit, on Python 3.12.13
(`/usr/bin/python3` here is 3.9.6; a baseline recorded there misattributes
host-portability failures, per the 2026-07-27 friction entry that produced #12):

| check | baseline `0d9f214` | result `951464b` |
| --- | --- | --- |
| `tools/validate.py` | exit 0, 3 WARN | exit 0, 3 WARN — byte-identical |
| `unittest discover -s tests` | `Ran 343`, `OK (skipped=1)` | `Ran 342`, `OK (skipped=1)` |
| `install.py --dry-run` | exit 0 | exit 0 |
| `git diff --check` | exit 0 | exit 0 |

Failing-identity set empty at both revisions. The test count drops by exactly
the one deleted. No file outside the ticket's `write_scope` is touched.

One regression was caught mid-pass and is worth recording: adding the
sufficiency clause before the overlap clause split the contiguous phrase
`tests/test_adaptive_delivery.py` pins, making a file outside this change's
scope part of the change — the exact shape that clause exists to stop. Fixed
by reordering the amendment, not by editing the pin.

## Deliberately not here

Three further qualified proposals from the 2026-07-27 cycle (exemplars by
pointer, workspace input sufficiency, a method for non-vacuity) remain
unmerged. Each is a paragraph rather than a phrase, and non-vacuity in
particular looks mis-shaped as a rule clause: the `biv-bench-20260731` run
solved it locally by writing a `negative_controls.py` with a `--selftest`,
which is `orch-mechanize` territory.

The content and research packs never asserted an exit-zero green and are
unchanged. The design pack's slicing keeps its overlap-only rule; the
sufficiency evidence is entirely from code work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
