### PR TITLE
orch-visualize: form-laned visual pages with a legibility gate

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,16 +118,18 @@ the same loop to the library's own skills.
 
 ### Visualize anything
 
-`orch-visualize` renders anything you hand it as a verified Mermaid
-diagram — a workflow, your session trace, a codebase, a process from a
-doc. Every diagram is syntax-checked against a real renderer before it
-comes back. This is its drawing of the pipeline that ships every
+`orch-visualize` renders anything you hand it as a verified visual
+page — a workflow, your session trace, a codebase, a process from a
+doc — choosing the form per subject: Mermaid graphs (ELK layout),
+styled HTML panels for timelines and comparisons, Vega-Lite charts
+for data. Every visual is syntax-checked and legibility-linted before
+it comes back. This is its drawing of the pipeline that ships every
 orchflows delivery:
 
 ```mermaid
 flowchart TD
     spec["orch-spec — freeze exactly what should be made"] --> pack{"pack: code | content | research | design"}
-    pack --> ws["orch-workspace — clean, isolated working area"]
+    pack -->|stamped| ws["orch-workspace — clean, isolated working area"]
     ws --> dec["orch-decompose — cut the spec into ordered tickets"]
     dec --> frontier["orch-frontier — dispatch every ready ticket"]
     frontier --> task["orch-task"]
@@ -244,7 +246,7 @@ bricks either way.
     │   │   └── orch-render            — Builds a screen and checks how it actually looks and behaves
     │   │
     │   └── utilities/ — Small optional helpers
-    │       ├── orch-visualize — Turns supplied information into a diagram
+    │       ├── orch-visualize — Turns supplied information into a visual page
     │       └── orch-off       — Stops orchflows from automatically choosing skills
     │
     ├── Layer 2 · packs/ — Setups for different kinds of projects

--- a/skills/utilities/orch-visualize/SKILL.md
+++ b/skills/utilities/orch-visualize/SKILL.md
@@ -1,32 +1,35 @@
 ---
 name: orch-visualize
-description: Render any supplied subject as verified Mermaid diagrams with a terse explanation. Use when the user asks to see structure.
+description: Render any supplied subject as a verified visual page of diagrams, panels, and charts. Use when the user asks to see structure.
 role: worker
 ---
 
 Require: the subject — supplied or named content only; gather no new
-evidence and decide nothing about the subject. Label every inferred
-connection inferred.
+evidence and decide nothing about it. Label every inferred connection
+inferred. The page plus its prose preserves what the subject states;
+any single visual may omit, never assert falsely.
 
-Choose the diagram by the subject's own shape — for a skill or
-workflow, resolve every backticked call recursively; stop on a
-missing dependency or cycle and say so. Preserve what the subject
-states: order, branches, parallel lanes, loop bounds and exits,
-failure returns. Conditional or weak edges dotted; defect edges red;
-cycles as real back-edges.
+Choose each visual by the subject's dominant relationship per the
+form ladder in [references/authoring.md](references/authoring.md) —
+Mermaid fences for graph shapes, kit `viz-html` fences for panel
+shapes, `vega-lite` fences for data, prose or tables when no
+relationship needs 2-D locality. A subject the lint rejects whole
+splits into an overview plus per-node detail panels under the
+reference's staging law. Write each visual plus at most one terse
+paragraph — what it shows, the one thing to notice — to
+`.orch/runs/viz/<subject>.md` unless the caller names a path.
 
-Write Mermaid blocks plus at most one terse paragraph per diagram —
-what it shows and the one thing to notice — to
-`.orch/runs/viz/<subject>.md` unless the caller names a path. Verify
-before returning: run this package's `scripts/verify_mermaid.py` on the
-output; one correction pass on rejection, then stop. Report verified
-only after exit 0, with graph count; otherwise return failed with the
-verifier's diagnostic. On the dispatch's request, render the verified
-page with `scripts/render_html.py` — a self-contained `<subject>.html`
-beside the source — and report its mode (cdn mode is degraded).
+Verify: run this package's `scripts/verify_mermaid.py --lint`; one
+correction pass on rejection, then stop. Render with
+`scripts/render_html.py`, view the page, and correct once from a
+defect list. Report verified only after both exit 0 with render
+mode svg; cdn mode is degraded, never verified. Otherwise return
+failed with the diagnostic.
 
-Never: decorate beyond the subject's own vocabulary; describe an
+Never: decorate beyond the subject's own vocabulary; emit `-beta`
+diagram types, legends, or a third abstraction level; describe an
 unverified page as verified; add evidence the subject did not supply.
 
-Return: status, file path, graph count, verifier evidence, and the
-per-diagram explanations; rendered page path with mode only on request.
+Return: status, file path, graph, chart, and component counts,
+verifier evidence, per-visual explanations, and the rendered page
+path with mode.

--- a/skills/utilities/orch-visualize/references/authoring.md
+++ b/skills/utilities/orch-visualize/references/authoring.md
@@ -43,19 +43,19 @@ Labels verb-object within the lint's word budget, quoted when
 punctuated. Decision branches always labeled `|so|`. Subgraphs flat
 within the lint's depth budget, single-line titles, no `direction`
 when any member links outside. classDef within the lint's count
-budget; color marks structure, meaning never rides color alone.
-Direction TD when breadth ≤3, LR for long thin chains; one direction
-per diagram.
+budget; color marks structure, meaning never rides color alone. One
+direction per diagram.
 
 ## Staging
 
 One diagram when the whole subject passes the lint. Otherwise an
-overview of at most 7 nodes in the subject's own vocabulary — a
-declarative-sentence title, expandable nodes marked with one shared
-classDef, omission free, false order or linkage forbidden — then one
-detail panel per marked node: same node ids, same direction, opening
-line naming its overview node and neighbors. Split an oversized
-detail sideways at the same level, never into a third level down.
+overview within the lint's overview budget, in the subject's own
+vocabulary — a declarative-sentence title, expandable nodes marked
+with one shared classDef, omission free, false order or linkage
+forbidden — then one detail panel per marked node: same node ids,
+same direction, opening line naming its overview node and neighbors.
+Split an oversized detail sideways at the same level, never into a
+third level down.
 
 ## Kit classes (`viz-html` fences)
 

--- a/skills/utilities/orch-visualize/references/authoring.md
+++ b/skills/utilities/orch-visualize/references/authoring.md
@@ -1,0 +1,73 @@
+# Authoring (consulted once at open)
+
+## Subject preparation
+
+For a skill or workflow subject, resolve every backticked call
+recursively; stop on a missing dependency or cycle and say so.
+Preserve across the page what the subject states: order, branches,
+parallel lanes, loop bounds and exits, failure returns. Conditional
+or weak edges dotted; defect edges red; cycles as real back-edges.
+
+## Form ladder — first form that fits wins
+
+1. Two facts or fewer → a sentence. Strict linear order → a numbered
+   list.
+2. Lookup values, heterogeneous units, or more than ~20 densely
+   related entities → a table.
+3. Conditions × outcomes → a decision table, conditions as rows.
+4. Otherwise a diagram typed by the dominant relationship: branching
+   process → `flowchart` · modes and transitions → `stateDiagram-v2` ·
+   ordered actor exchanges → `sequenceDiagram` · entities and
+   cardinality → `erDiagram` / `classDiagram` · chronology →
+   `timeline` or kit timeline · containment → kit boxes · comparison
+   → kit table · quantitative data → `vega-lite`.
+
+An arrow is legal only when its edge can be named — calls, causes,
+flows-to, precedes, depends-on — and that name is the edge label.
+No diagram is a valid outcome.
+
+## Mermaid
+
+Core types only: flowchart, sequenceDiagram, stateDiagram-v2,
+classDiagram, erDiagram, timeline, pie, gantt — the lint rejects the
+rest. On flowchart and state, lead the fence with ELK frontmatter
+(hosts without the plugin fall back to dagre, so layout is never
+load-bearing):
+
+    ---
+    config:
+      layout: elk
+    ---
+
+Labels verb-object within the lint's word budget, quoted when
+punctuated. Decision branches always labeled `|so|`. Subgraphs flat
+within the lint's depth budget, single-line titles, no `direction`
+when any member links outside. classDef within the lint's count
+budget; color marks structure, meaning never rides color alone.
+Direction TD when breadth ≤3, LR for long thin chains; one direction
+per diagram.
+
+## Staging
+
+One diagram when the whole subject passes the lint. Otherwise an
+overview of at most 7 nodes in the subject's own vocabulary — a
+declarative-sentence title, expandable nodes marked with one shared
+classDef, omission free, false order or linkage forbidden — then one
+detail panel per marked node: same node ids, same direction, opening
+line naming its overview node and neighbors. Split an oversized
+detail sideways at the same level, never into a third level down.
+
+## Kit classes (`viz-html` fences)
+
+`viz-steps` ordered step cards · `viz-timeline` dated rail ·
+`viz-compare` comparison table · `viz-boxes` nested containment ·
+`viz-callout` one annotation. Plain nested `div`/`table`/`ol`
+markup carrying these classes; headings and short text only; no
+inline styles, no scripts, no external resources.
+
+## Look pass
+
+After rendering, list defects — clipped or overlapping text, edges
+through nodes, crossings a reorder removes, mixed directions, a
+panel contradicting the overview — then fix exactly that list.
+Never rate the page, never redraw a visual with no listed defect.

--- a/skills/utilities/orch-visualize/scripts/render_html.py
+++ b/skills/utilities/orch-visualize/scripts/render_html.py
@@ -1,13 +1,25 @@
 #!/usr/bin/env python3
-"""Render a verified Mermaid Markdown page to one self-contained HTML file.
+"""Render a verified visual Markdown page to one self-contained HTML file.
 
-Primary path: every ```mermaid fence is rendered to inline SVG with the
-pinned Mermaid CLI, so the page needs no network and no JavaScript.
-When the CLI is unavailable or fails, the page carries the fence source
-in ``<pre class="mermaid">`` and loads Mermaid from the CDN at view
-time; the JSON result reports mode "cdn" so the caller can say so.
-All file and subprocess boundaries are explicit UTF-8 — never the
-console codepage. Always exits 0 except on unreadable input (2).
+Three fence kinds are rendered:
+  ```mermaid    -> inline SVG via the pinned Mermaid CLI; when the CLI is
+                   unavailable or fails, the fence source is carried in
+                   ``<pre class="mermaid">`` and Mermaid loads from the CDN
+                   at view time (mode "cdn").
+  ```vega-lite  -> inline SVG via vl-convert when importable; otherwise the
+                   spec is carried in ``<pre class="vega-lite">`` and
+                   vega-embed loads from the CDN at view time (mode "cdn").
+                   ORCH_VIZ_NO_VLCONVERT=1 forces that fallback (tests).
+  ```viz-html   -> passed through inside ``<section class="viz">``; the kit
+                   classes (viz-steps, viz-timeline, viz-compare, viz-boxes,
+                   viz-callout) are styled by the page stylesheet.
+
+Every inline SVG gets its ids salted per visual so clip paths, markers,
+and gradients cannot cross-contaminate on one page. Page colors ride CSS
+custom properties with a prefers-color-scheme default and [data-theme]
+overrides. All file and subprocess boundaries are explicit UTF-8 — never
+the console codepage. Always exits 0 except on unreadable input or
+unwritable output (2).
 
 Usage:
     render_html.py <page.md> [--out <page.html>]   -> result JSON on stdout
@@ -17,6 +29,7 @@ from __future__ import annotations
 import argparse
 import html
 import json
+import os
 import re
 import subprocess
 import sys
@@ -25,11 +38,15 @@ from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parent))
 from verify_mermaid import (  # noqa: E402
-    FENCE_RE,
     MERMAID_PACKAGE,
     TIMEOUT_SECONDS,
     _find_npx,
     _normalize_newlines,
+)
+
+ANY_FENCE_RE = re.compile(
+    r"^```(?P<kind>mermaid|vega-lite|viz-html)[ \t]*\r?\n(?P<body>.*?)^```[ \t]*$",
+    re.MULTILINE | re.DOTALL,
 )
 
 CDN_SCRIPT = (
@@ -38,21 +55,62 @@ CDN_SCRIPT = (
     "mermaid.initialize({startOnLoad:true});</script>"
 )
 
+VEGA_CDN_SCRIPT = (
+    '<script src="https://cdn.jsdelivr.net/npm/vega@6"></script>\n'
+    '<script src="https://cdn.jsdelivr.net/npm/vega-lite@6"></script>\n'
+    '<script src="https://cdn.jsdelivr.net/npm/vega-embed@7"></script>\n'
+    "<script>document.querySelectorAll('pre.vega-lite').forEach(function (pre) {"
+    "var spec = JSON.parse(pre.textContent);"
+    "var holder = document.createElement('div');"
+    "pre.replaceWith(holder);"
+    "vegaEmbed(holder, spec, {actions: false});"
+    "});</script>"
+)
+
+# Panels stay light in dark mode on purpose: CLI-rendered SVGs assume a
+# light canvas, and recoloring them is not this renderer's job.
 PAGE_CSS = """
-  body { margin: 0; background: #f7f6f2; color: #1d2229;
+  :root { --bg: #f7f6f2; --fg: #1d2229; --panel: #fdfdfb;
+          --line: #d8d9d2; --accent: #4a6b8a; }
+  @media (prefers-color-scheme: dark) {
+    :root { --bg: #12161a; --fg: #e6e4dd; --line: #2a3138; }
+  }
+  :root[data-theme="dark"] { --bg: #12161a; --fg: #e6e4dd; --line: #2a3138; }
+  :root[data-theme="light"] { --bg: #f7f6f2; --fg: #1d2229; --line: #d8d9d2; }
+  body { margin: 0; background: var(--bg); color: var(--fg);
          font: 16px/1.6 system-ui, sans-serif; }
   main { max-width: 900px; margin: 0 auto; padding: 40px 20px 80px; }
   h1 { font-size: 1.4rem; } h2 { font-size: 1.05rem; margin-top: 40px; }
   p { max-width: 65ch; }
   code { font-family: ui-monospace, Consolas, monospace; font-size: .9em; }
-  figure.diagram { margin: 16px 0; padding: 16px; background: #fdfdfb;
-                   border: 1px solid #d8d9d2; border-radius: 4px;
+  figure.diagram { margin: 16px 0; padding: 16px; background: var(--panel);
+                   border: 1px solid var(--line); border-radius: 4px;
                    overflow-x: auto; }
   figure.diagram svg { max-width: none; }
-  @media (prefers-color-scheme: dark) {
-    body { background: #12161a; color: #e6e4dd; }
-    figure.diagram { background: #f4f3ee; border-color: #2a3138; }
-  }
+  figure.diagram pre { color: #1d2229; }
+  section.viz { margin: 16px 0; padding: 16px; background: var(--panel);
+                border: 1px solid var(--line); border-radius: 4px;
+                overflow-x: auto; color: #1d2229; }
+  .viz-steps ol { margin: 0; padding-left: 1.4em; }
+  .viz-steps li { margin: 8px 0; padding: 8px 12px; background: #f7f6f2;
+                  border: 1px solid #d8d9d2; border-radius: 4px;
+                  max-width: 60ch; }
+  .viz-timeline { list-style: none; margin: 0; padding: 0;
+                  border-left: 2px solid var(--accent); }
+  .viz-timeline > * { margin: 0 0 12px 0; padding: 0 0 0 16px;
+                  position: relative; }
+  .viz-timeline > *::before { content: ""; position: absolute; left: -5px;
+                  top: .5em; width: 8px; height: 8px; border-radius: 50%;
+                  background: var(--accent); }
+  table.viz-compare { border-collapse: collapse; }
+  table.viz-compare th, table.viz-compare td { border: 1px solid #d8d9d2;
+                  padding: 6px 10px; text-align: left; vertical-align: top; }
+  table.viz-compare th { background: #f7f6f2; }
+  .viz-boxes { border: 1px solid #d8d9d2; border-radius: 4px;
+               padding: 10px 12px; margin: 8px 0; }
+  .viz-boxes .viz-boxes { background: #f7f6f2; }
+  .viz-callout { border-left: 3px solid var(--accent); padding: 4px 12px;
+                 margin: 12px 0; font-size: .95em; }
 """
 
 
@@ -81,6 +139,72 @@ def render_svg(source: str, npx: str, temporary_directory: Path, index: int):
     return svg if "<svg" in svg else None
 
 
+def render_vega_svg(spec_source: str):
+    """Vega-Lite spec -> SVG via vl-convert when importable; None otherwise."""
+
+    if os.environ.get("ORCH_VIZ_NO_VLCONVERT"):
+        return None
+    try:
+        import vl_convert
+    except Exception:
+        return None
+    try:
+        svg = vl_convert.vegalite_to_svg(vl_spec=json.loads(spec_source))
+    except Exception:
+        return None
+    return svg if "<svg" in svg else None
+
+
+def _salt_svg(svg: str, index: int) -> str:
+    """Prefix ids and every internal reference to them — url(#...), href,
+    aria idrefs, and `#id` selectors inside <style> blocks — so multiple
+    inline SVGs on one page cannot cross-contaminate clip paths, markers,
+    gradients, or each other's scoped stylesheets."""
+
+    ids = set(re.findall(r'\bid="([^"]+)"', svg))
+    if not ids:
+        return svg
+    prefix = f"v{index}-"
+    svg = re.sub(r'\bid="([^"]+)"', lambda m: f'id="{prefix}{m.group(1)}"', svg)
+    svg = re.sub(
+        r"url\(#([^)]+)\)",
+        lambda m: f"url(#{prefix}{m.group(1)})" if m.group(1) in ids else m.group(0),
+        svg,
+    )
+    svg = re.sub(
+        r'\b(href|xlink:href)="#([^"]+)"',
+        lambda m: f'{m.group(1)}="#{prefix}{m.group(2)}"'
+        if m.group(2) in ids
+        else m.group(0),
+        svg,
+    )
+    svg = re.sub(
+        r'\b(aria-labelledby|aria-describedby)="([^"]+)"',
+        lambda m: '{}="{}"'.format(
+            m.group(1),
+            " ".join(
+                (prefix + token) if token in ids else token
+                for token in m.group(2).split()
+            ),
+        ),
+        svg,
+    )
+    id_alternation = "|".join(
+        re.escape(known) for known in sorted(ids, key=len, reverse=True)
+    )
+    selector_re = re.compile(rf"#({id_alternation})(?![A-Za-z0-9_-])")
+
+    def _fix_style(match: re.Match[str]) -> str:
+        rewritten = selector_re.sub(
+            lambda m: f"#{prefix}{m.group(1)}", match.group(2)
+        )
+        return match.group(1) + rewritten + match.group(3)
+
+    return re.sub(
+        r"(<style[^>]*>)(.*?)(</style>)", _fix_style, svg, flags=re.DOTALL
+    )
+
+
 def _inline_md(text: str) -> str:
     escaped = html.escape(text, quote=False)
     escaped = re.sub(r"`([^`]+)`", r"<code>\1</code>", escaped)
