### PR TITLE
Benchmaker research charter, qualification hardening, evolve findings

### DIFF
--- a/benchmarks/benchmaker/README.md
+++ b/benchmarks/benchmaker/README.md
@@ -33,13 +33,13 @@ Frozen. One case per row; `validate_cases.py` enforces the bijection.
 
 ## Case package layout
 
-`cases/<id>/` holds `case.toml` (the ten frozen schema keys), `target/`
-(the tool under benchmark), `evidence/` (everything a builder may
-read), `seeds/good*/` and `seeds/bad-<slug>/` (protected ground truth,
-each bad seed carrying `defect.md`), and `expected.md` (what a qualified
-benchmark must demonstrate). `tools/validate_cases.py` is the normative
-statement of the schema, the value types, and the probe contract — read
-its module docstring rather than a paraphrase.
+`cases/<id>/` holds `case.toml` (the fourteen frozen schema keys),
+`target/` (the tool under benchmark), `evidence/` (everything a builder
+may read), `seeds/good*/` and `seeds/bad-<slug>/` (protected ground
+truth, each bad seed carrying `defect.md`), and `expected.md` (what a
+qualified benchmark must demonstrate). `tools/validate_cases.py` is the
+normative statement of the schema, the value types, and the probe
+contract — read its module docstring rather than a paraphrase.
 
 The `probe` in `case.toml` is the case author's sanity oracle, not the
 benchmark. It exists so the set can prove its own seeds are live before

--- a/benchmarks/benchmaker/cases/cli-dedupe/case.toml
+++ b/benchmarks/benchmaker/cases/cli-dedupe/case.toml
@@ -8,3 +8,7 @@ bound = "one benchmark run finishes in under 10 s wall clock in a single process
 expected_qualification = ["discrimination", "reproducibility", "cost-within-bound", "schema-valid"]
 negative = false
 port = "paths are case-relative and the probe is cwd-tolerant (case directory or repository root); an adapter may swap the implementation by appending `seeds/<slug>` or `seeds/<slug>/dedupe.py` to `probe`, by setting CASE_IMPL to either, or by substituting the `target` value inside `probe` — `target` and `seeds/good-alt` exit 0, every `seeds/bad-*` exits non-zero."
+tests = "Benchmark of a deterministic CLI discriminates near-miss mutants at flag boundaries and exact output bytes."
+size = "small"
+provenance = "expected.md"
+parallel_safe = true

--- a/benchmarks/benchmaker/cases/cli-dedupe/seeds/bad-blank-line-drop/defect.md
+++ b/benchmarks/benchmaker/cases/cli-dedupe/seeds/bad-blank-line-drop/defect.md
@@ -15,3 +15,5 @@ a benchmark built only from word-list fixtures never generates one.
 Blank-line handling is also the difference between "retained lines" and
 "non-empty lines" as the window's unit, so a suite that ignores it is
 blind to a whole class of window drift as well.
+
+deviation: input-class-drop

--- a/benchmarks/benchmaker/cases/cli-dedupe/seeds/bad-default-unbounded/defect.md
+++ b/benchmarks/benchmaker/cases/cli-dedupe/seeds/bad-default-unbounded/defect.md
@@ -15,3 +15,5 @@ input whose repeats are *not* adjacent — the one shape a fixture full of
 `a a b b` runs never produces. The seed is the cheap end of this case's
 discrimination range: any benchmark that fails to catch it has not
 tested the tool's default behaviour at all.
+
+deviation: default-substitution

--- a/benchmarks/benchmaker/cases/cli-dedupe/seeds/bad-ignore-case-output/defect.md
+++ b/benchmarks/benchmaker/cases/cli-dedupe/seeds/bad-ignore-case-output/defect.md
@@ -15,3 +15,5 @@ bytes rather than a case-insensitive or set-based match. A benchmark
 that asserts "the duplicate is gone" — by counting lines, sorting, or
 comparing case-insensitively — passes this seed, and would go on to
 accept any future change that silently rewrote user data.
+
+deviation: value-substitution

--- a/benchmarks/benchmaker/cases/cli-dedupe/seeds/bad-window-off-by-one/defect.md
+++ b/benchmarks/benchmaker/cases/cli-dedupe/seeds/bad-window-off-by-one/defect.md
@@ -18,3 +18,5 @@ seed identical to the reference and reports a benchmark that cannot
 distinguish a correct window from a wrong one. This is the case's
 discrimination floor — a benchmark that misses it has tested that
 dedupe deduplicates, not that it obeys its contract.
+
+deviation: boundary-shift

--- a/benchmarks/benchmaker/cases/composition-target/case.toml
+++ b/benchmarks/benchmaker/cases/composition-target/case.toml
@@ -16,3 +16,7 @@ expected_qualification = [
 ]
 negative = false
 port = "cwd is this case directory; the probe argument is a variant directory holding workflow.md — swap the `target` value inside `probe` for `seeds/<seed>/`, or pass the same path as CASE_IMPL. `target` and `seeds/good-three-step` exit 0, every `seeds/bad-*` exits non-zero; the per-failure stdout lines are the discrimination trace."
+tests = "A workflow file is benchmarked on its artifact chain, bindings, and gate - the recursion dry run."
+size = "small"
+provenance = "expected.md"
+parallel_safe = true

