### PR TITLE
Adopt opus-5 as the Claude Code worker binding

### DIFF
--- a/skills/kernel/orch-delegate/references/profiles.md
+++ b/skills/kernel/orch-delegate/references/profiles.md
@@ -6,7 +6,7 @@ file solely owns default model mappings and the child-naming algorithm.
 | Profile | Role | Codex | Claude Code |
 | --- | --- | --- | --- |
 | `orch-planner` | planner | agent_type `orch_planner`, model `gpt-5.6-sol`, model_reasoning_effort `ultra` | model `claude-opus-5`, effort `xhigh` |
-| `orch-worker` | worker | agent_type `orch_worker`, model `gpt-5.6-sol`, model_reasoning_effort `high`, service_tier `fast` | model `claude-sonnet-5`, effort `xhigh` |
+| `orch-worker` | worker | agent_type `orch_worker`, model `gpt-5.6-sol`, model_reasoning_effort `high`, service_tier `fast` | model `claude-opus-5`, effort `xhigh` |
 
 Use native invocation fields when available; a prompt-only request is
 requested, not verified. An unsupported or blocked model binding stops


### PR DESCRIPTION
One line in `profiles.md`, the sole owner of the mapping — `claude-sonnet-5`
appeared at exactly one place in the tree.

#6 set the planner to opus-5 and left the worker on sonnet-5 as the cost
choice. The worker binding has in fact been overridden to opus-5 on the
maintainer's install since at least 2026-07-27, when a reinstall aborted on
the drift. The friction entry from that day records the gap:

> the error says to move or remove the conflicting file and reinstall, and
> `--help` exposes no flag to keep, merge, or adopt the local value, so the
> only route is manual file surgery that discards the customization

Adopting is the third option that error message doesn't offer. Two
consequences, both checked:

- The declared binding now matches what is actually run, so the installed
  file stops drifting from its own receipt. `install.py:1090`'s conflict
  check short-circuits on `current == desired` before it reaches the drift
  comparison — verified by building the plan against this change: both
  `orch-planner.md` and `orch-worker.md` come out **byte-identical** to what
  is on disk, so the abort simply does not arise and no customization is
  discarded to clear it.
- Every worker child now resolves to opus pricing rather than sonnet. That is
  a deliberate reversal of #6's cost choice, not an oversight.
  `rules/delegation.md` §2's ladder still asks for the cheapest capable rung,
  and a dispatch wanting sonnet can name it through the packet's one-shot
  `profile` override (`rules/roles.md` §4) without touching this default.

## Verification

Python 3.12.13, baseline `5d99032`:

| check | result |
| --- | --- |
| `tools/validate.py` | exit 0, 3 WARN — identical to main's set |
| `unittest discover -s tests` | `Ran 350`, `OK (skipped=1)` |
| `install.py --dry-run` | exit 0 |
| `git diff --check` | exit 0 |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