@@ -104,42 +228,71 @@ def _prose_to_html(prose: str) -> str:
 
 
 def build_page(markdown: str, title: str, npx):
-    """Returns (html_text, mode, graph_count)."""
+    """Returns (html_text, mode, graph_count, chart_count, component_count)."""
+
     text = _normalize_newlines(markdown)
     pieces: list[str] = []
-    mode = "svg"
-    graphs = 0
+    graphs = charts = components = salt = 0
+    mermaid_fallback = vega_fallback = False
     cursor = 0
     with tempfile.TemporaryDirectory(prefix="orch-render-") as temporary:
         temporary_directory = Path(temporary)
-        for match in FENCE_RE.finditer(text):
+        for match in ANY_FENCE_RE.finditer(text):
             pieces.append(_prose_to_html(text[cursor : match.start()]))
-            graphs += 1
+            kind = match.group("kind")
             source = match.group("body")
-            svg = (
-                render_svg(source, npx, temporary_directory, graphs)
-                if npx is not None
-                else None
-            )
-            if svg is not None:
-                pieces.append(f'<figure class="diagram">{svg}</figure>')
-            else:
-                mode = "cdn"
-                pieces.append(
-                    '<figure class="diagram"><pre class="mermaid">'
-                    f"{html.escape(source)}</pre></figure>"
+            if kind == "mermaid":
+                graphs += 1
+                salt += 1
+                svg = (
+                    render_svg(source, npx, temporary_directory, salt)
+                    if npx is not None
+                    else None
                 )
+                if svg is not None:
+                    pieces.append(
+                        f'<figure class="diagram">{_salt_svg(svg, salt)}</figure>'
+                    )
+                else:
+                    mermaid_fallback = True
+                    pieces.append(
+                        '<figure class="diagram"><pre class="mermaid">'
+                        f"{html.escape(source)}</pre></figure>"
+                    )
+            elif kind == "vega-lite":
+                charts += 1
+                salt += 1
+                svg = render_vega_svg(source)
+                if svg is not None:
+                    pieces.append(
+                        f'<figure class="diagram">{_salt_svg(svg, salt)}</figure>'
+                    )
+                else:
+                    vega_fallback = True
+                    pieces.append(
+                        '<figure class="diagram"><pre class="vega-lite">'
+                        f"{html.escape(source)}</pre></figure>"
+                    )
+            else:  # viz-html: verified kit markup passes through untouched
+                components += 1
+                pieces.append(f'<section class="viz">\n{source.strip()}\n</section>')
             cursor = match.end()
         pieces.append(_prose_to_html(text[cursor:]))
     body = "\n".join(piece for piece in pieces if piece)
-    script = CDN_SCRIPT if mode == "cdn" else ""
+    scripts: list[str] = []
+    if mermaid_fallback:
+        scripts.append(CDN_SCRIPT)
+    if vega_fallback:
+        scripts.append(VEGA_CDN_SCRIPT)
+    mode = "cdn" if scripts else "svg"
+    script = "\n".join(scripts)
     page = (
         "<!doctype html>\n<html lang=\"en\">\n<head>\n<meta charset=\"utf-8\">\n"
         f"<meta name=\"viewport\" content=\"width=device-width, initial-scale=1\">\n"
         f"<title>{html.escape(title)}</title>\n<style>{PAGE_CSS}</style>\n</head>\n"
         f"<body>\n<main>\n{body}\n</main>\n{script}\n</body>\n</html>\n"
     )
-    return page, mode, graphs
+    return page, mode, graphs, charts, components
 
 
 def main(argv=None) -> int:
@@ -162,7 +315,7 @@ def main(argv=None) -> int:
             title = line[2:].strip()
             break
 
-    page, mode, graphs = build_page(markdown, title, _find_npx())
+    page, mode, graphs, charts, components = build_page(markdown, title, _find_npx())
     try:
         out.write_text(page, encoding="utf-8")
     except OSError as error:
@@ -170,7 +323,8 @@ def main(argv=None) -> int:
                          ensure_ascii=True))
         return 2
     print(json.dumps({"status": "rendered", "page": str(out), "mode": mode,
-                      "graphs": graphs}, ensure_ascii=True))
+                      "graphs": graphs, "charts": charts,
+                      "components": components}, ensure_ascii=True))
     return 0
 
 