--- a/benchmarks/benchmaker/cases/composition-target/seeds/bad-broken-edge/defect.md
+++ b/benchmarks/benchmaker/cases/composition-target/seeds/bad-broken-edge/defect.md
@@ -22,3 +22,5 @@ describes a step consuming evidence that was never produced. Catching it
 requires the benchmark to have modeled produces/consumes as a second
 relation over the same steps — which is precisely the modeling decision
 that separates a benchmark of a workflow from a benchmark of a graph.
+
+deviation: dangling-reference

--- a/benchmarks/benchmaker/cases/composition-target/seeds/bad-status-done-check/defect.md
+++ b/benchmarks/benchmaker/cases/composition-target/seeds/bad-status-done-check/defect.md
@@ -20,3 +20,5 @@ decision the benchmark must make before it can be built, and it is
 harder than it looks: the defective text is a well-formed English
 sentence about the workflow, in the right field, and it passes any
 check for the field's presence or non-emptiness.
+
+deviation: oracle-vacuity

--- a/benchmarks/benchmaker/cases/composition-target/seeds/bad-unbound-step/defect.md
+++ b/benchmarks/benchmaker/cases/composition-target/seeds/bad-unbound-step/defect.md
@@ -17,3 +17,5 @@ Catching it requires the benchmark to quantify over declared steps and
 ask which are bound, rather than reading the invariants block and
 finding it non-empty. A benchmark that only checks presence of the block
 scores this file clean.
+
+deviation: binding-omission

--- a/benchmarks/benchmaker/cases/contradictory-evidence/case.toml
+++ b/benchmarks/benchmaker/cases/contradictory-evidence/case.toml
@@ -14,3 +14,7 @@ expected_qualification = [
 ]
 negative = false
 port = "Paths are case-relative; the reference target doubles as the good seed; the probe is cwd-tolerant (repo root, case dir, or a temp copy of the case dir) and takes an optional variant directory argument. The two evidence documents disagree on exactly one boundary — the empty specification — and an adapter must present both, unedited and in either order, with no precedence cue."
+tests = "An evidence contradiction reaches the disagreement register and is settled before casing."
+size = "small"
+provenance = "expected.md"
+parallel_safe = true

--- a/benchmarks/benchmaker/cases/contradictory-evidence/seeds/bad-blank-raises/defect.md
+++ b/benchmarks/benchmaker/cases/contradictory-evidence/seeds/bad-blank-raises/defect.md
@@ -7,3 +7,5 @@ transcribed the settled decision as the single case `parse_ports("") == []`
 scores this variant clean; only one that carried the decision as a boundary --
 no ports named, whatever the whitespace -- catches it. It also probes whether
 a settled assumption was recorded as a rule or as one literal.
+
+deviation: boundary-shift

--- a/benchmarks/benchmaker/cases/contradictory-evidence/seeds/bad-empty-none/defect.md
+++ b/benchmarks/benchmaker/cases/contradictory-evidence/seeds/bad-empty-none/defect.md
@@ -6,3 +6,5 @@ missed by every weak encoding of the settled decision -- `assert not result`,
 all of which `None` satisfies. The variant tests oracle strength at the
 contested boundary: settling a disagreement buys nothing if the case that
 carries the settlement cannot fail.
+
+deviation: value-substitution

--- a/benchmarks/benchmaker/cases/contradictory-evidence/seeds/bad-empty-raises/defect.md
+++ b/benchmarks/benchmaker/cases/contradictory-evidence/seeds/bad-empty-raises/defect.md
@@ -9,3 +9,5 @@ empty specification at all scores both clean. Catching it requires surfacing
 the contradiction as an assumption or gap, settling it with the caller, and
 then encoding the settled answer as a case -- which is the whole contradiction
 angle.
+
+deviation: contract-substitution

--- a/benchmarks/benchmaker/cases/cost-explosion/case.toml
+++ b/benchmarks/benchmaker/cases/cost-explosion/case.toml
@@ -16,3 +16,7 @@ expected_qualification = [
 ]
 negative = false
 port = "adapter.py substitutes {impl} with target/ and with each seeds/*/ in turn and runs probe from the case directory, exit 0 = pass; benchmark.toml selects cases by angle."
+tests = "The smallest evaluation maximizing discrimination is selected inside a hard cost bound."
+size = "small"
+provenance = "expected.md"
+parallel_safe = true

--- a/benchmarks/benchmaker/cases/cost-explosion/seeds/bad-anchor/defect.md
+++ b/benchmarks/benchmaker/cases/cost-explosion/seeds/bad-anchor/defect.md
@@ -10,3 +10,5 @@ exhaustive truncation that fits the cost bound catches it. A benchmark
 that misses this one is not discriminating at all, and its presence
 gives the case a floor — a candidate evaluation cannot score by
 covering only the exotic corners.
+
+deviation: guard-deletion

--- a/benchmarks/benchmaker/cases/cost-explosion/seeds/bad-class-negation/defect.md
+++ b/benchmarks/benchmaker/cases/cost-explosion/seeds/bad-class-negation/defect.md
@@ -12,3 +12,5 @@ sample of 2,000 pairs from that space is expected to contain 0.06 of
 them. A benchmark catches this defect by choosing negated sets on
 purpose, which is the case's demand: the evaluation must be selected
 from the input space, not drawn from it.
+
+deviation: guard-deletion

