### PR TITLE
orch-tdd: red-green for oracle integrity, and a lawful exit

### DIFF
--- a/skills/instances/orch-tdd/SKILL.md
+++ b/skills/instances/orch-tdd/SKILL.md
@@ -8,16 +8,17 @@ Require: one claimed code [ticket](../../../contracts/work-item.md) and
 an isolated workspace at a clean baseline.
 
 Slice the objective so each slice is provable by one failing check.
-Per slice: write the check, watch it fail for the stated reason, make
-it pass with the least code that honestly passes, then reconcile with
-the workspace's idiom and shape per the ticket's craft reference. Test
-at public seams; rewrite any tautological check. Commit each verified
-slice. Close by running the ticket's full completion test through
-`orch-verify` against the result's fixed identity.
+Per slice, under the ticket's craft reference: write the check, replace
+tautological checks, watch it fail for the stated reason, make it pass
+with the least code that honestly passes, then reconcile. Commit each
+verified slice. Suspend through the ticket's `## Handoff` when honest
+passage needs scope the ticket does not grant. Close by running the
+ticket's completion test through `orch-verify` at the result's fixed
+identity.
 
-Never: write code before its failing check; weaken a check to pass it;
-leave the workspace off a committed baseline; touch paths outside the
-ticket's write scope.
+Never: write code before its failing check; weaken or rewrite a check
+to fit the code; leave the workspace off a committed baseline; touch
+paths outside the ticket's write scope.
 
 Return: the completed ticket per
 [work-item.md](../../../contracts/work-item.md)'s filing law.


### PR DESCRIPTION
Amends `skills/instances/orch-tdd/SKILL.md` — the code pack's unit executor — after a six-lane research delivery on whether test-first is the right unit discipline for coding agents.

## Why

**The ordering ablation has never been run.** No retrieved study varies only test-first vs code-first and reports an outcome difference. The two closest proxies are non-positive: the best-powered (N=500/arm, SWE-bench Verified, four frontier models) finds prompt-induced changes in agent test-writing do not shift resolution; another found TDD procedural instructions *without targeted test context* raised regressions 6.08% → 9.94%, "worse than no intervention at all", while supplying which tests matter cut them to 1.82%.

**The human base rate is weaker than its reputation.** Variance-weighted meta-analysis is null (g = −0.010, p = .964); the familiar "small positive effect" tracks the unstandardized arm that the abstract propagates. Component dismantling drops sequencing from both regression models and retains granularity.

**No vendor prescribes test-first.** They prescribe an *oracle* — "give the agent a way to verify its work". Test-first is an independent-practitioner position, split 2–2, and no recommendation in the register cites a measurement.

**What survives is not a productivity claim.** Tests generated after faulty code detect 14% of faults vs 25% generated independently; oracle accuracy drops 8.38–9.46pp on buggy code. Check-first defends *oracle integrity* — a contamination mechanism capability does not remove. And cheating rates rise with capability, so the check-integrity clauses are invariants to design against, not scaffolding to drop.

## Changes

- **`tautological check` consumed again**, as `replace` rather than `rewrite`, keeping the verb disjoint from the Never's `rewrite`. A tautological check is *defined* as one asserting implementation shape — i.e. one that already fits the code — so a colliding verb would strand exactly the check the body orders repaired.
- **Prohibition sharpened** from `weaken` to `weaken or rewrite … to fit the code`; the measured failure taxonomy includes modifying tests, not only softening assertions.
- **Craft pointer hoisted** to govern the whole slice sequence, so `seam` is reachable while the check is written and `idiom` while reconciling. Previously it sat in the reconcile step — reached after the check had already been written and passed.
- **Suspension path added**, triggered on scope the ticket does not grant — the reason `contracts/work-item.md` licenses. An executor with no lawful exit weakens the check it cannot honestly satisfy.
- **Restatements dropped**: `seam` and `idiom` remain consumed by the code lens, so neither term is orphaned under `contracts/pack-signature.md`.

Unchanged: the name, the `description`, and the code pack's `executor` cell. The keep-as-is case was argued at full strength on the same evidence before any recommendation.

## Verification

Both gates ruled before landing. The research gate returned 12 findings (3 HIGH) — all consumed in one correction pass. The library-lens admission gate ruled the first draft **inadmissible** on two blocking findings, both fixed here:

- the original suspension trigger ("no honest implementation satisfies the check") is not a reason `contracts/work-item.md` licenses, and fails its resumability test — criteria stay frozen, so a fresh claimant resumes into an identical unsatisfiable ticket;
- `rewrite` collided between the positive clause and the prohibition, failing toward a left-standing tautological check.

`tools/validate.py` also caught a `rules/composition.md` §10 carriage break that two rounds of adversarial review missed: deleting "against the result's fixed identity" broke the `orch-tdd → orch-verify` call edge.

Required checks, on the verified interpreter (`uv run --no-project python`, 3.12.4):

- `python tools/validate.py` — exit 0
- `python -m unittest discover -s tests` — exit 0
- `python install.py --dry-run` — exit 0
- `git diff --check` — exit 0

Body at **18 of the 25 lines** `rules/composition.md` §5 budgets for an instance skill.

Evidence, disagreement register, gaps register, and the per-clause durability classification are runtime state under `.orch/` and are not committed.

## Queued, not included

Committing the failing check as its own revision — the single-context approximation of denying the implementer authority over the check. Ruled on the merits and routed to its own spec: its coherent form breaks "every commit is a verified slice", whose repair lives in a code-pack `workspace` cell this run's spec excluded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)