--- a/skills/utilities/orch-visualize/scripts/verify_mermaid.py
+++ b/skills/utilities/orch-visualize/scripts/verify_mermaid.py
@@ -1,13 +1,24 @@
 #!/usr/bin/env python3
-"""Verify ```mermaid fenced diagrams embedded in a Markdown file.
+"""Verify the visual fences embedded in a Markdown page.
 
-Primary path: render each diagram with the pinned Mermaid CLI and locate
-syntax errors from its diagnostics. When the CLI is unavailable (npx not
-found) or fails to run for reasons other than a diagram syntax error, this
-degrades gracefully to a built-in structural parse that catches unbalanced
-brackets, an unknown diagram type on line 1, duplicate node redefinition
-with conflicting labels, and dangling edge references. Results produced by
-the fallback are marked "structural-only" in the output JSON.
+```mermaid fences: the primary path renders each diagram with the pinned
+Mermaid CLI and locates syntax errors from its diagnostics. When the CLI
+is unavailable (npx not found) or fails to run for reasons other than a
+diagram syntax error, this degrades gracefully to a built-in structural
+parse that catches unbalanced brackets, an unknown diagram type, duplicate
+node redefinition with conflicting labels, and dangling edge references.
+Results produced by the fallback are marked "structural-only" in the JSON.
+
+```vega-lite fences are checked for valid JSON; ```viz-html fences for
+balanced tags and absence of scripts.
+
+--lint additionally enforces the legibility contract: a type gate on
+every diagram (no `-beta`, mindmap, journey, zenuml), then flowchart
+rules — node budget, fan-out, subgraph depth, `direction` in
+externally-linked subgraphs, labeled decision branches — and, when the
+CLI rendered an SVG, node-overlap and viewBox-containment geometry
+checks. A page with prose but no visual fence passes as prose-only;
+an empty page is an error.
 """
 
 from __future__ import annotations
@@ -19,7 +30,8 @@ import shutil
 import subprocess
 import sys
 import tempfile
-from dataclasses import dataclass
+from dataclasses import dataclass, field
+from html.parser import HTMLParser
 from pathlib import Path
 
 
@@ -30,6 +42,14 @@ TIMEOUT_SECONDS = 120
 ANSI_ESCAPE = re.compile(r"\x1b\[[0-?]*[ -/]*[@-~]")
 FENCE_RE = re.compile(
     r"^```mermaid[ \t]*\r?\n(?P<body>.*?)^```[ \t]*$",
+    re.MULTILINE | re.DOTALL,
+)
+VEGA_FENCE_RE = re.compile(
+    r"^```vega-lite[ \t]*\r?\n(?P<body>.*?)^```[ \t]*$",
+    re.MULTILINE | re.DOTALL,
+)
+VIZ_HTML_FENCE_RE = re.compile(
+    r"^```viz-html[ \t]*\r?\n(?P<body>.*?)^```[ \t]*$",
     re.MULTILINE | re.DOTALL,
 )
 ERROR_LOCATION = re.compile(
@@ -49,9 +69,12 @@ KNOWN_DIAGRAM_TYPES = {
     "flowchart", "graph", "sequenceDiagram", "classDiagram", "classDiagram-v2",
     "stateDiagram", "stateDiagram-v2", "erDiagram", "journey", "gantt", "pie",
     "quadrantChart", "requirementDiagram", "gitGraph", "mindmap", "timeline",
-    "sankey-beta", "sankey", "block-beta", "C4Context", "C4Container",
-    "C4Component", "C4Dynamic", "C4Deployment", "xychart-beta", "packet-beta",
-    "kanban", "architecture-beta", "zenuml", "radar-beta", "info",
+    "sankey-beta", "sankey", "block-beta", "block", "C4Context", "C4Container",
+    "C4Component", "C4Dynamic", "C4Deployment", "xychart-beta", "xychart",
+    "packet-beta", "packet", "kanban", "architecture-beta", "zenuml",
+    "radar-beta", "radar", "treemap-beta", "treemap", "venn-beta",
+    "ishikawa-beta", "cynefin-beta", "railroad-beta", "wardley", "swimlane",
+    "info",
 }
 
 NODE_DEF_RE = re.compile(
@@ -82,12 +105,12 @@ def _normalize_newlines(text: str) -> str:
     return text.replace("\r\n", "\n").replace("\r", "\n")
 
 
-def extract_diagrams(text: str) -> list[Diagram]:
-    """Extract every ```mermaid fenced block, retaining its source-file line."""
+def extract_diagrams(text: str, fence_re: re.Pattern[str] = FENCE_RE) -> list[Diagram]:
+    """Extract every matching fenced block, retaining its source-file line."""
 
     text = _normalize_newlines(text)
     diagrams: list[Diagram] = []
-    for match in FENCE_RE.finditer(text):
+    for match in fence_re.finditer(text):
         source = match.group("body")
         source_start_line = text.count("\n", 0, match.start("body")) + 1
         diagrams.append(
@@ -98,6 +121,32 @@ def extract_diagrams(text: str) -> list[Diagram]:
             )
         )
     return diagrams
+
+
+def _frontmatter_span(lines: list[str]) -> int:
+    """Number of leading lines occupied by a YAML frontmatter block
+    (Mermaid per-diagram config such as `layout: elk`); 0 when absent."""
+
+    if not lines or lines[0].strip() != "---":
+        return 0
+    for index in range(1, len(lines)):
+        if lines[index].strip() == "---":
+            return index + 1
+    return 0
+
+
+def _diagram_type(diagram: Diagram) -> tuple[str, int]:
+    """The diagram-type token and its line index, skipping frontmatter."""
+
+    lines = _source_lines(diagram)
+    start = _frontmatter_span(lines)
+    if start:
+        while start < len(lines) and not lines[start].strip():
+            start += 1
+    if start >= len(lines) or not lines[start].strip():
+        return "", -1
+    token_match = re.match(r"[A-Za-z0-9_-]+", lines[start].strip())
+    return (token_match.group(0) if token_match else ""), start
 
 
 def _source_lines(diagram: Diagram) -> list[str]:
@@ -162,17 +211,15 @@ def make_failure(
 
 
 def check_diagram_type(diagram: Diagram) -> dict[str, object] | None:
-    lines = _source_lines(diagram)
-    if not lines or not lines[0].strip():
+    token, line_index = _diagram_type(diagram)
+    if line_index < 0:
         return make_failure(diagram, 0, "diagram is empty on line 1", rule="empty_diagram")
-    first = lines[0].strip()
-    token_match = re.match(r"[A-Za-z0-9_-]+", first)
-    token = token_match.group(0) if token_match else ""
     if token not in KNOWN_DIAGRAM_TYPES:
+        first = _source_lines(diagram)[line_index].strip()
         return make_failure(
             diagram,
-            0,
-            f"unknown diagram type '{token or first[:20]}' on line 1",
+            line_index,
+            f"unknown diagram type '{token or first[:20]}' on line {line_index + 1}",
             rule="unknown_diagram_type",
         )
     return None
@@ -327,6 +374,433 @@ def structural_check(diagram: Diagram) -> list[dict[str, object]]:
     return failures
 
 
+# --- Legibility lint (--lint) ----------------------------------------------------
+
+LINT_NODE_BUDGET = 31        # decompose above (Mendling 2012 error-probability threshold)
+LINT_NODE_WARN = 25
+LINT_FAN_OUT_MAX = 4
+LINT_LABEL_WORD_MAX = 5
+LINT_CLASSDEF_MAX = 3
+LINT_SUBGRAPH_DEPTH_MAX = 1
+LINT_FORBIDDEN_TYPES = {"mindmap", "journey", "zenuml"}
+FLOW_TYPES = {"flowchart", "graph"}
+DIRECTION_RE = re.compile(r"^\s*direction\s+(?:TB|TD|BT|LR|RL)\b")
+CLASSDEF_RE = re.compile(r"^\s*classDef\s")
+NON_NODE_TOKENS = {
+    "subgraph", "end", "direction", "classDef", "class", "style", "click",
+    "linkStyle", "flowchart", "graph",
+}
+
+
+@dataclass
+class FlowGraph:
+    nodes: set[str] = field(default_factory=set)
+    edges: list[tuple[str, str, bool, int]] = field(default_factory=list)
+    decision_nodes: set[str] = field(default_factory=set)
+    labels: dict[str, tuple[str, int]] = field(default_factory=dict)
+    subgraphs: list[dict[str, object]] = field(default_factory=list)
+    max_depth: int = 0
+    classdef_count: int = 0
+
+
+def _extract_flow_graph(diagram: Diagram) -> FlowGraph:
+    """A best-effort node/edge model of a flowchart, from source text alone.
+
+    Edge labels written dash-inline (`-- so -->`) are not modeled; the
+    authoring contract mandates the `|so|` form this parser understands.
+    """
+
+    lines = _source_lines(diagram)
+    masked = [_mask_line(line) for line in lines]
+    graph = FlowGraph()
+    stack: list[dict[str, object]] = []
+
+    def note_node(node_id: str) -> None:
+        if node_id in NON_NODE_TOKENS:
+            return
+        graph.nodes.add(node_id)
+        for frame in stack:
+            frame["members"].add(node_id)
+
+    for line_index in range(_frontmatter_span(lines), len(lines)):
+        raw, line = lines[line_index], masked[line_index]
+        stripped = line.strip()
+        if CLASSDEF_RE.match(line):
+            graph.classdef_count += 1
+            continue
+        subgraph_match = SUBGRAPH_RE.match(line)
+        if subgraph_match:
+            frame: dict[str, object] = {
+                "id": subgraph_match.group("id"),
+                "line_index": line_index,
+                "members": set(),
+                "direction_line": None,
+                "depth": len(stack) + 1,
+            }
+            stack.append(frame)
+            graph.subgraphs.append(frame)
+            graph.max_depth = max(graph.max_depth, len(stack))
+            continue
+        if stripped == "end" and stack:
+            stack.pop()
+            continue
+        if DIRECTION_RE.match(line):
+            if stack:
+                stack[-1]["direction_line"] = line_index
+            continue
+        for match in NODE_DEF_RE.finditer(line):
+            note_node(match.group("id"))
+            if match.group("l3") is not None:
+                graph.decision_nodes.add(match.group("id"))
+        for match in NODE_DEF_RE.finditer(raw):
+            node_id = match.group("id")
+            label = next(
+                (
+                    group
+                    for group in (
+                        match.group("l1"),
+                        match.group("l2"),
+                        match.group("l3"),
+                        match.group("l4"),
+                    )
+                    if group is not None
+                ),
+                "",
+            ).strip().strip("\"'")
+            if label and node_id not in graph.labels:
+                graph.labels[node_id] = (label, line_index)
+        segments = ARROW_RE.split(line)
+        if len(segments) > 1:
+            for segment_index in range(len(segments) - 1):
+                left, right = segments[segment_index], segments[segment_index + 1]
+                right_clean = re.sub(r"^\s*\|[^|\n]*\|", "", right)
+                labeled = right_clean != right
+                # Both sides may be `&`-lists (a & b --> c & d): every
+                # combination is a real edge and counts toward fan-out.
+                sources = []
+                for part in left.split("&"):
+                    src_match = re.search(
+                        r"([A-Za-z][A-Za-z0-9_-]*)\s*"
+                        r"(?:\[[^\]\n]*\]|\([^)\n]*\)|\{[^}\n]*\})?\s*$",
+                        part,
+                    )
+                    if src_match:
+                        sources.append(src_match.group(1))
+                destinations = []
+                for part in right_clean.split("&"):
+                    dst_match = re.match(r"\s*([A-Za-z][A-Za-z0-9_-]*)", part)
+                    if dst_match:
+                        destinations.append(dst_match.group(1))
+                for src in sources:
+                    for dst in destinations:
+                        if src in NON_NODE_TOKENS or dst in NON_NODE_TOKENS:
+                            continue
+                        note_node(src)
+                        note_node(dst)
+                        graph.edges.append((src, dst, labeled, line_index))
+    return graph
+
+
+def lint_diagram(diagram: Diagram) -> tuple[list[dict[str, object]], list[str]]:
+    """Source-level legibility failures and advisory warnings for one diagram."""
+
+    failures: list[dict[str, object]] = []
+    warnings: list[str] = []
+    token, token_line = _diagram_type(diagram)
+    if token_line < 0:
+        return failures, warnings
+    if token.endswith("-beta") or token in LINT_FORBIDDEN_TYPES:
+        failures.append(
+            make_failure(
+                diagram,
+                token_line,
+                f"lint: diagram type '{token}' is forbidden (beta or weak-layout); "
+                "use a core type or a viz-html kit block",
+                rule="lint_forbidden_type",
+            )
+        )
+        return failures, warnings
+    if token not in FLOW_TYPES:
+        return failures, warnings
+
+    graph = _extract_flow_graph(diagram)
+    node_count = len(graph.nodes)
+    if node_count > LINT_NODE_BUDGET:
+        failures.append(
+            make_failure(
+                diagram,
+                token_line,
+                f"lint: {node_count} nodes exceed the {LINT_NODE_BUDGET}-node budget; "
+                "split into an overview plus detail panels",
+                rule="lint_node_budget",
+            )
+        )
+    elif node_count > LINT_NODE_WARN:
+        warnings.append(
+            f"graph {diagram.index}: {node_count} nodes; target {LINT_NODE_WARN} or fewer"
+        )
+
+    out_degree: dict[str, int] = {}
+    first_edge_line: dict[str, int] = {}
+    for src, _dst, _labeled, line_index in graph.edges:
+        out_degree[src] = out_degree.get(src, 0) + 1
+        first_edge_line.setdefault(src, line_index)
+    for src in sorted(out_degree):
+        degree = out_degree[src]
+        if degree > LINT_FAN_OUT_MAX:
+            failures.append(
+                make_failure(
+                    diagram,
+                    first_edge_line[src],
+                    f"lint: node '{src}' fans out to {degree} nodes "
+                    f"(max {LINT_FAN_OUT_MAX}); group targets or split",
+                    rule="lint_fan_out",
+                )
+            )
+        elif degree == LINT_FAN_OUT_MAX:
+            warnings.append(f"graph {diagram.index}: node '{src}' fans out to {degree} nodes")
+
+    if graph.max_depth > LINT_SUBGRAPH_DEPTH_MAX:
+        deep = next(
+            frame for frame in graph.subgraphs if frame["depth"] > LINT_SUBGRAPH_DEPTH_MAX
+        )
+        failures.append(
+            make_failure(
+                diagram,
+                int(deep["line_index"]),
+                f"lint: subgraph nesting depth {graph.max_depth} exceeds "
+                f"{LINT_SUBGRAPH_DEPTH_MAX}; split sideways instead",
+                rule="lint_subgraph_depth",
+            )
+        )
+
+    for frame in graph.subgraphs:
+        if frame["direction_line"] is None:
+            continue
+        members = frame["members"]
+        if any((src in members) != (dst in members) for src, dst, _l, _i in graph.edges):
+            failures.append(
+                make_failure(
+                    diagram,
+                    int(frame["direction_line"]),
+                    f"lint: 'direction' inside subgraph '{frame['id']}' is ignored "
+                    "because a member links across its boundary",
+                    rule="lint_direction_ignored",
+                )
+            )
+
+    for src, _dst, labeled, line_index in graph.edges:
+        if src in graph.decision_nodes and not labeled:
+            failures.append(
+                make_failure(
+                    diagram,
+                    line_index,
+                    f"lint: unlabeled branch from decision node '{src}'; "
+                    "label every decision exit with |so|",
+                    rule="lint_decision_unlabeled",
+                )
+            )
+
+    long_labels = [
+        node_id
+        for node_id, (label, _line) in sorted(graph.labels.items())
+        if len(label.split()) > LINT_LABEL_WORD_MAX
+    ]
+    if long_labels:
+        warnings.append(
+            f"graph {diagram.index}: labels over {LINT_LABEL_WORD_MAX} words on: "
+            + ", ".join(long_labels)
+        )
+    if graph.classdef_count > LINT_CLASSDEF_MAX:
+        warnings.append(
+            f"graph {diagram.index}: {graph.classdef_count} classDefs; "
+            f"max {LINT_CLASSDEF_MAX}"
+        )
+    return failures, warnings
+
+
+SVG_NS = "{http://www.w3.org/2000/svg}"
+TRANSLATE_RE = re.compile(r"translate\(\s*(-?[\d.]+)[,\s]\s*(-?[\d.]+)\s*\)")
+
+
+def geometry_failures(
+    diagram: Diagram, svg_bytes: bytes
+) -> list[dict[str, object]] | None:
+    """Node-overlap and viewBox-containment checks over a CLI-rendered SVG.
+
+    Returns None when the SVG lacks the expected structure — geometry is
+    then reported skipped, never guessed."""
+
+    try:
+        import xml.etree.ElementTree as ElementTree
+
+        root = ElementTree.fromstring(svg_bytes.decode("utf-8", errors="replace"))
+        boxes: list[tuple[float, float, float, float]] = []
+        for group in root.iter(f"{SVG_NS}g"):
+            if "node" not in (group.get("class") or "").split():
+                continue
+            translate = TRANSLATE_RE.search(group.get("transform") or "")
+            rect = group.find(f"{SVG_NS}rect")
+            if translate is None or rect is None:
+                continue
+            boxes.append(
+                (
+                    float(translate.group(1)) + float(rect.get("x", "0")),
+                    float(translate.group(2)) + float(rect.get("y", "0")),
+                    float(rect.get("width", "0")),
+                    float(rect.get("height", "0")),
+                )
+            )
+        if len(boxes) < 2:
+            return None
+        failures: list[dict[str, object]] = []
+        overlaps = 0
+        for i in range(len(boxes)):
+            for j in range(i + 1, len(boxes)):
+                ax, ay, aw, ah = boxes[i]
+                bx, by, bw, bh = boxes[j]
+                dx = min(ax + aw, bx + bw) - max(ax, bx)
+                dy = min(ay + ah, by + bh) - max(ay, by)
+                if dx > 1.0 and dy > 1.0:
+                    overlaps += 1
+        if overlaps:
+            failures.append(
+                make_failure(
+                    diagram,
+                    0,
+                    f"lint: {overlaps} node pair(s) overlap in the rendered layout; "
+                    "reduce density or split",
+                    rule="lint_geometry_overlap",
+                )
+            )
+        view_box = (root.get("viewBox") or "").replace(",", " ").split()
+        if len(view_box) == 4:
+            min_x, min_y, width, height = (float(part) for part in view_box)
+            outside = sum(
+                1
+                for (x, y, w, h) in boxes
+                if x < min_x - 1
+                or y < min_y - 1
+                or x + w > min_x + width + 1
+                or y + h > min_y + height + 1
+            )
+            if outside:
+                failures.append(
+                    make_failure(
+                        diagram,
+                        0,
+                        f"lint: {outside} node(s) fall outside the SVG viewBox",
+                        rule="lint_geometry_overflow",
+                    )
+                )
+        return failures
+    except Exception:
+        return None
+
+
+# --- Non-mermaid fences -----------------------------------------------------------
+
+VOID_TAGS = {
+    "area", "base", "br", "col", "embed", "hr", "img", "input", "link",
+    "meta", "source", "track", "wbr",
+}
+SCRIPT_TAG_RE = re.compile(r"<\s*script\b", re.IGNORECASE)
+INLINE_STYLE_RE = re.compile(r"\bstyle\s*=\s*[\"']", re.IGNORECASE)
+EXTERNAL_REF_RE = re.compile(r"\b(?:src|href)\s*=\s*[\"'](?:https?:)?//", re.IGNORECASE)
+
+
+class _TagBalance(HTMLParser):
+    def __init__(self) -> None:
+        super().__init__(convert_charrefs=True)
+        self.stack: list[tuple[str, int]] = []
+        self.problem: tuple[str, int] | None = None
+
+    def handle_starttag(self, tag: str, attrs: object) -> None:
+        if tag not in VOID_TAGS:
+            self.stack.append((tag, self.getpos()[0]))
+
+    def handle_endtag(self, tag: str) -> None:
+        if tag in VOID_TAGS or self.problem is not None:
+            return
+        if not self.stack or self.stack[-1][0] != tag:
+            self.problem = (tag, self.getpos()[0])
+        else:
+            self.stack.pop()
+
+
+def check_vega_fence(block: Diagram) -> dict[str, object] | None:
+    try:
+        json.loads(block.source)
+    except json.JSONDecodeError as error:
+        return {
+            "fence": "vega-lite",
+            "chart_index": block.index,
+            "source_line": block.source_start_line + max(error.lineno - 1, 0),
+            "message": f"vega-lite spec is not valid JSON: {error.msg}",
+            "rule": "invalid_vega_json",
+        }
+    return None
+
+
+def check_viz_html_fence(block: Diagram) -> list[dict[str, object]]:
+    failures: list[dict[str, object]] = []
+
+    def forbid(pattern: re.Pattern[str], message: str, rule: str) -> None:
+        found = pattern.search(block.source)
+        if found is not None:
+            failures.append(
+                {
+                    "fence": "viz-html",
+                    "component_index": block.index,
+                    "source_line": block.source_start_line
+                    + block.source[: found.start()].count("\n"),
+                    "message": message,
+                    "rule": rule,
+                }
+            )
+
+    forbid(SCRIPT_TAG_RE, "viz-html fences never carry scripts", "viz_html_script")
+    forbid(
+        INLINE_STYLE_RE,
+        "viz-html fences never carry inline styles; use the kit classes",
+        "viz_html_inline_style",
+    )
+    forbid(
+        EXTERNAL_REF_RE,
+        "viz-html fences never reference external resources",
+        "viz_html_external",
+    )
+    parser = _TagBalance()
+    try:
+        parser.feed(_normalize_newlines(block.source))
+        parser.close()
+    except Exception:
+        pass  # html.parser is lenient; the stack below is the verdict
+    if parser.problem is not None:
+        tag, line = parser.problem
+        failures.append(
+            {
+                "fence": "viz-html",
+                "component_index": block.index,
+                "source_line": block.source_start_line + line - 1,
+                "message": f"viz-html markup unbalanced: unexpected </{tag}>",
+                "rule": "unbalanced_html",
+            }
+        )
+    elif parser.stack:
+        tag, line = parser.stack[-1]
+        failures.append(
+            {
+                "fence": "viz-html",
+                "component_index": block.index,
+                "source_line": block.source_start_line + line - 1,
+                "message": f"viz-html markup unbalanced: unclosed <{tag}>",
+                "rule": "unbalanced_html",
+            }
+        )
+    return failures
+
+
 # --- Mermaid CLI path ------------------------------------------------------------
 
 
@@ -461,8 +935,9 @@ def _find_npx() -> str | None:
 
 def verify_diagram_cli(
     diagram: Diagram, npx: str, temporary_directory: Path
-) -> tuple[str, list[dict[str, object]]]:
-    """Returns (status, failures) with status in {"ok", "syntax_error", "tool_error"}."""
+) -> tuple[str, list[dict[str, object]], bytes | None]:
+    """Returns (status, failures, rendered_svg) with status in
+    {"ok", "syntax_error", "tool_error"}; rendered_svg only on "ok"."""
 
     output_path = temporary_directory / f"diagram-{diagram.index}.svg"
     command = [npx, "--yes", MERMAID_PACKAGE, "-i", "-", "-o", str(output_path)]
@@ -481,7 +956,7 @@ def verify_diagram_cli(
             check=False,
         )
     except (OSError, subprocess.SubprocessError, UnicodeError):
-        return "tool_error", []
+        return "tool_error", [], None
 
     combined_output = "\n".join(
         part for part in (result.stderr, result.stdout) if part
@@ -490,17 +965,17 @@ def verify_diagram_cli(
         if MERMAID_SYNTAX_ERROR.search(combined_output):
             failure = _diagnose_cli_syntax_error(diagram, combined_output)
             if failure is None:
-                return "tool_error", []
-            return "syntax_error", [failure]
-        return "tool_error", []
+                return "tool_error", [], None
+            return "syntax_error", [failure], None
+        return "tool_error", [], None
 
     try:
         rendered = output_path.read_bytes()
     except OSError:
-        return "tool_error", []
+        return "tool_error", [], None
     if b"<svg" not in rendered:
-        return "tool_error", []
-    return "ok", []
+        return "tool_error", [], None
+    return "ok", [], rendered
 
 
 # --- Entry point -------------------------------------------------------------------
@@ -521,7 +996,13 @@ def _emit(payload: dict[str, object]) -> None:
 
 def parse_arguments(argv: list[str] | None = None) -> argparse.Namespace:
     parser = argparse.ArgumentParser(description=__doc__)
-    parser.add_argument("path", type=Path, help="Markdown file containing mermaid fences")
+    parser.add_argument("path", type=Path, help="Markdown file containing visual fences")
+    parser.add_argument(
+        "--lint",
+        action="store_true",
+        help="also enforce the legibility contract: type gate, node budget, "
+        "fan-out, subgraph depth, decision labels, rendered geometry",
+    )
     return parser.parse_args(argv)
 
 
@@ -542,28 +1023,50 @@ def main(argv: list[str] | None = None) -> int:
         return 2
 
     diagrams = extract_diagrams(text)
-    if not diagrams:
+    charts = extract_diagrams(text, VEGA_FENCE_RE)
+    components = extract_diagrams(text, VIZ_HTML_FENCE_RE)
+    if not diagrams and not charts and not components:
+        if not text.strip():
+            payload = {
+                "status": "error",
+                "graphs": 0,
+                "failures": [],
+                "file": str(path),
+                "message": "No ```mermaid fenced block was found "
+                "(nor ```vega-lite or ```viz-html) and the page is empty.",
+            }
+            _emit(payload)
+            _write(sys.stderr, f"{path}: {payload['message']}\n")
+            return 2
+        # Prose with no visual fence is a legal page: the form ladder's
+        # first rungs (sentence, list, table) draw nothing.
         payload = {
-            "status": "error",
+            "status": "pass",
             "graphs": 0,
+            "charts": 0,
+            "components": 0,
+            "mode": "prose-only",
             "failures": [],
             "file": str(path),
-            "message": "No ```mermaid fenced block was found.",
         }
         _emit(payload)
-        _write(sys.stderr, f"{path}: {payload['message']}\n")
-        return 2
+        return 0
 
     npx = _find_npx()
     failures: list[dict[str, object]] = []
     modes_used: set[str] = set()
+    lint_warnings: list[str] = []
+    geometry_checked = 0
 
     with tempfile.TemporaryDirectory(prefix="orch-mermaid-") as temporary:
         temporary_directory = Path(temporary)
         for diagram in diagrams:
             used_cli = False
+            rendered_svg: bytes | None = None
             if npx is not None:
-                status, diagram_failures = verify_diagram_cli(diagram, npx, temporary_directory)
+                status, diagram_failures, rendered_svg = verify_diagram_cli(
+                    diagram, npx, temporary_directory
+                )
                 if status == "ok":
                     modes_used.add("cli")
                     used_cli = True
@@ -578,8 +1081,26 @@ def main(argv: list[str] | None = None) -> int:
                 for failure in structural_failures:
                     failure["structural_only"] = True
                 failures.extend(structural_failures)
+            if arguments.lint:
+                lint_fails, lint_warns = lint_diagram(diagram)
+                failures.extend(lint_fails)
+                lint_warnings.extend(lint_warns)
+                if rendered_svg is not None:
+                    geometry = geometry_failures(diagram, rendered_svg)
+                    if geometry is not None:
+                        geometry_checked += 1
+                        failures.extend(geometry)
 
-    if modes_used == {"cli"}:
+    for block in charts:
+        chart_failure = check_vega_fence(block)
+        if chart_failure is not None:
+            failures.append(chart_failure)
+    for block in components:
+        failures.extend(check_viz_html_fence(block))
+
+    if not diagrams:
+        mode = "static-only"
+    elif modes_used == {"cli"}:
         mode = "cli"
     elif modes_used == {"structural"}:
         mode = "structural-only"
@@ -590,10 +1111,17 @@ def main(argv: list[str] | None = None) -> int:
     payload: dict[str, object] = {
         "status": status,
         "graphs": len(diagrams),
+        "charts": len(charts),
+        "components": len(components),
         "mode": mode,
         "failures": failures,
         "file": str(path),
     }
+    if arguments.lint:
+        payload["lint"] = {
+            "warnings": lint_warnings,
+            "geometry_checked": geometry_checked,
+        }
     if "cli" in modes_used:
         payload["mermaid_version"] = MERMAID_VERSION
     for failure in failures:

--- a/skills/utilities/orch-visualize/scripts/verify_mermaid.py
+++ b/skills/utilities/orch-visualize/scripts/verify_mermaid.py
@@ -17,8 +17,9 @@ every diagram (no `-beta`, mindmap, journey, zenuml), then flowchart
 rules — node budget, fan-out, subgraph depth, `direction` in
 externally-linked subgraphs, labeled decision branches — and, when the
 CLI rendered an SVG, node-overlap and viewBox-containment geometry
-checks. A page with prose but no visual fence passes as prose-only;
-an empty page is an error.
+checks. On a staged page (two or more flow diagrams) the first flow
+diagram is advised against the overview budget. A page with prose but
+no visual fence passes as prose-only; an empty page is an error.
 """
 
 from __future__ import annotations