--- a/benchmarks/benchmaker/cases/cost-explosion/seeds/bad-range-upper/defect.md
+++ b/benchmarks/benchmaker/cases/cost-explosion/seeds/bad-range-upper/defect.md
@@ -16,3 +16,5 @@ contain 0.0015 of them. Only an evaluation that reasons from the
 language's boundary rules and picks the endpoint deliberately catches
 it, and that is what a benchmark for this target has to demonstrate
 inside the cost bound.
+
+deviation: boundary-shift

--- a/benchmarks/benchmaker/cases/lib-rate-limiter/case.toml
+++ b/benchmarks/benchmaker/cases/lib-rate-limiter/case.toml
@@ -8,3 +8,7 @@ bound = "one benchmark run finishes in under 5 s wall clock in a single process;
 expected_qualification = ["discrimination", "reproducibility", "cost-within-bound", "schema-valid"]
 negative = false
 port = "paths are case-relative and the probe is cwd-tolerant (case directory or repository root); an adapter may swap the implementation by appending `seeds/<slug>` or `seeds/<slug>/token_bucket.py` to `probe`, by setting CASE_IMPL to either, or by substituting the `target` value inside `probe` — `target` and `seeds/good-alt` exit 0, every `seeds/bad-*` exits non-zero."
+tests = "Produced benchmark controls time injectably; wall-clock testing cannot qualify."
+size = "small"
+provenance = "expected.md"
+parallel_safe = true

--- a/benchmarks/benchmaker/cases/lib-rate-limiter/seeds/bad-burst-edge/defect.md
+++ b/benchmarks/benchmaker/cases/lib-rate-limiter/seeds/bad-burst-edge/defect.md
@@ -17,3 +17,5 @@ saturates and never sees the defect. This is the near-miss: it survives a
 suite that uses an injectable clock correctly but only ever asks small
 questions of it, and it is caught only by a case that deliberately
 overshoots the saturation point.
+
+deviation: guard-deletion

--- a/benchmarks/benchmaker/cases/lib-rate-limiter/seeds/bad-double-credit/defect.md
+++ b/benchmarks/benchmaker/cases/lib-rate-limiter/seeds/bad-double-credit/defect.md
@@ -17,3 +17,5 @@ reflects one interval rather than two. A benchmark whose cases are
 either all-grant or all-deny, or which resets a fresh bucket for every
 assertion, never puts a denial and a later grant on the same instance
 and scores this seed clean.
+
+deviation: state-omission

--- a/benchmarks/benchmaker/cases/lib-rate-limiter/seeds/bad-refill-rounding/defect.md
+++ b/benchmarks/benchmaker/cases/lib-rate-limiter/seeds/bad-refill-rounding/defect.md
@@ -16,3 +16,5 @@ the clock by 2 seconds in one jump and then calls once sees `int(2.0)`
 and passes. The seed is the direct penalty for treating an injected
 clock as a source of whole-second ticks rather than of arbitrary
 instants.
+
+deviation: value-truncation

--- a/benchmarks/benchmaker/cases/lib-rate-limiter/seeds/bad-wall-clock/defect.md
+++ b/benchmarks/benchmaker/cases/lib-rate-limiter/seeds/bad-wall-clock/defect.md
@@ -18,3 +18,5 @@ refill is to wait for one, so a benchmark that abandons clock injection
 either misses this seed or trades its entire time budget for a single
 case. Catching it cheaply and catching it at all are the same
 requirement.
+
+deviation: contract-substitution

--- a/benchmarks/benchmaker/cases/multi-domain/case.toml
+++ b/benchmarks/benchmaker/cases/multi-domain/case.toml
@@ -34,3 +34,7 @@ negative = false
 # Oracle classes per half (the frozen list vocabulary cannot carry them):
 # code half deterministic; report half judged-or-structural.
 port = "bench-stack adapter: substitute {target} in `probe`, run it with cwd set to the case directory, exit 0 = pass; keep the generator's output directory as run output so the report half can be scored structurally or handed to a judge; the two halves map to two chained single-pack runs, not one mixed run."
+tests = "Code and document halves are materialized as chained single-pack runs and scored coupled."
+size = "small"
+provenance = "expected.md"
+parallel_safe = true

--- a/benchmarks/benchmaker/cases/multi-domain/seeds/bad-broken-code/defect.md
+++ b/benchmarks/benchmaker/cases/multi-domain/seeds/bad-broken-code/defect.md
@@ -12,3 +12,5 @@ deterministic oracle that executes the generated module against a record
 carrying two independent violations catches it, which is why the produced
 benchmark must run the generated code as code rather than reason about it from
 the report.
+
+deviation: early-exit

--- a/benchmarks/benchmaker/cases/multi-domain/seeds/bad-lying-report/defect.md
+++ b/benchmarks/benchmaker/cases/multi-domain/seeds/bad-lying-report/defect.md
@@ -12,3 +12,5 @@ artifact — checking the report's per-field claims against the schema and
 against what the validator actually emits — because the report is what a
 person reads before trusting the generated module, and a confidently wrong
 report is worse than no report.
+
+deviation: artifact-desync

--- a/benchmarks/benchmaker/cases/multi-domain/seeds/bad-stale-error-list/defect.md
+++ b/benchmarks/benchmaker/cases/multi-domain/seeds/bad-stale-error-list/defect.md
@@ -12,3 +12,5 @@ messages the report advertises must equal the set the generated validator
 demonstrably emits. A quality benchmark for a two-artifact generator must
 grade that coupling, or it will certify documentation that sends a reader
 looking for a string the code never produces.
