### PR TITLE
orch-visualize: default deliverable is the rendered HTML page

### DIFF
--- a/skills/utilities/orch-visualize/SKILL.md
+++ b/skills/utilities/orch-visualize/SKILL.md
@@ -15,21 +15,21 @@ Mermaid fences for graph shapes, kit `viz-html` fences for panel
 shapes, `vega-lite` fences for data, prose or tables when no
 relationship needs 2-D locality. A subject the lint rejects whole
 splits into an overview plus per-node detail panels under the
-reference's staging law. Write each visual plus at most one terse
-paragraph — what it shows, the one thing to notice — to
-`.orch/runs/viz/<subject>.md` unless the caller names a path.
+reference's staging law. Author each visual plus one terse
+paragraph — what it shows, the one thing to notice — in
+`.orch/runs/viz/<subject>.md` (or the caller's named path); the
+rendered `<subject>.html` beside it is the deliverable.
 
 Verify: run this package's `scripts/verify_mermaid.py --lint`; one
 correction pass on rejection, then stop. Render with
-`scripts/render_html.py`, view the page, and correct once from a
-defect list. Report verified only after both exit 0 with render
-mode svg; cdn mode is degraded, never verified. Otherwise return
-failed with the diagnostic.
+`scripts/render_html.py`, view the page, correct once from a defect
+list. Verified only when both exit 0 in svg mode — cdn is degraded,
+never verified; otherwise return failed with the diagnostic.
 
 Never: decorate beyond the subject's own vocabulary; emit `-beta`
 diagram types, legends, or a third abstraction level; describe an
 unverified page as verified; add evidence the subject did not supply.
 
-Return: status, file path, graph, chart, and component counts,
-verifier evidence, per-visual explanations, and the rendered page
-path with mode.
+Return: status, the rendered page path with mode — the deliverable;
+then the markdown source path, graph, chart, and component counts,
+verifier evidence, and per-visual explanations.


### PR DESCRIPTION
User-requested behavior change: orch-visualize now names the rendered `<subject>.html` as its deliverable; the markdown source is authoring state, and the Return leads with the page path. One file, wording-only; all four required checks green (validator line budget forced a compression of the Verify paragraph, semantics unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)