@@ -378,6 +379,7 @@ def structural_check(diagram: Diagram) -> list[dict[str, object]]:
 
 LINT_NODE_BUDGET = 31        # decompose above (Mendling 2012 error-probability threshold)
 LINT_NODE_WARN = 25
+LINT_OVERVIEW_BUDGET = 7     # staged pages: the first flow diagram is the overview
 LINT_FAN_OUT_MAX = 4
 LINT_LABEL_WORD_MAX = 5
 LINT_CLASSDEF_MAX = 3
@@ -1057,6 +1059,7 @@ def main(argv: list[str] | None = None) -> int:
     modes_used: set[str] = set()
     lint_warnings: list[str] = []
     geometry_checked = 0
+    flow_node_counts: list[tuple[int, int]] = []
 
     with tempfile.TemporaryDirectory(prefix="orch-mermaid-") as temporary:
         temporary_directory = Path(temporary)
@@ -1085,11 +1088,26 @@ def main(argv: list[str] | None = None) -> int:
                 lint_fails, lint_warns = lint_diagram(diagram)
                 failures.extend(lint_fails)
                 lint_warnings.extend(lint_warns)
+                token, _line = _diagram_type(diagram)
+                if token in FLOW_TYPES:
+                    flow_node_counts.append(
+                        (diagram.index, len(_extract_flow_graph(diagram).nodes))
+                    )
                 if rendered_svg is not None:
                     geometry = geometry_failures(diagram, rendered_svg)
                     if geometry is not None:
                         geometry_checked += 1
                         failures.extend(geometry)