+
+deviation: artifact-desync

--- a/benchmarks/benchmaker/cases/nondeterministic-target/case.toml
+++ b/benchmarks/benchmaker/cases/nondeterministic-target/case.toml
@@ -26,3 +26,7 @@ non-zero is FAIL, target and seeds/good-cumulative must exit 0 and \
 every seeds/bad-* must exit non-zero; the probe pins seeds 7 and 11, \
 which appear nowhere in evidence/, and its distributional band is \
 5700 < count of shard 0 in 20000 draws < 6300."""
+tests = "Nondeterminism is qualified by pinned seeds scored against a recorded stream or a declared per-seed statistical case."
+size = "small"
+provenance = "expected.md"
+parallel_safe = true

--- a/benchmarks/benchmaker/cases/nondeterministic-target/seeds/bad-restream/defect.md
+++ b/benchmarks/benchmaker/cases/nondeterministic-target/seeds/bad-restream/defect.md
@@ -12,3 +12,5 @@ case that compares the full stream for a pinned seed against a
 recorded expectation catches it. It is also the reason "pin a seed"
 alone is not the requirement: the pinned run must be scored against a
 fixed expected stream, not merely against itself.
+
+deviation: contract-substitution

--- a/benchmarks/benchmaker/cases/nondeterministic-target/seeds/bad-seed-ignored/defect.md
+++ b/benchmarks/benchmaker/cases/nondeterministic-target/seeds/bad-seed-ignored/defect.md
@@ -11,3 +11,5 @@ histogram" scores this seed as a pass. Catching it requires either an
 expected stream recorded for a pinned seed or an explicit same-seed
 run-to-run equality case; both are the seed-pinning discipline this
 angle exists to force.
+
+deviation: input-ignored

--- a/benchmarks/benchmaker/cases/nondeterministic-target/seeds/bad-uniform-weights/defect.md
+++ b/benchmarks/benchmaker/cases/nondeterministic-target/seeds/bad-uniform-weights/defect.md
@@ -10,3 +10,5 @@ outside the runbook's 1.5-point tolerance. A benchmark catches it by
 comparing an exact recorded stream, or by a distributional case with a
 declared sample size and tolerance; a benchmark carrying neither is
 testing that the tool is repeatable, not that it is right.
+
+deviation: input-ignored

--- a/benchmarks/benchmaker/cases/overfit-trap/case.toml
+++ b/benchmarks/benchmaker/cases/overfit-trap/case.toml
@@ -24,3 +24,7 @@ seeds/<seed>/pricing.py for a seed — then run it: exit 0 is PASS, \
 non-zero is FAIL, target and seeds/good-banded must exit 0 and every \
 seeds/bad-* must exit non-zero; the probe's four orders appear \
 nowhere in evidence/ and must stay that way."""
+tests = "Produced benchmark catches a candidate that memorizes the visible worked examples."
+size = "small"
+provenance = "expected.md"
+parallel_safe = true

--- a/benchmarks/benchmaker/cases/overfit-trap/seeds/bad-flat-tier/defect.md
+++ b/benchmarks/benchmaker/cases/overfit-trap/seeds/bad-flat-tier/defect.md
@@ -10,3 +10,5 @@ examples in `evidence/`. It is here as the discrimination floor: a
 benchmark that cannot catch this one is not measuring the target at
 all, and a set where it is the *only* seed caught is the exact signal
 that the cases were copied from the documentation.
+
+deviation: rule-substitution

--- a/benchmarks/benchmaker/cases/overfit-trap/seeds/bad-hardcoded/defect.md
+++ b/benchmarks/benchmaker/cases/overfit-trap/seeds/bad-hardcoded/defect.md
@@ -12,3 +12,5 @@ unit_cents)` pair appears nowhere in `evidence/`; a benchmark that
 mirrors the documentation's table certifies a tool that cannot price
 an order. Catching this is the whole anti-goodhart angle: the produced
 benchmark must measure the behavior, not replay the evidence.
+
+deviation: memorization

--- a/benchmarks/benchmaker/cases/overfit-trap/seeds/bad-round-half/defect.md
+++ b/benchmarks/benchmaker/cases/overfit-trap/seeds/bad-round-half/defect.md
@@ -13,3 +13,5 @@ reaches the volume or bulk band. It is the second reason
 example-mirroring fails here: the visible evidence is silent on the
 one input class that separates a documented rule from its plausible
 neighbor.
+
+deviation: boundary-shift

--- a/benchmarks/benchmaker/cases/skill-summarize/case.toml
+++ b/benchmarks/benchmaker/cases/skill-summarize/case.toml
@@ -17,3 +17,7 @@ expected_qualification = [
 ]
 negative = false
 port = "cwd is this case directory; the probe argument is a variant directory holding summarize.md plus output.md — swap the `target` value inside `probe` for `seeds/<seed>/`, or pass the same path as CASE_IMPL. `target` and `seeds/good-terse` exit 0, every `seeds/bad-*` exits non-zero; adapter carries the judged anchors from expected.md as a separate scoring channel."
+tests = "Judged outcome stays anchored and secondary; deterministic checks own byte-decidable facts."
+size = "small"
+provenance = "expected.md"
+parallel_safe = true

--- a/benchmarks/benchmaker/cases/skill-summarize/seeds/bad-fabricated-citation/defect.md
+++ b/benchmarks/benchmaker/cases/skill-summarize/seeds/bad-fabricated-citation/defect.md
@@ -18,3 +18,5 @@ cited id against the closed source set is the cheapest check that
 separates a citation from its imitation — and it is the deterministic
 half, so a produced benchmark that leaves this to a judge has put a
 byte-decidable fact behind a scoring opinion.
+
+deviation: reference-fabrication

--- a/benchmarks/benchmaker/cases/skill-summarize/seeds/bad-over-length/defect.md
+++ b/benchmarks/benchmaker/cases/skill-summarize/seeds/bad-over-length/defect.md
@@ -16,3 +16,5 @@ any benchmark that extracts `max_words` from the prompt under test and
 scores against that number scores this variant as compliant. Holding the
 case's own constant is what makes the check failable, and a failable
 oracle is the qualification requirement this seed exercises.
+
+deviation: constraint-relaxation

--- a/benchmarks/benchmaker/cases/skill-summarize/seeds/bad-uncited-claims/defect.md
+++ b/benchmarks/benchmaker/cases/skill-summarize/seeds/bad-uncited-claims/defect.md
@@ -19,3 +19,5 @@ over citations, which is a design decision the benchmark has to make
 before it can be made. That is what this seed measures: not whether the
 produced benchmark checks citations, but whether it chose the right set
 to quantify over.
+
+deviation: quantifier-narrowing

--- a/benchmarks/benchmaker/cases/sparse-evidence/case.toml
+++ b/benchmarks/benchmaker/cases/sparse-evidence/case.toml
@@ -14,3 +14,7 @@ expected_qualification = [
 ]
 negative = false
 port = "Paths are case-relative; the reference target doubles as the good seed; the probe is cwd-tolerant (repo root, case dir, or a temp copy of the case dir) and takes an optional variant directory argument, so an adapter may either append seeds/bad-<slug> to the probe or overlay a seed onto target/ in a copy."
+tests = "Thin evidence forces gap declaration and intent-quantified cases beyond the examples."
+size = "small"
+provenance = "expected.md"
+parallel_safe = true

--- a/benchmarks/benchmaker/cases/sparse-evidence/seeds/bad-first-only/defect.md
+++ b/benchmarks/benchmaker/cases/sparse-evidence/seeds/bad-first-only/defect.md
@@ -5,3 +5,5 @@ benchmark built by transcribing the examples into cases passes this variant,
 which is the whole failure mode the sparse-evidence angle tests: thin evidence
 must be read for its stated intent and its uncovered boundaries declared as
 gaps, not narrowed to the examples that happen to be written down.
+
+deviation: quantifier-narrowing

--- a/benchmarks/benchmaker/cases/sparse-evidence/seeds/bad-long-value/defect.md
+++ b/benchmarks/benchmaker/cases/sparse-evidence/seeds/bad-long-value/defect.md
@@ -6,3 +6,5 @@ reading the intent's purpose clause as a constraint on the value space rather
 than treating the example inputs as the value space; a benchmark whose only
 inputs are example-sized strings certifies a redactor that leaks every secret
 worth redacting.
+
+deviation: input-class-drop

--- a/benchmarks/benchmaker/cases/sparse-evidence/seeds/bad-repeated-key/defect.md
+++ b/benchmarks/benchmaker/cases/sparse-evidence/seeds/bad-repeated-key/defect.md
@@ -6,3 +6,5 @@ it requires a case built from the quantifier in the intent sentence -- every
 value, including a key that appears twice -- rather than from one step past the
 examples. A benchmark that stops at the first generalization it can think of
 scores this variant clean.
+
+deviation: quantifier-narrowing

--- a/benchmarks/benchmaker/cases/stateful-plugin/case.toml
+++ b/benchmarks/benchmaker/cases/stateful-plugin/case.toml
@@ -28,3 +28,7 @@ expected_qualification = [
 
 negative = false
 port = "bench-stack adapter: substitute {target} in `probe`, run it with cwd set to the case directory, exit 0 = pass; the adapter must give the produced benchmark a scratch state location it owns and must run the suite twice from clean state, keeping both transcripts as run output so the isolation verdict is recomputable."
+tests = "Produced benchmark builds setup/teardown isolation and proves clean-state repeatability."
+size = "medium"
+provenance = "expected.md"
+parallel_safe = true

--- a/benchmarks/benchmaker/cases/stateful-plugin/seeds/bad-delete-masks/defect.md
+++ b/benchmarks/benchmaker/cases/stateful-plugin/seeds/bad-delete-masks/defect.md
@@ -11,3 +11,5 @@ then delete again, then confirm a key that was never stored also fails. A
 quality benchmark for a store must include those follow-up commands, because a
 delete that only hides is how a store's state file grows without bound and how
 a resurrected key reappears after an unrelated write.
+
+deviation: state-masking

--- a/benchmarks/benchmaker/cases/stateful-plugin/seeds/bad-overwrite-empty/defect.md
+++ b/benchmarks/benchmaker/cases/stateful-plugin/seeds/bad-overwrite-empty/defect.md
@@ -12,3 +12,5 @@ nothing. A quality benchmark must choose boundary values for a store's own
 data — the empty string, and any other value whose truthiness differs from its
 presence — because a store that cannot represent an empty value silently
 serves stale data to every later read.
+
+deviation: guard-insertion

--- a/benchmarks/benchmaker/cases/stateful-plugin/seeds/bad-state-leak/defect.md
+++ b/benchmarks/benchmaker/cases/stateful-plugin/seeds/bad-state-leak/defect.md
@@ -18,3 +18,5 @@ state to produce the same transcript. A benchmark that runs its suite once —
 however thorough that one pass is — certifies this seed as correct, and the
 leak surfaces later as a test that passes alone and fails in a second run, or
 passes on a fresh machine and fails on a developer's.
+
+deviation: side-channel-state

--- a/benchmarks/benchmaker/cases/unobservable-outcome/case.toml
+++ b/benchmarks/benchmaker/cases/unobservable-outcome/case.toml
@@ -11,3 +11,7 @@ expected_qualification = [
 ]
 negative = true
 port = "Paths are case-relative; the probe is cwd-tolerant (repo root, case dir, or a temp copy of the case dir) and asserts nothing about behavior. seeds/ is empty by design — an adapter must score the returned artifact against expected.md, not run a discrimination pass, and must not present target/cheer.py as a source of requirements."
+tests = "An unobservable outcome stops at evaluation design with declared gaps; nothing is invented."
+size = "small"
+provenance = "expected.md"
+parallel_safe = true

--- a/benchmarks/benchmaker/tools/validate_cases.py
+++ b/benchmarks/benchmaker/tools/validate_cases.py
@@ -16,13 +16,23 @@ The case.toml subset this reads is: bare keys, one ``key = value`` per
 logical line, plus plain table headers. Values are strings (single-line
 or triple quoted, literal or basic), booleans, decimal integers, and
 arrays of those. Types: ``id``, ``angle``, ``outcome``, ``target``,
-``probe`` and ``port`` are non-empty strings; ``bound`` is a non-empty
-string or a positive integer; ``evidence`` and
+``probe``, ``port``, ``tests`` and ``provenance`` are non-empty
+strings; ``tests`` is the case's one-line statement of what it tests
+and must be a single line; ``provenance`` names the artifact that
+licenses the case; ``size`` is ``small``, ``medium`` or
+``large`` and sets the per-probe-run timeout (60, 300, 900 s);
+``parallel_safe`` is a boolean, and when it is false the case must
+carry ``parallel_risk``, a non-empty string naming the mechanism by
+which concurrent runs corrupt each other (forbidden when true);
+``bound`` is a non-empty string or a positive integer; ``evidence`` and
 ``expected_qualification`` are lists of strings; ``negative`` is a
-boolean. Declared paths are relative to the case directory and use
-forward slashes. Where ``tomllib`` is available the file is parsed twice
-and the two results must agree, so a case.toml that drifts out of the
-subset is reported rather than silently misread.
+boolean. Every bad seed's ``defect.md`` carries exactly one
+``deviation:`` line naming the deviation that produced it. Declared
+paths are relative to
+the case directory and use forward slashes. Where ``tomllib`` is
+available the file is parsed twice and the two results must agree, so a
+case.toml that drifts out of the subset is reported rather than
+silently misread.
 
 A probe runs once per implementation directory — ``target/`` first, then
 each ``seeds/good*/`` and each ``seeds/bad-*/`` — with the case
@@ -58,7 +68,8 @@ except ModuleNotFoundError:  # tomllib is 3.11+; this file supports 3.9.
 
 HERE = Path(__file__).resolve().parent
 DEFAULT_CASES_DIR = HERE.parent / "cases"
-PROBE_TIMEOUT = 300
+SIZE_TIMEOUTS = {"small": 60, "medium": 300, "large": 900}
+DEFAULT_PROBE_TIMEOUT = 300
 
 # Frozen by the run spec's angle matrix: angle -> case id.
 MATRIX = {
@@ -76,9 +87,12 @@ MATRIX = {
     "workflow-target": "composition-target",
 }
 
-STRING_KEYS = ("id", "angle", "outcome", "target", "probe", "port")
+STRING_KEYS = ("id", "angle", "outcome", "target", "probe", "port", "tests", "provenance")
 LIST_KEYS = ("evidence", "expected_qualification")
-SCHEMA_KEYS = frozenset(STRING_KEYS + LIST_KEYS + ("bound", "negative"))
+SCHEMA_KEYS = frozenset(
+    STRING_KEYS + LIST_KEYS + ("bound", "negative", "size", "parallel_safe")
+)
+CONDITIONAL_KEYS = frozenset(("parallel_risk",))
 QUALIFICATIONS = frozenset(
     (
         "discrimination",
@@ -379,7 +393,7 @@ def render_probe(command, declared_target, impl_rel):
     return argv + [impl_rel]
 
 
-def run_probe(case_dir, command, declared_target, impl_dir):
+def run_probe(case_dir, command, declared_target, impl_dir, timeout):
     """Return (returncode, detail). returncode is None when it could not run."""
     impl_rel = impl_dir.relative_to(case_dir).as_posix()
     try:
@@ -397,21 +411,21 @@ def run_probe(case_dir, command, declared_target, impl_dir):
             env=env,
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,
-            timeout=PROBE_TIMEOUT,
+            timeout=timeout,
         )
     except FileNotFoundError:
         return None, "probe command not found: {}".format(argv[0])
     except OSError as error:
         return None, "probe command failed to start: {}".format(error)
     except subprocess.TimeoutExpired:
-        return None, "probe exceeded {} s".format(PROBE_TIMEOUT)
+        return None, "probe exceeded {} s".format(timeout)
     return done.returncode, _first_line(done.stderr) or _first_line(done.stdout)
 
 
 def check_schema(data, name, fail):
     for key in sorted(SCHEMA_KEYS - set(data)):
         fail("case.toml is missing required key '{}'".format(key))
-    for key in sorted(set(data) - SCHEMA_KEYS):
+    for key in sorted(set(data) - SCHEMA_KEYS - CONDITIONAL_KEYS):
         fail("case.toml carries key '{}', outside the frozen schema".format(key))
     for key in STRING_KEYS:
         if key in data and not _nonempty_string(data[key]):
@@ -428,6 +442,18 @@ def check_schema(data, name, fail):
             fail("'bound' must be a non-empty string or a positive integer")
     if "negative" in data and not isinstance(data["negative"], bool):
         fail("'negative' must be a boolean")
+    if _nonempty_string(data.get("tests")) and "\n" in data["tests"].strip():
+        fail("'tests' must be a single line")
+    if "size" in data and data["size"] not in SIZE_TIMEOUTS:
+        fail("'size' must be one of {}".format(sorted(SIZE_TIMEOUTS)))
+    if "parallel_safe" in data:
+        safe = data["parallel_safe"]
+        if not isinstance(safe, bool):
+            fail("'parallel_safe' must be a boolean")
+        elif safe and "parallel_risk" in data:
+            fail("'parallel_risk' is only allowed when parallel_safe is false")
+        elif not safe and not _nonempty_string(data.get("parallel_risk")):
+            fail("parallel_safe = false requires 'parallel_risk' naming the corruption mechanism")
     if _nonempty_string(data.get("id")) and data["id"] != name:
         fail("id '{}' does not match the directory name".format(data["id"]))
     for value in data.get("expected_qualification", []) or []:
@@ -510,6 +536,17 @@ def check_seeds(bad, negative, fail):
         if not text.strip():
             fail("seed '{}' has an empty defect.md".format(seed.name))
             continue
+        deviations = [
+            line
+            for line in text.splitlines()
+            if line.startswith("deviation:") and line[len("deviation:") :].strip()
+        ]
+        if len(deviations) != 1:
+            fail(
+                "seed '{}' defect.md must carry exactly one 'deviation:' line, found {}".format(
+                    seed.name, len(deviations)
+                )
+            )
         haystack = (text + " " + seed.name).lower()
         if any(mark in haystack for mark in NEAR_MISS_MARKS):
             near_miss += 1
@@ -540,17 +577,18 @@ def check_probe(case_dir, data, good, bad, fail):
         return
     if not bad:
         return
+    timeout = SIZE_TIMEOUTS.get(data.get("size"), DEFAULT_PROBE_TIMEOUT)
     declared = data.get("target") if _nonempty_string(data.get("target")) else ""
     passing = [("target", case_dir / "target")]
     passing.extend((seed.name, seed) for seed in good)
     for label, impl in passing:
-        code, detail = run_probe(case_dir, command, declared, impl)
+        code, detail = run_probe(case_dir, command, declared, impl, timeout)
         if code is None:
             fail("probe against {}: {}".format(label, detail))
         elif code != 0:
             fail("probe must pass {} but exited {} ({})".format(label, code, detail or "no output"))
     for seed in bad:
-        code, detail = run_probe(case_dir, command, declared, seed)
+        code, detail = run_probe(case_dir, command, declared, seed, timeout)
         if code is None:
             fail("probe against {}: {}".format(seed.name, detail))
         elif code == 0:

--- a/compositions/benchmaker.md
+++ b/compositions/benchmaker.md
@@ -23,8 +23,10 @@ identity.
 Steps:
 - acquire-spec — `orch-spec` under the carrier rule: freeze one
   evidence-acquisition spec from the request, workspace or evidence
-  access, and one applicable pack per internal spec. Skipped when a
-  supplied qualified synthesis is reused.
+  access, and one applicable pack per internal spec, lanes and
+  synthesis artifacts per the
+  [research charter](references/benchmaker-research.md). Skipped when
+  a supplied qualified synthesis is reused.
 - acquire — `orch-deliver` of that frozen routing-stamped spec. A
   non-complete delivery, decision gap, or uncovered remainder returns
   its partial evidence and stops design.

--- a/compositions/references/benchmaker-protocol.md
+++ b/compositions/references/benchmaker-protocol.md
@@ -82,10 +82,18 @@ Check oracle failability, coverage, discrimination, reproducibility,
 redundancy, provenance, and execution cost independently. Every oracle must be
 capable of failing. Discrimination requires seeded known-good and known-bad
 variants supplied by the qualifying context — the benchmark passes every good
-seed and fails every bad one. Where no known-bad variant can exist, absence of
-bad seeds leaves discrimination UNVERIFIED and an explicit gap. A required
-deterministic failure blocks qualification. Judged criteria carry anchors,
-remain secondary, and cannot compensate for required deterministic failure.
+seed and fails every bad one. The bad set includes one inert variant with the
+intended behavior absent, and a bad variant counts only when shown to change
+the observable outcome — an equivalent variant is excluded, not scored. An
+inert variant shown equivalent is itself a finding: the chosen outcome does
+not observe the intended behavior, recorded as a gap with discrimination
+UNVERIFIED for that behavior. Where
+no known-bad variant can exist, absence of bad seeds leaves discrimination
+UNVERIFIED and an explicit gap. For a nondeterministic outcome, qualification
+fixes a declared trial count; good variants pass and bad variants fail on
+every trial. A required deterministic failure blocks qualification. Judged
+criteria carry anchors, remain secondary, cannot compensate for required
+deterministic failure, and record their rerun variance before sealing.
 
 Resolve every runnable component and verify its byte digest before replay.
 Qualification recomputes its checks from those bytes and captured outputs;

--- a/compositions/references/benchmaker-protocol.md
+++ b/compositions/references/benchmaker-protocol.md
@@ -39,10 +39,10 @@ the stage allocation, never the caller bound.
 ## Evidence acquisition
 
 Reuse a supplied qualified synthesis only when its identity, provenance,
-claim-to-source trace, disagreement register, gaps, and boundary coverage are
-fixed. Otherwise obtain a converged synthesis under the source policy before
-evaluation design. Public examples are provenance-bearing seeds, never
-protected certification evidence by default.
+boundary coverage, and the
+[research charter](benchmaker-research.md)'s artifacts are fixed. Otherwise
+obtain a converged synthesis under the source policy — lanes and artifacts
+per that charter — before evaluation design.
 
 Freeze the synthesis and sources at one result identity. Unsupported semantics
 remain gaps; they never become invented target truth. A non-complete delivery,

--- a/compositions/references/benchmaker-research.md
+++ b/compositions/references/benchmaker-research.md
@@ -1,0 +1,52 @@
+# BenchMaker research charter
+
+The acquire stage cuts its research by this charter; the research
+pack's slicing law owns lane independence and the terminal join.
+
+## Lanes
+
+- **Target intent** — what the target is for, from evidence about the
+  target itself: its stated claims; its demand and failure record;
+  its declared boundaries and refusals; the operator and harness its
+  outcome is observed through; its change history. Cover each of
+  these the evidence provides; record the rest as gaps.
+- **Field** — what already exists around the target's class: prior
+  benchmarks and suites, each returned with a disposition — adapt,
+  differentiate, or ignore, with reason; comparable artifacts and
+  their failure records; named failure taxonomies; oracle precedent
+  and its known failure modes; the class's gaming and contamination
+  record. An empty answer is a finding: record the searches that
+  proved it.
+
+## Synthesis artifacts
+
+The terminal synthesis is complete only when it fixes, at one result
+identity:
+
+- construct definition — one statement of the capability measured and
+  its scope;
+- claim register — each claim, its source, and its falsifying
+  observation; every claim maps to a case specification or a recorded
+  gap;
+- failure atlas — observed and taxonomy-derived failure modes, each
+  naming the deviation that produces it;
+- prior-art register — the field lane's dispositions;
+- disagreement register — per the research pack's oracle policy;
+- gaps — everything acquisition left uncovered or unresolved;
+  explicit, `[]` when none;
+- sourcing mode — mined, authored, or generated-then-filtered, chosen
+  by what the evidence admits.
+
+## Exhibited and protected material
+
+Anything a public source shows is exhibited — assume every candidate
+has seen it — and enters the synthesis only with its source recorded.
+Exhibited material never becomes protected evidence unchanged; a
+protected seed built from it is an authored variant carrying a named
+deviation.
+
+## Bounds
+
+Demand and failure mining stop when consecutive items yield no new
+failure class. A source policy that bars a lane's sources narrows the
+lane to what remains and records the gap; it never blocks the run.

--- a/docs/benchmaker.md
+++ b/docs/benchmaker.md
@@ -6,6 +6,8 @@ observable outcome. Its
 [composition](../compositions/benchmaker.md) owns invocation; its
 [protocol](../compositions/references/benchmaker-protocol.md)
 owns construction and qualification; its
+[research charter](../compositions/references/benchmaker-research.md)
+owns acquisition's lane cut and synthesis shape; its
 [manifest](../compositions/references/benchmaker-manifest.md) owns
 identity.
 


### PR DESCRIPTION
Three landings on one branch:

- **Evolve campaign findings** (`benchmarks/benchmaker/FINDINGS-EVOLVE.md`): the durable record of the no-promotion campaign — six candidates over two generations lawfully killed, findings E1-E6.
- **Research charter** (unit 1): evidence acquisition gains a fixed two-lane contract (target-intent, field) with seven required synthesis artifacts, an exhibited/protected law, and mining bounds. New `compositions/references/benchmaker-research.md`; protocol, composition, and docs ownership map link it.
- **Qualification hardening + case-set schema supersession** (unit 2): protocol qualification adds the inert bad variant (with equivalence-finding bridge), bad-variant equivalence proof, declared trial count for nondeterministic outcomes, and judged rerun variance. The case set moves to fourteen frozen schema keys (`tests`, `size` driving enforced probe timeouts, `provenance`, `parallel_safe`), and every bad seed names its `deviation:`. All twelve cases and thirty-five seeds updated; the flagless validator run stays green.

Both units were gated through independent library-lens critiques (10 + 9 findings, all applied in single correction passes). Note: the schema change supersedes the case set the B(0) seal covered — reseal before the next campaign.

🤖 Generated with [Claude Code](https://claude.com/claude-code)