+
+    # On a staged page the first flow diagram is the overview; advisory
+    # because a multi-relationship page legitimately has no overview.
+    if arguments.lint and len(flow_node_counts) >= 2:
+        first_index, first_nodes = flow_node_counts[0]
+        if first_nodes > LINT_OVERVIEW_BUDGET:
+            lint_warnings.append(
+                f"graph {first_index}: leads a staged page with {first_nodes} "
+                f"nodes; the overview budget is {LINT_OVERVIEW_BUDGET}"
+            )
 
     for block in charts:
         chart_failure = check_vega_fence(block)

--- a/tests/test_render_html.py
+++ b/tests/test_render_html.py
@@ -33,9 +33,12 @@ SAMPLE = (
 def _no_npx_env():
     """An environment where shutil.which can never resolve npx, whatever the
     real host PATH contains — forces the cdn fallback deterministically
-    instead of depending on (or spawning) a real Mermaid CLI."""
+    instead of depending on (or spawning) a real Mermaid CLI. The vl-convert
+    knob likewise forces the vega cdn fallback regardless of what the host
+    happens to have installed."""
     env = dict(os.environ)
     env["PATH"] = ""
+    env["ORCH_VIZ_NO_VLCONVERT"] = "1"
     return env
 
 
@@ -158,6 +161,72 @@ class TestRenderHtmlBoundaryInputs(unittest.TestCase):
             page = Path(payload["page"]).read_text(encoding="utf-8")
             self.assertIn('<pre class="mermaid">', page)
             self.assertIn("label 1999", page)
+
+
+class TestKitAndChartFences(unittest.TestCase):
+    def test_viz_html_fence_passes_markup_through(self):
+        page_md = (
+            "# Kit\n\n"
+            "```viz-html\n"
+            '<div class="viz-steps"><ol><li>step one</li><li>step two</li></ol></div>\n'
+            "```\n"
+        )
+        with tempfile.TemporaryDirectory() as tmp:
+            result = run_renderer(Path(tmp), page_md)
+            self.assertEqual(0, result.returncode, result.stdout + result.stderr)
+            payload = json.loads(result.stdout)
+            self.assertEqual("rendered", payload["status"])
+            self.assertEqual(0, payload["graphs"])
+            self.assertEqual(1, payload["components"])
+            page = Path(payload["page"]).read_text(encoding="utf-8")
+            self.assertIn('<section class="viz">', page)
+            self.assertIn("<li>step one</li>", page)
+            self.assertIn(".viz-steps", page)
+
+    def test_vega_lite_fence_falls_back_to_cdn(self):
+        page_md = (
+            "```vega-lite\n"
+            '{"mark": "bar", "data": {"values": [{"x": 1}]}}\n'
+            "```\n"
+        )
+        with tempfile.TemporaryDirectory() as tmp:
+            result = run_renderer(Path(tmp), page_md)
+            self.assertEqual(0, result.returncode, result.stdout + result.stderr)
+            payload = json.loads(result.stdout)
+            self.assertEqual("cdn", payload["mode"])
+            self.assertEqual(1, payload["charts"])
+            page = Path(payload["page"]).read_text(encoding="utf-8")
+            self.assertIn('<pre class="vega-lite">', page)
+            self.assertIn("vega-embed", page)
+            self.assertNotIn("mermaid.esm", page)
+
+
+class TestSvgIdSalting(unittest.TestCase):
+    def test_ids_and_references_are_prefixed_per_visual(self):
+        sys.path.insert(
+            0, str(ROOT / "skills" / "utilities" / "orch-visualize" / "scripts")
+        )
+        import render_html
+
+        svg = (
+            '<svg id="my-svg" aria-labelledby="my-title" role="img">'
+            "<style>#my-svg .node rect{fill:red}#other{}</style>"
+            '<title id="my-title">t</title>'
+            '<defs><clipPath id="a"><rect/></clipPath></defs>'
+            '<g clip-path="url(#a)"></g><use href="#a"/>'
+            '<g clip-path="url(#external)"></g></svg>'
+        )
+        salted = render_html._salt_svg(svg, 3)
+        self.assertIn('id="v3-a"', salted)
+        self.assertIn("url(#v3-a)", salted)
+        self.assertIn('href="#v3-a"', salted)
+        self.assertIn("url(#external)", salted)
+        # Mermaid CLI SVGs scope their stylesheet by root id; the selector
+        # and the aria idref must be rewritten with the id or the diagram
+        # detaches from its own styles.
+        self.assertIn("#v3-my-svg .node rect", salted)
+        self.assertIn("#other{}", salted)
+        self.assertIn('aria-labelledby="v3-my-title"', salted)
 
 
 if __name__ == "__main__":

--- a/tests/test_verify_mermaid.py
+++ b/tests/test_verify_mermaid.py
@@ -28,12 +28,12 @@ def _no_npx_env():
     return env
 
 
-def run_verifier(markdown: str):
+def run_verifier(markdown: str, *extra_args: str):
     with tempfile.TemporaryDirectory() as tmp:
         path = Path(tmp) / "diagram.md"
         path.write_text(markdown, encoding="utf-8")
         return subprocess.run(
-            [sys.executable, str(VERIFIER), str(path)],
+            [sys.executable, str(VERIFIER), str(path), *extra_args],
             capture_output=True,
             text=True,
             encoding="utf-8",
@@ -187,12 +187,15 @@ class TestBoundaryInputs(unittest.TestCase):
         self.assertEqual("error", payload["status"])
         self.assertIn("No ```mermaid fenced block", payload["message"])
 
-    def test_file_without_mermaid_fence_reports_no_fence_and_exits_two(self):
+    def test_file_without_any_fence_passes_as_prose_only(self):
+        # The form ladder's first rungs (sentence, list, table) draw
+        # nothing, so a fence-free prose page is a legal verified page.
         result = run_verifier("# Just a heading\n\nSome prose with no fence at all.\n")
-        self.assertEqual(2, result.returncode, result.stdout + result.stderr)
+        self.assertEqual(0, result.returncode, result.stdout + result.stderr)
         payload = json.loads(result.stdout)
-        self.assertEqual("error", payload["status"])
-        self.assertIn("No ```mermaid fenced block", payload["message"])
+        self.assertEqual("pass", payload["status"])
+        self.assertEqual(0, payload["graphs"])
+        self.assertEqual("prose-only", payload["mode"])
 
     def test_non_utf8_bytes_report_unreadable_and_exit_two(self):
         result = run_verifier_bytes(b"\xff\xfe\x00\x01garbage, not valid utf-8")
@@ -228,6 +231,221 @@ class TestBoundaryInputs(unittest.TestCase):
         self.assertEqual("pass", payload["status"])
         self.assertEqual(1, payload["graphs"])
         self.assertEqual("structural-only", payload["mode"])
+
+
+class TestElkFrontmatter(unittest.TestCase):
+    def test_elk_frontmatter_diagram_passes_structural_check(self):
+        result = run_verifier(
+            "```mermaid\n"
+            "---\n"
+            "config:\n"
+            "  layout: elk\n"
+            "---\n"
+            "flowchart TD\n"
+            '    a["start work"] --> b["done"]\n'
+            "```\n"
+        )
+        self.assertEqual(0, result.returncode, result.stdout + result.stderr)
+        payload = json.loads(result.stdout)
+        self.assertEqual("pass", payload["status"])
+        self.assertEqual(1, payload["graphs"])
+
+
+class TestLegibilityLint(unittest.TestCase):
+    """--lint promotes legibility-contract violations to failures; without
+    the flag the same inputs keep the historical pass behavior."""
+
+    def _lint_rules(self, result):
+        payload = json.loads(result.stdout)
+        return payload, [failure["rule"] for failure in payload["failures"]]
+
+    def test_forbidden_type_mindmap_fails_only_under_lint(self):
+        source = "```mermaid\nmindmap\n  root\n```\n"
+        self.assertEqual(0, run_verifier(source).returncode)
+        result = run_verifier(source, "--lint")
+        self.assertEqual(1, result.returncode, result.stdout + result.stderr)
+        payload, rules = self._lint_rules(result)
+        self.assertIn("lint_forbidden_type", rules)
+
+    def test_forbidden_type_beta_suffix_fails_under_lint(self):
+        result = run_verifier("```mermaid\ntreemap-beta\n```\n", "--lint")
+        self.assertEqual(1, result.returncode, result.stdout + result.stderr)
+        _payload, rules = self._lint_rules(result)
+        self.assertIn("lint_forbidden_type", rules)
+
+    def test_node_budget_exceeded_fails_under_lint(self):
+        lines = ["flowchart TD"]
+        for index in range(34):
+            lines.append(f'    n{index}["step {index}"] --> n{index + 1}["step {index + 1}"]')
+        source = "```mermaid\n" + "\n".join(lines) + "\n```\n"
+        self.assertEqual(0, run_verifier(source).returncode)
+        result = run_verifier(source, "--lint")
+        self.assertEqual(1, result.returncode, result.stdout + result.stderr)
+        _payload, rules = self._lint_rules(result)
+        self.assertIn("lint_node_budget", rules)
+
+    def test_fan_out_over_four_fails_under_lint(self):
+        lines = ["flowchart TD"]
+        for index in range(5):
+            lines.append(f'    hub["dispatch work"] --> t{index}["target {index}"]')
+        result = run_verifier("```mermaid\n" + "\n".join(lines) + "\n```\n", "--lint")
+        self.assertEqual(1, result.returncode, result.stdout + result.stderr)
+        _payload, rules = self._lint_rules(result)
+        self.assertIn("lint_fan_out", rules)
+
+    def test_fan_out_via_ampersand_list_fails_under_lint(self):
+        result = run_verifier(
+            "```mermaid\n"
+            "flowchart TD\n"
+            '    hub["dispatch work"] --> a["t1"] & b["t2"] & c["t3"] & d["t4"] & e["t5"]\n'
+            "```\n",
+            "--lint",
+        )
+        self.assertEqual(1, result.returncode, result.stdout + result.stderr)
+        _payload, rules = self._lint_rules(result)
+        self.assertIn("lint_fan_out", rules)
+
+    def test_nested_subgraph_fails_under_lint(self):
+        result = run_verifier(
+            "```mermaid\n"
+            "flowchart TD\n"
+            "    subgraph outer\n"
+            "        subgraph inner\n"
+            '            z1["deep node"]\n'
+            "        end\n"
+            "    end\n"
+            "```\n",
+            "--lint",
+        )
+        self.assertEqual(1, result.returncode, result.stdout + result.stderr)
+        _payload, rules = self._lint_rules(result)
+        self.assertIn("lint_subgraph_depth", rules)
+
+    def test_direction_in_externally_linked_subgraph_fails_under_lint(self):
+        result = run_verifier(
+            "```mermaid\n"
+            "flowchart TD\n"
+            "    subgraph s1\n"
+            "        direction LR\n"
+            '        x1["inside a"] --> x2["inside b"]\n'
+            "    end\n"
+            '    x2 --> y1["outside"]\n'
+            "```\n",
+            "--lint",
+        )
+        self.assertEqual(1, result.returncode, result.stdout + result.stderr)
+        _payload, rules = self._lint_rules(result)
+        self.assertIn("lint_direction_ignored", rules)
+
+    def test_unlabeled_decision_branch_fails_under_lint(self):
+        result = run_verifier(
+            "```mermaid\n"
+            "flowchart TD\n"
+            '    a["check input"] --> d{"valid?"}\n'
+            '    d --> b["accept"]\n'
+            "```\n",
+            "--lint",
+        )
+        self.assertEqual(1, result.returncode, result.stdout + result.stderr)
+        _payload, rules = self._lint_rules(result)
+        self.assertIn("lint_decision_unlabeled", rules)
+
+    def test_clean_diagram_passes_lint_with_warning_channel(self):
+        result = run_verifier(
+            "```mermaid\n"
+            "flowchart TD\n"
+            '    a["check input"] --> d{"valid?"}\n'
+            '    d -->|yes| b["accept"]\n'
+            '    d -->|no| c["reject"]\n'
+            "```\n",
+            "--lint",
+        )
+        self.assertEqual(0, result.returncode, result.stdout + result.stderr)
+        payload = json.loads(result.stdout)
+        self.assertEqual("pass", payload["status"])
+        self.assertEqual([], payload["lint"]["warnings"])
+        self.assertEqual(0, payload["lint"]["geometry_checked"])
+
+
+class TestStaticFences(unittest.TestCase):
+    """vega-lite and viz-html fences are verified without any mermaid block."""
+
+    def test_vega_only_page_passes_with_chart_count(self):
+        result = run_verifier(
+            "```vega-lite\n"
+            '{"mark": "bar", "data": {"values": []}}\n'
+            "```\n"
+        )
+        self.assertEqual(0, result.returncode, result.stdout + result.stderr)
+        payload = json.loads(result.stdout)
+        self.assertEqual("pass", payload["status"])
+        self.assertEqual(0, payload["graphs"])
+        self.assertEqual(1, payload["charts"])
+        self.assertEqual("static-only", payload["mode"])
+
+    def test_invalid_vega_json_fails(self):
+        result = run_verifier("```vega-lite\n{not json}\n```\n")
+        self.assertEqual(1, result.returncode, result.stdout + result.stderr)
+        payload = json.loads(result.stdout)
+        self.assertEqual(
+            ["invalid_vega_json"], [failure["rule"] for failure in payload["failures"]]
+        )
+
+    def test_unbalanced_viz_html_fails(self):
+        result = run_verifier(
+            "```viz-html\n"
+            '<div class="viz-steps"><ol><li>one</li></ol>\n'
+            "```\n"
+        )
+        self.assertEqual(1, result.returncode, result.stdout + result.stderr)
+        payload = json.loads(result.stdout)
+        self.assertEqual(
+            ["unbalanced_html"], [failure["rule"] for failure in payload["failures"]]
+        )
+
+    def test_script_in_viz_html_fails(self):
+        result = run_verifier(
+            "```viz-html\n"
+            "<div><script>alert(1)</script></div>\n"
+            "```\n"
+        )
+        self.assertEqual(1, result.returncode, result.stdout + result.stderr)
+        payload = json.loads(result.stdout)
+        rules = [failure["rule"] for failure in payload["failures"]]
+        self.assertIn("viz_html_script", rules)
+
+    def test_inline_style_in_viz_html_fails(self):
+        result = run_verifier(
+            "```viz-html\n"
+            '<div style="color: red">styled</div>\n'
+            "```\n"
+        )
+        self.assertEqual(1, result.returncode, result.stdout + result.stderr)
+        payload = json.loads(result.stdout)
+        rules = [failure["rule"] for failure in payload["failures"]]
+        self.assertIn("viz_html_inline_style", rules)
+
+    def test_external_reference_in_viz_html_fails(self):
+        result = run_verifier(
+            "```viz-html\n"
+            '<div><img src="https://example.com/x.png"></div>\n'
+            "```\n"
+        )
+        self.assertEqual(1, result.returncode, result.stdout + result.stderr)
+        payload = json.loads(result.stdout)
+        rules = [failure["rule"] for failure in payload["failures"]]
+        self.assertIn("viz_html_external", rules)
+
+    def test_balanced_viz_html_passes(self):
+        result = run_verifier(
+            "```viz-html\n"
+            '<table class="viz-compare"><tr><th>axis</th><td>value</td></tr></table>\n'
+            "```\n"
+        )
+        self.assertEqual(0, result.returncode, result.stdout + result.stderr)
+        payload = json.loads(result.stdout)
+        self.assertEqual("pass", payload["status"])
+        self.assertEqual(1, payload["components"])
 
 
 if __name__ == "__main__":

--- a/tests/test_verify_mermaid.py
+++ b/tests/test_verify_mermaid.py
@@ -350,6 +350,23 @@ class TestLegibilityLint(unittest.TestCase):
         _payload, rules = self._lint_rules(result)
         self.assertIn("lint_decision_unlabeled", rules)
 
+    def test_oversized_overview_on_staged_page_warns_but_passes(self):
+        overview_lines = ["flowchart LR"]
+        for index in range(8):
+            overview_lines.append(f'    o{index}["phase {index}"] --> o{index + 1}["phase {index + 1}"]')
+        source = (
+            "```mermaid\n" + "\n".join(overview_lines) + "\n```\n\n"
+            "```mermaid\nflowchart TD\n    a[\"detail a\"] --> b[\"detail b\"]\n```\n"
+        )
+        result = run_verifier(source, "--lint")
+        self.assertEqual(0, result.returncode, result.stdout + result.stderr)
+        payload = json.loads(result.stdout)
+        self.assertEqual("pass", payload["status"])
+        self.assertTrue(
+            any("overview budget" in warning for warning in payload["lint"]["warnings"]),
+            payload["lint"]["warnings"],
+        )
+
     def test_clean_diagram_passes_lint_with_warning_channel(self):
         result = run_verifier(
             "```mermaid\n"


### PR DESCRIPTION
Rebuilds orch-visualize from the research in two evidence rounds (comprehension science + substrate/toolchain): the model emits semantics, a deterministic engine owns geometry.

## What changed
- **SKILL.md** — form-gated contract: choose each visual by the subject's dominant relationship (Mermaid graphs with ELK, `viz-html` kit panels, `vega-lite` charts, prose/tables when nothing needs 2-D locality); staged overview → detail past the lint budget; verify + render gate with a bounded defect-list look pass. Return shape change (breaking): chart/component counts, page path always returned.
- **verify_mermaid.py** — ELK frontmatter tolerance; opt-in `--lint` legibility gate (type gate incl. `-beta` suffix, 31-node budget, fan-out incl. `&`-lists, subgraph depth, ignored-`direction`, labeled decision branches, node-overlap/viewBox geometry on CLI renders, advisory overview budget on staged pages); `vega-lite` JSON and `viz-html` balance/script/style/external checks; prose-only pages now pass (the form ladder's "no diagram" outcome is legal).
- **render_html.py** — three fence kinds on one self-contained page; kit component CSS with custom-property light/dark theming; per-visual SVG id salting incl. scoped `<style>` selectors and aria idrefs; per-lane CDN fallbacks.
- **references/authoring.md** (new) — form ladder, ELK snippet, staging law, kit classes, look-pass rules; numeric budgets owned solely by the lint constants.
- **README** — synced mentions; the showcase diagram now passes its own lint.

## Evidence
- Independent library-lens critique: admit-with-corrections; all ten findings addressed, plus two future-proofness trims from a final review (direction heuristic dropped — research null result; overview budget moved into the lint as single owner).
- Demo: old vs new contract on the same subject (benchmaker) — the old page passes the old syntax-only check and fails the new gate with 8 unlabeled decision branches, 1 ignored `direction`, and a real rendered-layout overlap; the new page passes with 3 ELK graphs geometry-checked + 1 kit table.

## Checks
`tools/validate.py` clean · 399 unit tests OK · `install.py --dry-run` clean · `git diff --check` clean · primary path proven end-to-end with the real Mermaid CLI (ELK layout, salted ids, geometry check).

🤖 Generated with [Claude Code](https://claude.com/claude-code)