### PR TITLE
Add generic Evolve search planning

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,8 +110,9 @@ all sessions in a project, then point a second run at the first one.
 The `benchmaker` composition builds a qualified benchmark for any
 target with an observable outcome — a prompt, a skill, a script. The
 `evolve` composition then runs a tournament against it:
-bounded generations of candidates, blind judges, promotion only when a
-frozen rule and margin are beaten. Together they turn "make this
+bounded generations planned deterministically from settled public outcomes,
+blind judges, and promotion only when a frozen rule and margin are beaten.
+Together they turn "make this
 better" into a measured campaign instead of vibes. The dataflow is in
 [docs/benchmaker.md](docs/benchmaker.md); `skill-tournament` applies
 the same loop to the library's own skills.
@@ -246,8 +247,9 @@ bricks either way.
     │   │   └── orch-render            — Builds a screen and checks how it actually looks and behaves
     │   │
     │   └── utilities/ — Small optional helpers
-    │       ├── orch-visualize — Turns supplied information into a visual page
-    │       └── orch-off       — Stops orchflows from automatically choosing skills
+    │       ├── orch-visualize   — Turns supplied information into a visual page
+    │       ├── orch-search-plan — Produces replayable candidate-search plans
+    │       └── orch-off         — Stops orchflows from automatically choosing skills
     │
     ├── Layer 2 · packs/ — Setups for different kinds of projects
     │   ├── orch-code-pack     — Tells the system how to organize, save, and check software work

--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ Name the bricks yourself when you want a specific shape:
 
     > orch-loop orch-deliver until `pytest -q` exits 0
     > orch-panel these three cache designs — blind judges, pick one
+    > evolve this blog post — no benchmark, derive a blind judge panel
     > evolve the summarizer prompt against the frozen benchmark
 
 Or build your own workflow in plain English:

--- a/compositions/evolve.md
+++ b/compositions/evolve.md
@@ -1,55 +1,66 @@
 ---
 name: evolve
-description: Evolve one target through bounded candidate generations against one frozen qualified benchmark. Manual-only campaign.
+description: Evolve one target through bounded candidate generations against one frozen evaluation. Manual-only campaign.
 entry: named
 ---
 
 Require: one complete [delegation packet](../contracts/delegation.md)
 whose `inputs` carry one frozen evolve spec governed by the
-[spec contract](../contracts/spec.md). Its `evidence` identifies the
-incumbent identity, fixed result/evidence, covered eligibility verdict,
-Judge-owned incumbent score card, and qualified benchmark revision and
-scoring identity. `affected_surfaces` and packet `authority` name candidate
-scope; their intersection is mutation authority. `acceptance` freezes optimizer activation, search policy,
-candidate-accessible dimension and feedback mappings, runner, writer, lane
-count per candidate, promotion done-check and rule, required margin, and
-regression criteria; `bound` and packet `bounds` cap the campaign.
+[spec contract](../contracts/spec.md). Its `evidence` identifies the incumbent
+identity and fixed result/evidence identity for the artifact; a supplied frozen evaluation adds
+the frozen evaluation identity, mode, scoring contract, and covered incumbent
+verdict and score card.
+`affected_surfaces` and packet `authority` name candidate scope; their
+intersection is mutation authority. `acceptance` freezes evaluation setup,
+search policy, candidate-accessible dimensions and feedback, writer, lane count per candidate,
+promotion done-check and rule, required margin, and regression criteria;
+`bound` and packet `bounds` cap the campaign.
+When no evaluation is supplied, the packet also carries the inputs, disjoint
+evaluation-design write scope, and reserved bound mapped by the
+[evaluation-open protocol](references/evolve-evaluation.md).
 
 Steps:
-- eligibility — `orch-verify` checks the incumbent's fixed evidence against required
-  eligibility and regression criteria. Only covered PASS permits generation
-  direction from its score card; expose no protected item-level evidence.
-- campaign — `orch-loop` over the generation body mapped by the
-  [generation protocol](references/evolve-generation.md), which calls
-  `orch-search-plan`, `orch-worklog`, `orch-delegate`, `orch-integrate`, and
-  `orch-panel` around the frozen writer and runner, reusing the eligibility Verify binding.
+- evaluation — use the supplied frozen evaluation. When no frozen evaluation is
+  supplied, `orch-eval-design` creates one candidate-blind Judge brief under the
+  evaluation-open protocol before generation; this is judged mode. A qualified
+  benchmark plus runner is benchmark mode.
+- eligibility — `orch-verify` checks fixed incumbent evidence against the
+  evaluation's required admission and regression criteria. Only covered PASS
+  permits generation direction; expose no protected item-level evidence.
+- campaign — `orch-loop` over the body mapped by the
+  [generation protocol](references/evolve-generation.md). It uses one frozen
+  `orch-panel` binding before the first plan and after each candidate set, then
+  calls `orch-search-plan`, `orch-worklog`, `orch-delegate`, and `orch-integrate`
+  around the frozen writer and evaluation, reusing the eligibility Verify binding.
 
-Edges:
-- seq eligibility → campaign.
-- loop campaign — generation body, frozen bound, and a fresh `orch-judge`
-  done-check over the final incumbent and its admitted result/evidence.
+Edges: seq evaluation → eligibility → campaign; loop campaign — generation body,
+frozen bound, and a fresh `orch-judge` done-check over the final incumbent and
+its admitted result/evidence.
 
 Invariants:
-- Freeze the benchmark revision, runner, scoring, protected evidence policy,
-  active controller and planner revisions, mutation authority, search policy,
-  promotion rule, required margin, and bound. A changed constant starts a new
-  campaign and projection in which every retained candidate is evaluated again.
-- Kill any candidate lacking PASS on every required deterministic criterion;
-  judged score cannot compensate. Verified survivors each carry a covered-PASS
-  result/evidence identity, and every Panel score card cites the admitted evidence.
+- Freeze the evaluation identity, evaluation mode, scoring, criteria, evidence
+  adapter, optional runner, protected evidence policy, controller and planner
+  revisions, mutation authority, search policy, promotion rule, margin, and
+  bound. A changed constant starts a new campaign and reevaluates every retained
+  candidate; benchmark mode also freezes its benchmark revision.
+- Benchmark mode runs the qualified runner. Judged mode scores each fixed
+  artifact snapshot through the same candidate-blind Judge brief and Panel.
+- Kill any candidate lacking PASS on every required admission criterion; judged
+  score cannot compensate. Every Panel score card cites admitted evidence.
 - The archive supplies exploration parents only; Evolve alone applies the
   promotion rule and margin. Promotion alone never completes.
-- A missing candidate-accessible numeric mapping returns a blocked partial
-  result with a Benchmaker gap for a separate Benchmaker run.
-- Never: change campaign constants; rank an ineligible candidate; re-execute or
-  substitute admitted evidence; expose protected evidence; call evaluation
-  design or Benchmaker; activate a selected candidate; add a closing wrapper.
+- A missing public numeric mapping returns a blocked partial result with an
+  evaluation-design gap.
+- Never: change evaluation after campaign open; rank an ineligible candidate;
+  re-execute or substitute admitted evidence; expose protected evidence; call
+  Benchmaker; activate a selected candidate; add a closing wrapper.
 
 Done check: Loop's final score card cites the final incumbent identity and its
 admitted result/evidence and satisfies the frozen promotion done-check.
 
 Return: status, result — the final incumbent identity, verification — the final
-score card and eligibility verdicts; then frozen benchmark revision, accepted
-projection and plan identities, generation count, promotion/kill log,
-disagreement, partial evidence, feedback and gaps, bounds spent, and cumulative
-changed artifacts including Worklog and accepted descendant changes.
+score card and admission verdicts; then frozen evaluation identity and mode,
+benchmark revision when used, accepted projection and plan identities,
+generation count, promotion/kill log, disagreement, partial evidence, feedback
+and gaps, bounds spent, and cumulative changed artifacts including Worklog and
+accepted descendant changes.

--- a/compositions/evolve.md
+++ b/compositions/evolve.md
@@ -16,7 +16,7 @@ count per candidate, promotion done-check and rule, required margin, and
 regression criteria; `bound` and packet `bounds` cap the campaign.
 
 Steps:
-- eligibility — `orch-verify` the incumbent's fixed evidence against required
+- eligibility — Verify the incumbent's fixed evidence against required
   eligibility and regression criteria. Only covered PASS permits generation
   direction from its score card; expose no protected item-level evidence.
 - campaign — `orch-loop` over the generation body mapped by the

--- a/compositions/evolve.md
+++ b/compositions/evolve.md
@@ -16,13 +16,13 @@ count per candidate, promotion done-check and rule, required margin, and
 regression criteria; `bound` and packet `bounds` cap the campaign.
 
 Steps:
-- eligibility — Verify the incumbent's fixed evidence against required
+- eligibility — `orch-verify` checks the incumbent's fixed evidence against required
   eligibility and regression criteria. Only covered PASS permits generation
   direction from its score card; expose no protected item-level evidence.
 - campaign — `orch-loop` over the generation body mapped by the
   [generation protocol](references/evolve-generation.md), which calls
-  `orch-search-plan`, `orch-worklog`, `orch-delegate`, `orch-integrate`,
-  `orch-verify`, and `orch-panel` around the frozen writer and runner.
+  `orch-search-plan`, `orch-worklog`, `orch-delegate`, `orch-integrate`, and
+  `orch-panel` around the frozen writer and runner, reusing the eligibility Verify binding.
 
 Edges:
 - seq eligibility → campaign.

--- a/compositions/evolve.md
+++ b/compositions/evolve.md
@@ -6,76 +6,50 @@ entry: named
 
 Require: one complete [delegation packet](../contracts/delegation.md)
 whose `inputs` carry one frozen evolve spec governed by the
-[spec contract](../contracts/spec.md). The spec's `evidence`
-identifies the incumbent identity, its fixed benchmark
-result/evidence, covered eligibility verdict and Judge-owned score
-card, plus one qualified benchmark revision and covered-PASS
-qualification verdict. `affected_surfaces` names candidate-mutable
-target surfaces; packet `authority` names write scope and exclusions.
-Mutation authority is their intersection. Spec `acceptance` fixes
-generation width, lane count per candidate, promotion done-check and
-rule, required margin, and regression criteria; spec `bound` and
-packet `bounds` cap the campaign.
+[spec contract](../contracts/spec.md). Its `evidence` identifies the
+incumbent identity, fixed result/evidence, covered eligibility verdict,
+Judge-owned incumbent score card, and qualified benchmark revision and
+scoring identity. `affected_surfaces` and packet `authority` name candidate
+scope; their intersection is mutation authority. `acceptance` freezes optimizer activation, search policy,
+candidate-accessible dimension and feedback mappings, runner, writer, lane
+count per candidate, promotion done-check and rule, required margin, and
+regression criteria; `bound` and packet `bounds` cap the campaign.
 
 Steps:
-- eligibility — `orch-verify`: the incumbent's fixed result/evidence
-  identity and frozen required eligibility and regression criteria,
-  with named oracles and `oracle_class`. Only covered PASS permits the
-  Judge-owned incumbent score card to supply generation direction;
-  expose no protected item-level evidence.
-- generation — the loop body, a caller-owned composite: independent
-  variants through `orch-delegate` within mutation authority; every
-  child return crosses `orch-integrate` with caller write scope; the
-  frozen runner produces one fixed result/evidence identity per
-  integrated candidate, submitted with the same frozen criteria to
-  `orch-verify`; verified survivors, including the incumbent, go as a
-  fixed set — each candidate bound to its covered-PASS result/evidence
-  identity and the frozen benchmark revision and scoring identity —
-  with frozen criteria, predeclared aggregation, and lane count to
-  `orch-panel`.
-  Promote only a survivor whose score card cites the admitted evidence
-  and satisfies the frozen rule and margin; promotion alone never
-  completes.
-- closing — a fresh `orch-judge` over the final incumbent, its
-  admitted result/evidence identity, and frozen scoring criteria.
+- eligibility — `orch-verify` the incumbent's fixed evidence against required
+  eligibility and regression criteria. Only covered PASS permits generation
+  direction from its score card; expose no protected item-level evidence.
+- campaign — `orch-loop` over the generation body mapped by the
+  [generation protocol](references/evolve-generation.md), which calls
+  `orch-search-plan`, `orch-worklog`, `orch-delegate`, `orch-integrate`,
+  `orch-verify`, and `orch-panel` around the frozen writer and runner.
 
 Edges:
-- seq eligibility → campaign → closing.
-- loop campaign — body `generation`, the promotion done-check, the
-  frozen bound, dispatched through `orch-loop` with the frozen goal
-  and a context packet carrying campaign constants, incumbent identity
-  and score card, promotion/kill log, disagreement, and failed
-  approaches.
+- seq eligibility → campaign.
+- loop campaign — generation body, frozen bound, and a fresh `orch-judge`
+  done-check over the final incumbent and its admitted result/evidence.
 
 Invariants:
-- Freeze the benchmark revision, runner, scoring, protected evidence
-  policy, mutation authority, promotion rule, required margin, and
-  bound. A campaign comparing candidates across a moving benchmark
-  measures nothing.
-- A changed benchmark starts a new campaign in which every retained
-  candidate is evaluated again.
-- Kill any candidate lacking PASS on every required deterministic
-  criterion; deterministic failure blocks eligibility and judged score
-  cannot compensate.
-- Judge lanes are blind per `orch-panel`; they cite the admitted
-  evidence without re-execution or substitution.
-- A judged done-check PASS is provisional; only a closing score card
-  citing the final incumbent's admitted evidence can satisfy the
-  done-check.
-- An ambiguous or non-discriminating benchmark returns a blocked
-  partial result, evidence, and feedback for a separate BenchMaker
-  run. Terminal states and partial-result law follow
-  [rules/loops.md](../rules/loops.md).
-- Never: change campaign constants; rank an ineligible candidate;
-  re-execute or substitute admitted evidence for judging; expose
-  protected evidence; call evaluation design or BenchMaker; treat a
-  changed benchmark as continuity.
+- Freeze the benchmark revision, runner, scoring, protected evidence policy,
+  active controller and planner revisions, mutation authority, search policy,
+  promotion rule, required margin, and bound. A changed constant starts a new
+  campaign and projection in which every retained candidate is evaluated again.
+- Kill any candidate lacking PASS on every required deterministic criterion;
+  judged score cannot compensate. Verified survivors each carry a covered-PASS
+  result/evidence identity, and every Panel score card cites the admitted evidence.
+- The archive supplies exploration parents only; Evolve alone applies the
+  promotion rule and margin. Promotion alone never completes.
+- A missing candidate-accessible numeric mapping returns a blocked partial
+  result with a Benchmaker gap for a separate Benchmaker run.
+- Never: change campaign constants; rank an ineligible candidate; re-execute or
+  substitute admitted evidence; expose protected evidence; call evaluation
+  design or Benchmaker; activate a selected candidate; add a closing wrapper.
 
-Done check: the closing `orch-judge` score card, citing the final
-incumbent's admitted result/evidence identity, satisfies the frozen
-promotion done-check.
+Done check: Loop's final score card cites the final incumbent identity and its
+admitted result/evidence and satisfies the frozen promotion done-check.
 
-Return: status, result — the final incumbent identity, verification —
-the closing score card and eligibility verdicts; then the frozen
-benchmark revision, generation count, promotion/kill log, disagreement,
-partial evidence, feedback and gaps, and bounds spent.
+Return: status, result — the final incumbent identity, verification — the final
+score card and eligibility verdicts; then frozen benchmark revision, accepted
+projection and plan identities, generation count, promotion/kill log,
+disagreement, partial evidence, feedback and gaps, bounds spent, and cumulative
+changed artifacts including Worklog and accepted descendant changes.

--- a/compositions/references/evolve-evaluation.md
+++ b/compositions/references/evolve-evaluation.md
@@ -1,0 +1,20 @@
+# Evolve evaluation-open mapping
+
+Consult this mapping once at campaign open only when no frozen evaluation is
+supplied. Evolve maps the parent packet into one complete Eval-design packet:
+
+- `objective` carries the target identity and intended observable outcome.
+- `inputs` carry the fixed incumbent evidence, source identities, source policy,
+  judgment permission, and applicable pack craft, lens, and oracle references.
+- `authority` grants one evaluation-design write scope disjoint from candidate
+  mutation authority and excludes target mutation.
+- `bounds` carries the evaluation-design allocation reserved before the campaign.
+- `return_contract` requests the evaluation-design identity, assumptions, gaps,
+  and changed artifacts.
+- `reply_to` is the active Evolve controller.
+
+Missing carriage or a material design gap returns a blocked partial result before
+generation. No candidate, variant, or score enters this packet. In judged mode,
+the accepted evaluation-design identity is both evaluation and scoring identity;
+it covers the frozen Judge brief, criteria, aggregation, and artifact-evidence
+adapter. Evolve adds it to the Worklog before the eligibility or campaign step.

--- a/compositions/references/evolve-generation.md
+++ b/compositions/references/evolve-generation.md
@@ -5,17 +5,17 @@ promotion judgment.
 
 1. Derive the closed search-policy, prior projection, settled wrapper, and
    remaining bound from the frozen spec and latest Worklog entry. If a complete
-   candidate-accessible dimension mapping is absent, do not call
-   `orch-search-plan`; return the blocked Benchmaker gap.
+   candidate-accessible dimension mapping is absent, do not call the search
+   planner; return the blocked Benchmaker gap.
 2. Accept only the planner's canonical response. Append it to the current
-   iteration through `orch-worklog`; only its plan and projection identities
+   iteration through the Worklog owner; only its plan and projection identities
    ride the next Loop context.
 3. For each ordered slot, map focus and public feedback or complementary parents
    to the frozen writer. Record slot, handoff, reservation, and `in_flight` in
-   the same Worklog entry before `orch-delegate`; pass every return through
-   `orch-integrate`, run the frozen benchmark runner, and submit its fixed
-   result/evidence identity to `orch-verify`.
-4. Send the incumbent and eligible candidates as one fixed set to `orch-panel`,
+   the same Worklog entry before delegation; pass every return through the join
+   owner, run the frozen benchmark runner, and submit its fixed result/evidence
+   identity to the eligibility verifier.
+4. Send the incumbent and eligible candidates as one fixed set to Panel,
    then apply Evolve's frozen promotion rule and margin. Map planner `no_fit` to
    Loop `limited`; a `pending` response launches nothing.
 

--- a/compositions/references/evolve-generation.md
+++ b/compositions/references/evolve-generation.md
@@ -1,0 +1,33 @@
+# Evolve generation mapping
+
+One trusted Evolve controller maps each Loop iteration without transferring its
+promotion judgment.
+
+1. Derive the closed search-policy, prior projection, settled wrapper, and
+   remaining bound from the frozen spec and latest Worklog entry. If a complete
+   candidate-accessible dimension mapping is absent, do not call
+   `orch-search-plan`; return the blocked Benchmaker gap.
+2. Accept only the planner's canonical response. Append it to the current
+   iteration through `orch-worklog`; only its plan and projection identities
+   ride the next Loop context.
+3. For each ordered slot, map focus and public feedback or complementary parents
+   to the frozen writer. Record slot, handoff, reservation, and `in_flight` in
+   the same Worklog entry before `orch-delegate`; pass every return through
+   `orch-integrate`, run the frozen benchmark runner, and submit its fixed
+   result/evidence identity to `orch-verify`.
+4. Send the incumbent and eligible candidates as one fixed set to `orch-panel`,
+   then apply Evolve's frozen promotion rule and margin. Map planner `no_fit` to
+   Loop `limited`; a `pending` response launches nothing.
+
+The projection carries the complete admitted and nonplanning candidate records,
+archive identities, and zero/one/two-parent DAG. It never carries transcript
+prose or protected evidence. Worklog remains authoritative for spend and launch
+state.
+
+On restart, reuse an accepted response. Reconcile or block an ambiguous
+`in_flight` handoff; never redispatch a live slot. Candidate workspaces cannot
+change the frozen active controller or planner revision, and a selected result
+is never activated by this campaign.
+
+The generation return adds accepted descendant changes and the Worklog path to
+cumulative changed artifacts.

--- a/compositions/references/evolve-generation.md
+++ b/compositions/references/evolve-generation.md
@@ -3,10 +3,12 @@
 One trusted Evolve controller maps each Loop iteration without transferring its
 promotion judgment.
 
-1. Derive the closed search-policy, prior projection, settled wrapper, and
-   remaining bound from the frozen spec and latest Worklog entry. If a complete
-   candidate-accessible dimension mapping is absent, do not call the search
-   planner; return the blocked Benchmaker gap.
+1. Derive the closed search policy, prior projection, settled wrapper, and
+   remaining bound from the frozen spec and latest Worklog entry. Before the
+   first plan, use the frozen Panel binding before the first plan to score the
+   fixed incumbent. Its score card identity and complete numeric dimension vector
+   form the admitted origin. If the mapping is incomplete, do not call the
+   planner; return the blocked evaluation-design gap.
 2. Accept only the planner's canonical response. Append it to the current
    iteration through the Worklog owner; only its plan and projection identities
    ride the next Loop context. The latest Worklog entry persists the accepted
@@ -14,16 +16,16 @@ promotion judgment.
 3. For each ordered slot, map focus and public feedback or complementary parents
    to the frozen writer. Record slot, handoff, reservation, and `in_flight` in
    the same Worklog entry before delegation; pass every return through the join
-   owner, run the frozen benchmark runner, and submit its fixed result/evidence
-   identity to the eligibility verifier.
-4. Send the incumbent and eligible candidates as one fixed set to Panel,
-   then apply Evolve's frozen promotion rule and margin. Map planner `no_fit` to
-   Loop `limited`; a `pending` response launches nothing.
+   owner. In benchmark mode run
+   the frozen runner; in judged mode freeze the returned artifact snapshot as the
+   result/evidence. Submit that fixed evidence to the eligibility verifier.
+4. Send the incumbent and eligible candidates as one fixed set to Panel under
+   the frozen evaluation, then apply Evolve's promotion rule and margin. Map
+   planner `no_fit` to Loop `limited`; a `pending` response launches nothing.
 
-The projection carries the complete admitted and nonplanning candidate records,
-archive identities, and zero/one/two-parent DAG. It never carries transcript
-prose or protected evidence. Worklog remains authoritative for spend and launch
-state.
+The projection carries complete candidate records, archive identities, and the
+zero/one/two-parent DAG. It never carries transcript prose, evaluation mode, or
+protected evidence. Worklog remains authoritative for spend and launch state.
 
 On restart, reuse an accepted response. Reconcile or block an ambiguous
 `in_flight` handoff; never redispatch a live slot. Active controller and planner

--- a/compositions/references/evolve-generation.md
+++ b/compositions/references/evolve-generation.md
@@ -9,7 +9,8 @@ promotion judgment.
    planner; return the blocked Benchmaker gap.
 2. Accept only the planner's canonical response. Append it to the current
    iteration through the Worklog owner; only its plan and projection identities
-   ride the next Loop context.
+   ride the next Loop context. The latest Worklog entry persists the accepted
+   response's complete projection, including every archive member.
 3. For each ordered slot, map focus and public feedback or complementary parents
    to the frozen writer. Record slot, handoff, reservation, and `in_flight` in
    the same Worklog entry before delegation; pass every return through the join

--- a/compositions/references/evolve-generation.md
+++ b/compositions/references/evolve-generation.md
@@ -26,9 +26,10 @@ prose or protected evidence. Worklog remains authoritative for spend and launch
 state.
 
 On restart, reuse an accepted response. Reconcile or block an ambiguous
-`in_flight` handoff; never redispatch a live slot. Candidate workspaces cannot
-change the frozen active controller or planner revision, and a selected result
-is never activated by this campaign.
+`in_flight` handoff; never redispatch a live slot. Active controller and planner
+revisions remain outside candidate mutation authority. A self-target candidate
+remains non-control and cannot become the active campaign controller or planner.
+A selected result is never activated by this campaign.
 
 The generation return adds accepted descendant changes and the Worklog path to
 cumulative changed artifacts.

--- a/compositions/skill-tournament.md
+++ b/compositions/skill-tournament.md
@@ -4,33 +4,26 @@ description: Apply the evolve campaign to one fixed skill identity against a ben
 entry: named
 ---
 
-Require: one fixed skill identity, the variant surface declaration,
-and the campaign bounds.
+Require: one fixed skill identity, declared mutable surface, frozen optimizer
+policy and candidate-accessible mappings, and campaign bounds.
 
 Steps:
-- benchmark — the `benchmaker` composition over the fixed skill
-  identity: evidence, evaluation design, materialization,
-  qualification — one benchmark revision the campaign never changes.
-- campaign — the `evolve` composition; frozen bindings: variant writer
-  `orch-build`, variants differing only in the declared surface; each
-  variant runs in isolation against the benchmark, its fixed evidence
-  to `orch-verify`, every required failure excluded before
-  `orch-panel`; blind judges cite the admitted evidence, one score
-  card per eligible candidate; the frozen promotion rule returns one
-  evolution result.
+- benchmark — the `benchmaker` composition builds and qualifies one benchmark
+  revision the campaign never changes for the fixed skill identity.
+- campaign — the `evolve` composition receives that revision, the frozen policy
+  and bounds, variant writer binding orch-build, and variants limited to the
+  declared surface.
 
-Edges: seq benchmark → campaign — the qualified benchmark revision is
-the campaign's qualified-benchmark evidence.
+Edges: seq benchmark → campaign — the qualified benchmark revision is the
+campaign's qualified-benchmark evidence.
 
-Invariants — Never: change the benchmark inside the campaign; install
-the winner — an evolution result does not activate; activation is a
-separate authorized run; let a benchmaker run whose target is
-BenchMaker itself call evolve — a separate evolve campaign consumes
-the qualified benchmark, and a later benchmark revision is
-independently qualified before a later campaign.
+Invariants — Never: change the benchmark or policy inside the campaign; restate
+or call Evolve's verification, panel, search, or selection internals; install a
+winner; let a Benchmaker run targeting Benchmaker call Evolve. A selected
+evolution result requires a separate authorized integration before activation.
 
-Done check: the campaign's closing score card, over the one benchmark
-revision every candidate was scored against.
+Done check: the campaign's final score card covers the one benchmark revision
+every candidate was scored against.
 
-Return: status, result — the evolution result, verification — the
-closing score card; then the benchmark revision and the variant set.
+Return: status, result — the evolution result, verification — the final score
+card; then the benchmark revision, variant set, and cumulative changed artifacts.

--- a/docs/vocabulary.md
+++ b/docs/vocabulary.md
@@ -144,8 +144,14 @@ The benchmark pipeline has exactly four artifact roles:
   frozen scoring criteria: per-criterion scores with verdicts, oracle classes,
   and evidence, plus overall score and confidence.
 - **evolution result** — the `evolve` composition's campaign artifact: final incumbent
-  identity and closing score card, frozen benchmark revision, campaign
-  history, partial evidence, feedback, gaps, and bounds spent.
+  identity and closing score card, frozen evaluation identity and mode,
+  optional benchmark revision, campaign history, partial evidence, feedback,
+  gaps, and bounds spent.
+- **evaluation mode** — benchmark executes one frozen qualified runner; judged
+  scores one fixed artifact snapshot through a frozen candidate-blind Judge
+  brief. Both bind one evaluation and scoring identity before candidates. The
+  evaluation identity covers mode, scoring contract, Judge brief or runner,
+  evidence adapter, and optional benchmark revision.
 - **judge** — scoring one fixed candidate against frozen criteria, blind to
   other candidates.
 - **judgment shapes** — critique returns findings, judge returns score

--- a/skills/engines/orch-panel/SKILL.md
+++ b/skills/engines/orch-panel/SKILL.md
@@ -4,31 +4,34 @@ description: Adjudicate a fixed candidate set through blind independent judge la
 role: none
 ---
 
-Require: a fixed candidate set whose every entry binds one candidate
-identity to its covered-PASS benchmark result/evidence identity; the frozen
-benchmark and scoring identities; frozen scoring criteria, each naming its
-oracle and `oracle_class`; a declared aggregation method — rank, vote, or
-score — chosen before any lane runs; and the lane count per candidate.
+Require: a fixed candidate set whose every entry binds one candidate identity to
+its covered-PASS evaluation result/evidence identity; frozen evaluation and
+scoring identities; frozen evaluation mode; one frozen candidate-blind Judge
+brief; frozen scoring criteria, each naming its oracle and `oracle_class`; a
+declared aggregation method — rank, vote, or score — chosen before any lane
+runs; and the lane count per candidate.
 
-For each candidate, form the declared number of complete delegation
-packets. Each packet's objective asks `orch-judge` to score exactly one fixed
-candidate identity from its admitted evidence; inputs contain only that candidate
-identity, its exact result/evidence identity, the frozen benchmark and scoring
-identities, and frozen scoring criteria bound to that evidence; authority grants no target
-write; bounds cap the lane; return_contract requests one score card citing
-the exact evidence identity; reply_to names the dispatcher.
+Carry the frozen candidate-blind Judge brief verbatim into every packet. For each candidate,
+form the declared number of complete delegation packets. Each packet's objective
+asks `orch-judge` to score exactly one fixed candidate identity from its admitted
+evidence; inputs contain only that identity, its exact result/evidence identity,
+the frozen evaluation mode, frozen evaluation and scoring identities, brief, and
+frozen scoring criteria. Benchmark mode evidence names executed runner/oracle output; judged
+mode evidence names the static artifact snapshot. Authority grants no target
+write; bounds cap the lane; return_contract requests one score card citing the
+exact evidence identity; reply_to names the dispatcher.
 
-Dispatch the packets in parallel through `orch-delegate`. Keep every lane
-blind to all other candidates, provenance, lanes, and scores; every child
-return crosses `orch-integrate` with the caller's write scope.
+Dispatch packets in parallel through `orch-delegate`. Keep every lane blind to
+all other candidates, provenance, lanes, and scores; every child return crosses
+`orch-integrate` with the caller's write scope.
 
-Aggregate exactly by the declared method from the per-lane score cards.
-Report every dissent and its evidence in the disagreement register; high
-disagreement remains information about the criteria.
+Aggregate exactly by the declared method from the per-lane score cards. Report
+every dissent and its evidence in the disagreement register; high disagreement
+remains information about the criteria.
 
-Never: let a judge packet carry multiple candidates; re-execute or substitute
-admitted evidence; let lanes see each other; change the aggregation method
-after seeing scores; drop a dissenting lane.
+Never: let one packet carry multiple candidates; replace or alter the frozen
+brief; re-execute or substitute admitted evidence; let lanes see each other;
+change the aggregation method after seeing scores; drop a dissenting lane.
 
 Return: the aggregate order or verdict, per-lane score cards citing their
 admitted result/evidence identities, and the disagreement register.

--- a/skills/utilities/orch-search-plan/SKILL.md
+++ b/skills/utilities/orch-search-plan/SKILL.md
@@ -1,0 +1,22 @@
+---
+name: orch-search-plan
+description: Produce one canonical bounded candidate-search plan from frozen policy and settled public outcomes.
+role: none
+---
+
+Require: one UTF-8 JSON request on stdin carrying frozen policy, prior
+projection, settled public outcomes, and remaining bound per the
+[protocol](references/protocol.md).
+
+Run the sole operation:
+
+    python skills/utilities/orch-search-plan/scripts/search_plan.py advance
+
+Write one canonical JSON response plus LF to stdout. Invalid input exits 2 with
+empty stdout and one bounded diagnostic on stderr.
+
+Never: read repository state; write a file; launch a process; use a model,
+network, service, plugin, or non-standard-library dependency; infer protected
+evidence or campaign judgment.
+
+Return: the `search-advance/v1` response on stdout.

--- a/skills/utilities/orch-search-plan/references/protocol.md
+++ b/skills/utilities/orch-search-plan/references/protocol.md
@@ -6,6 +6,8 @@ The sole command reads one closed UTF-8 JSON request
 orders below; integers are JSON integers; dimension values and resolutions are
 finite canonical decimal strings. Duplicate keys, unknown fields, floats,
 noncanonical decimals, and invalid identities or references are invalid.
+The request is at most 1,000,000 UTF-8 bytes; every identity string is at most
+256 Unicode code points; every decimal string is at most 128 characters.
 
 ## Policy
 

--- a/skills/utilities/orch-search-plan/references/protocol.md
+++ b/skills/utilities/orch-search-plan/references/protocol.md
@@ -14,8 +14,10 @@ The request is at most 1,000,000 UTF-8 bytes; every identity string is at most
 `search-policy/v1` is closed:
 
 - `identity` is its tagged identity; `planner_revision`,
-  `target_owner_identity`, `benchmark_revision`, and `scoring_identity` are
-  opaque identities.
+  `target_owner_identity`, `evaluation_identity`, and `scoring_identity` are
+  opaque identities. The evaluation owner binds its mode, scoring contract,
+  Judge brief or runner, evidence adapter, and optional benchmark revision;
+  the planner validates identity continuity and never interprets that bundle.
 - `mutation_surface_identities`, `feedback_source_identities`, and
   `bound_unit_names` are duplicate-free ordered identity lists;
   `ordering_seed` is opaque.
@@ -33,7 +35,7 @@ The policy identity is `sha256:` plus SHA-256 over
 
 `projection` is null for the first call, otherwise one closed
 `search-projection/v1` carrying `identity`, `policy_identity`,
-`benchmark_revision`, `last_settled_generation`, `last_plan`,
+`evaluation_identity`, `last_settled_generation`, `last_plan`,
 `preferred_incumbent_identity`, `nodes`, `archive`, `seen_slot_identities`, and
 `incorporated_outcome_identities`. Nodes retain each candidate's full admitted
 or nonplanning outcome; archive entries are candidate identities into nodes.
@@ -41,14 +43,14 @@ or nonplanning outcome; archive entries are candidate identities into nodes.
 `settled` is the closed wrapper `{preferred_incumbent_identity,outcomes}`.
 Every outcome has `kind`, `outcome_identity`, `slot_identity`, and closed `cost`.
 An admitted outcome adds `candidate_identity`, ordered `parent_identities`,
-owner and surfaces, `benchmark_revision`, fixed result and evidence identities,
+owner and surfaces, `evaluation_identity`, fixed result and evidence identities,
 `eligibility_status:"PASS"`, eligibility-verdict and score-card identities,
 an ordered complete `dimension_vector` of `{identity,value}`, and ordered public
 `feedback` entries `{source_identity,dimension_identity,reference_identity}`.
 The origin is admitted with null slot and no parents.
 
 A produced ineligible outcome adds candidate and parent identities, owner and
-surfaces, benchmark, fixed result and evidence, covered non-PASS eligibility
+surfaces, evaluation, fixed result and evidence, covered non-PASS eligibility
 status and verdict, and fixed `disposition`; it has no planning vector, score
 card, or feedback. A no-candidate outcome adds only fixed `disposition` to the
 common fields. Missing, duplicate, stale, dangling, or lineage-mismatched
@@ -69,7 +71,7 @@ still reflects first.
 
 Reflection slots precede merge slots. Their closed records carry `identity`,
 generation, ordinal, kind, ordered parents, focus or complementary dimension
-identities, ordered allowed feedback, owner, surfaces, benchmark revision, and
+identities, ordered allowed feedback, owner, surfaces, evaluation identity, and
 closed reservation. Merge feedback is the ordered union of each parent's
 allowed feedback on dimensions where that parent is resolution-better: parent
 order, policy dimension order, feedback-source order, then reference identity.
@@ -86,7 +88,7 @@ not ambient fixed precision.
 ## Result
 
 `search-plan/v1` is closed over `identity`, `policy_identity`,
-`benchmark_revision`, `input_projection_identity`, ordered
+`evaluation_identity`, `input_projection_identity`, ordered
 `basis_outcome_identities`, `generation`, and ordered `slots`.
 `search-advance/v1` is closed over `schema`, `status` (`planned|pending|no_fit`),
 input and output projection identities, `projection`, `plan`, ordered

--- a/skills/utilities/orch-search-plan/references/protocol.md
+++ b/skills/utilities/orch-search-plan/references/protocol.md
@@ -1,0 +1,91 @@
+# Search-plan protocol
+
+The sole command reads one closed UTF-8 JSON request
+`{policy, projection, settled, remaining_bound}` and emits one canonical
+`search-advance/v1` object plus LF. JSON keys sort lexically; arrays retain the
+orders below; integers are JSON integers; dimension values and resolutions are
+finite canonical decimal strings. Duplicate keys, unknown fields, floats,
+noncanonical decimals, and invalid identities or references are invalid.
+
+## Policy
+
+`search-policy/v1` is closed:
+
+- `identity` is its tagged identity; `planner_revision`,
+  `target_owner_identity`, `benchmark_revision`, and `scoring_identity` are
+  opaque identities.
+- `mutation_surface_identities`, `feedback_source_identities`, and
+  `bound_unit_names` are duplicate-free ordered identity lists;
+  `ordering_seed` is opaque.
+- `dimensions` is ordered. Each closed entry has `identity`, direction
+  `maximize|minimize`, candidate-accessible `source_identity`, and positive
+  canonical `resolution`.
+- positive integer `generation_width`, integer `merge_slots` in its closed
+  range, and `reservations:{reflect,merge}`; each reservation is a closed map
+  from every bound-unit name to a nonnegative integer.
+
+The policy identity is `sha256:` plus SHA-256 over
+`b"search-policy/v1\0" + canonical(payload-without-identity)`.
+
+## Projection and settled outcomes
+
+`projection` is null for the first call, otherwise one closed
+`search-projection/v1` carrying `identity`, `policy_identity`,
+`benchmark_revision`, `last_settled_generation`, `last_plan`,
+`preferred_incumbent_identity`, `nodes`, `archive`, `seen_slot_identities`, and
+`incorporated_outcome_identities`. Nodes retain each candidate's full admitted
+or nonplanning outcome; archive entries are candidate identities into nodes.
+
+`settled` is the closed wrapper `{preferred_incumbent_identity,outcomes}`.
+Every outcome has `kind`, `outcome_identity`, `slot_identity`, and closed `cost`.
+An admitted outcome adds `candidate_identity`, ordered `parent_identities`,
+owner and surfaces, `benchmark_revision`, fixed result and evidence identities,
+`eligibility_status:"PASS"`, eligibility-verdict and score-card identities,
+an ordered complete `dimension_vector` of `{identity,value}`, and ordered public
+`feedback` entries `{source_identity,dimension_identity,reference_identity}`.
+The origin is admitted with null slot and no parents.
+
+A produced ineligible outcome adds candidate and parent identities, owner and
+surfaces, benchmark, fixed result and evidence, covered non-PASS eligibility
+status and verdict, and fixed `disposition`; it has no planning vector, score
+card, or feedback. A no-candidate outcome adds only fixed `disposition` to the
+common fields. Missing, duplicate, stale, dangling, or lineage-mismatched
+outcomes are invalid. Later calls carry zero or one terminal outcome for every
+slot in the prior plan and no other outcome; a partial set is atomically
+`pending`.
+
+`remaining_bound` is closed over the policy's ordered bound units with
+nonnegative integer values.
+
+## Planning and identities
+
+Resolution-aware Pareto comparison uses every admitted node. For one oriented
+dimension delta, `delta >= resolution` is better, `delta <= -resolution` is
+worse, and the remainder ties. The archive retains all and only non-dominated
+candidate identities. The preferred incumbent may sit outside the archive and
+still reflects first.
+
+Reflection slots precede merge slots. Their closed records carry `identity`,
+generation, ordinal, kind, ordered parents, focus or complementary dimension
+identities, ordered allowed feedback, owner, surfaces, benchmark revision, and
+closed reservation. Merge feedback is the ordered union of each parent's
+allowed feedback on dimensions where that parent is resolution-better: parent
+order, policy dimension order, feedback-source order, then reference identity.
+The greedy componentwise prefix of the full ordered slots is returned; no first
+fit yields `no_fit` with the updated projection and null `last_plan`.
+
+Tagged identities hash `tag + NUL + canonical(payload-without-identity)`. Slot
+payloads depend on no plan or output projection. A plan hashes prior projection,
+normalized outcomes, and slots, then the output projection embeds that plan;
+this ordering is acyclic. Changing focus or public feedback therefore changes
+the slot's mutation-packet identity. Decimal comparison uses exact coefficients,
+not ambient fixed precision.
+
+## Result
+
+`search-plan/v1` is closed over `identity`, `policy_identity`,
+`benchmark_revision`, `input_projection_identity`, ordered
+`basis_outcome_identities`, `generation`, and ordered `slots`.
+`search-advance/v1` is closed over `schema`, `status` (`planned|pending|no_fit`),
+input and output projection identities, `projection`, `plan`, ordered
+`missing_slot_identities`, and bounded machine-readable `diagnostics`.

--- a/skills/utilities/orch-search-plan/scripts/search_plan.py
+++ b/skills/utilities/orch-search-plan/scripts/search_plan.py
@@ -122,7 +122,7 @@ POLICY_KEYS = {
     "planner_revision",
     "target_owner_identity",
     "mutation_surface_identities",
-    "benchmark_revision",
+    "evaluation_identity",
     "scoring_identity",
     "dimensions",
     "feedback_source_identities",
@@ -143,7 +143,7 @@ ADMITTED_KEYS = {
     "parent_identities",
     "target_owner_identity",
     "mutation_surface_identities",
-    "benchmark_revision",
+    "evaluation_identity",
     "result_identity",
     "evidence_identity",
     "eligibility_status",
@@ -161,7 +161,7 @@ INELIGIBLE_KEYS = {
     "parent_identities",
     "target_owner_identity",
     "mutation_surface_identities",
-    "benchmark_revision",
+    "evaluation_identity",
     "result_identity",
     "evidence_identity",
     "eligibility_status",
@@ -179,7 +179,7 @@ PROJECTION_KEYS = {
     "schema",
     "identity",
     "policy_identity",
-    "benchmark_revision",
+    "evaluation_identity",
     "last_settled_generation",
     "last_plan",
     "preferred_incumbent_identity",
@@ -192,7 +192,7 @@ PLAN_KEYS = {
     "schema",
     "identity",
     "policy_identity",
-    "benchmark_revision",
+    "evaluation_identity",
     "input_projection_identity",
     "basis_outcome_identities",
     "generation",
@@ -209,7 +209,7 @@ SLOT_KEYS = {
     "feedback",
     "target_owner_identity",
     "mutation_surface_identities",
-    "benchmark_revision",
+    "evaluation_identity",
     "reservation",
 }
 
@@ -226,7 +226,7 @@ def _validate_policy(policy):
     for key in (
         "planner_revision",
         "target_owner_identity",
-        "benchmark_revision",
+        "evaluation_identity",
         "scoring_identity",
         "ordering_seed",
     ):
@@ -317,8 +317,8 @@ def _validate_admitted(
         raise ProtocolError("origin owner drift")
     if outcome["mutation_surface_identities"] != surfaces:
         raise ProtocolError("origin mutation-surface drift")
-    if outcome["benchmark_revision"] != policy["benchmark_revision"]:
-        raise ProtocolError("origin benchmark drift")
+    if outcome["evaluation_identity"] != policy["evaluation_identity"]:
+        raise ProtocolError("origin evaluation drift")
     if outcome["eligibility_status"] != "PASS":
         raise ProtocolError("origin must be covered PASS")
     _closed(outcome["cost"], units, "outcome cost")
@@ -370,8 +370,8 @@ def _validate_ineligible(outcome, policy, surfaces, units):
         raise ProtocolError("outcome owner drift")
     if outcome["mutation_surface_identities"] != surfaces:
         raise ProtocolError("outcome mutation-surface drift")
-    if outcome["benchmark_revision"] != policy["benchmark_revision"]:
-        raise ProtocolError("outcome benchmark drift")
+    if outcome["evaluation_identity"] != policy["evaluation_identity"]:
+        raise ProtocolError("outcome evaluation drift")
     if outcome["eligibility_status"] not in ("FAIL", "UNVERIFIED"):
         raise ProtocolError("ineligible outcome must be covered non-PASS")
     _closed(outcome["cost"], units, "outcome cost")
@@ -507,8 +507,8 @@ def _validate_slot(slot, policy, surfaces, feedback_sources, dimension_ids, unit
         raise ProtocolError("slot owner drift")
     if slot["mutation_surface_identities"] != surfaces:
         raise ProtocolError("slot mutation-surface drift")
-    if slot["benchmark_revision"] != policy["benchmark_revision"]:
-        raise ProtocolError("slot benchmark drift")
+    if slot["evaluation_identity"] != policy["evaluation_identity"]:
+        raise ProtocolError("slot evaluation drift")
     _closed(slot["reservation"], units, "slot reservation")
     for unit in units:
         _integer(slot["reservation"][unit], "slot reservation")
@@ -525,8 +525,8 @@ def _validate_plan(plan, policy, surfaces, feedback_sources, dimension_ids, unit
         raise ProtocolError("plan schema is invalid")
     if plan["policy_identity"] != policy["identity"]:
         raise ProtocolError("plan policy drift")
-    if plan["benchmark_revision"] != policy["benchmark_revision"]:
-        raise ProtocolError("plan benchmark drift")
+    if plan["evaluation_identity"] != policy["evaluation_identity"]:
+        raise ProtocolError("plan evaluation drift")
     if plan["input_projection_identity"] is not None:
         _string(plan["input_projection_identity"], "plan input projection")
     _unique_strings(plan["basis_outcome_identities"], "plan outcomes")
@@ -552,8 +552,8 @@ def _validate_projection(
         raise ProtocolError("projection schema is invalid")
     if projection["policy_identity"] != policy["identity"]:
         raise ProtocolError("projection policy drift")
-    if projection["benchmark_revision"] != policy["benchmark_revision"]:
-        raise ProtocolError("projection benchmark drift")
+    if projection["evaluation_identity"] != policy["evaluation_identity"]:
+        raise ProtocolError("projection evaluation drift")
     settled_generation = _integer(
         projection["last_settled_generation"], "settled generation"
     )
@@ -693,7 +693,7 @@ def _reflection_slots(
             "mutation_surface_identities": copy.deepcopy(
                 policy["mutation_surface_identities"]
             ),
-            "benchmark_revision": policy["benchmark_revision"],
+            "evaluation_identity": policy["evaluation_identity"],
             "reservation": copy.deepcopy(policy["reservations"]["reflect"]),
         }
         yield _identified("search-slot/v1", payload)
@@ -808,7 +808,7 @@ def _proposed_slots(policy, nodes, archive, preferred, generation):
             "mutation_surface_identities": copy.deepcopy(
                 policy["mutation_surface_identities"]
             ),
-            "benchmark_revision": policy["benchmark_revision"],
+            "evaluation_identity": policy["evaluation_identity"],
             "reservation": copy.deepcopy(policy["reservations"]["merge"]),
         }
         yield _identified("search-slot/v1", payload)
@@ -943,7 +943,7 @@ def _advance_later(request, policy, surfaces, feedback_sources, dimension_ids, u
             {
                 "schema": "search-plan/v1",
                 "policy_identity": policy["identity"],
-                "benchmark_revision": policy["benchmark_revision"],
+                "evaluation_identity": policy["evaluation_identity"],
                 "input_projection_identity": projection["identity"],
                 "basis_outcome_identities": [
                     outcome["outcome_identity"] for outcome in normalized_outcomes
@@ -957,7 +957,7 @@ def _advance_later(request, policy, surfaces, feedback_sources, dimension_ids, u
         {
             "schema": "search-projection/v1",
             "policy_identity": policy["identity"],
-            "benchmark_revision": policy["benchmark_revision"],
+            "evaluation_identity": policy["evaluation_identity"],
             "last_settled_generation": prior_plan["generation"],
             "last_plan": next_plan,
             "preferred_incumbent_identity": preferred,
@@ -1044,7 +1044,7 @@ def _advance_generation_zero(request):
             "feedback": feedback,
             "target_owner_identity": policy["target_owner_identity"],
             "mutation_surface_identities": copy.deepcopy(surfaces),
-            "benchmark_revision": policy["benchmark_revision"],
+            "evaluation_identity": policy["evaluation_identity"],
             "reservation": copy.deepcopy(reservation),
         }
         slots.append(_identified("search-slot/v1", slot_payload))
@@ -1058,7 +1058,7 @@ def _advance_generation_zero(request):
             {
                 "schema": "search-plan/v1",
                 "policy_identity": policy["identity"],
-                "benchmark_revision": policy["benchmark_revision"],
+                "evaluation_identity": policy["evaluation_identity"],
                 "input_projection_identity": None,
                 "basis_outcome_identities": [origin["outcome_identity"]],
                 "generation": 1,
@@ -1070,7 +1070,7 @@ def _advance_generation_zero(request):
         {
             "schema": "search-projection/v1",
             "policy_identity": policy["identity"],
-            "benchmark_revision": policy["benchmark_revision"],
+            "evaluation_identity": policy["evaluation_identity"],
             "last_settled_generation": 0,
             "last_plan": plan,
             "preferred_incumbent_identity": preferred,

--- a/skills/utilities/orch-search-plan/scripts/search_plan.py
+++ b/skills/utilities/orch-search-plan/scripts/search_plan.py
@@ -1,15 +1,382 @@
 #!/usr/bin/env python3
-"""Static stdin/stdout entry point for canonical search planning."""
+"""Pure canonical search-plan transformation."""
 
+import copy
+from decimal import Decimal, InvalidOperation
+import hashlib
+import json
+import re
 import sys
+
+
+MAX_INPUT_BYTES = 1_000_000
+MAX_DECIMAL_CHARS = 128
+DECIMAL_RE = re.compile(r"-?(?:0|[1-9][0-9]*)(?:\.[0-9]*[1-9])?\Z")
+SHA256_RE = re.compile(r"sha256:[0-9a-f]{64}\Z")
+
+
+class ProtocolError(ValueError):
+    pass
+
+
+def _canonical_bytes(value):
+    return json.dumps(
+        value,
+        ensure_ascii=False,
+        separators=(",", ":"),
+        sort_keys=True,
+    ).encode("utf-8")
+
+
+def _tagged_identity(tag, payload):
+    digest = hashlib.sha256(tag.encode("utf-8") + b"\0" + _canonical_bytes(payload))
+    return "sha256:" + digest.hexdigest()
+
+
+def _identified(tag, payload):
+    value = copy.deepcopy(payload)
+    value["identity"] = _tagged_identity(tag, payload)
+    return value
+
+
+def _reject_constant(_value):
+    raise ProtocolError("noncanonical number")
+
+
+def _reject_float(_value):
+    raise ProtocolError("numbers requiring decimal syntax must be strings")
+
+
+def _closed(value, keys, label):
+    if not isinstance(value, dict) or set(value) != set(keys):
+        raise ProtocolError(label + " is not a closed object")
+
+
+def _string(value, label):
+    if not isinstance(value, str) or not value or len(value) > 256:
+        raise ProtocolError(label + " must be a bounded identity string")
+    return value
+
+
+def _integer(value, label, minimum=0):
+    if type(value) is not int or value < minimum:
+        raise ProtocolError(label + " must be a nonnegative integer")
+    return value
+
+
+def _unique_strings(value, label, allow_empty=False):
+    if not isinstance(value, list) or (not allow_empty and not value):
+        raise ProtocolError(label + " must be an ordered identity list")
+    result = [_string(item, label) for item in value]
+    if len(result) != len(set(result)):
+        raise ProtocolError(label + " contains duplicates")
+    return result
+
+
+def _decimal_string(value, label, positive=False):
+    if (
+        not isinstance(value, str)
+        or len(value) > MAX_DECIMAL_CHARS
+        or DECIMAL_RE.fullmatch(value) is None
+    ):
+        raise ProtocolError(label + " must be a canonical decimal string")
+    try:
+        number = Decimal(value)
+    except InvalidOperation as exc:
+        raise ProtocolError(label + " is not finite") from exc
+    if number == 0 and value.startswith("-"):
+        raise ProtocolError(label + " must not be negative zero")
+    if positive and number <= 0:
+        raise ProtocolError(label + " must be positive")
+    return value
+
+
+def _load_request(raw):
+    if len(raw) > MAX_INPUT_BYTES:
+        raise ProtocolError("input exceeds bound")
+
+    def pairs(items):
+        result = {}
+        for key, value in items:
+            if key in result:
+                raise ProtocolError("duplicate object key")
+            result[key] = value
+        return result
+
+    try:
+        text = raw.decode("utf-8")
+        return json.loads(
+            text,
+            object_pairs_hook=pairs,
+            parse_float=_reject_float,
+            parse_constant=_reject_constant,
+        )
+    except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+        raise ProtocolError("input is not one UTF-8 JSON object") from exc
+
+
+POLICY_KEYS = {
+    "schema",
+    "identity",
+    "planner_revision",
+    "target_owner_identity",
+    "mutation_surface_identities",
+    "benchmark_revision",
+    "scoring_identity",
+    "dimensions",
+    "feedback_source_identities",
+    "ordering_seed",
+    "generation_width",
+    "merge_slots",
+    "bound_unit_names",
+    "reservations",
+}
+DIMENSION_KEYS = {"identity", "direction", "source_identity", "resolution"}
+FEEDBACK_KEYS = {"source_identity", "dimension_identity", "reference_identity"}
+ADMITTED_KEYS = {
+    "kind",
+    "outcome_identity",
+    "slot_identity",
+    "cost",
+    "candidate_identity",
+    "parent_identities",
+    "target_owner_identity",
+    "mutation_surface_identities",
+    "benchmark_revision",
+    "result_identity",
+    "evidence_identity",
+    "eligibility_status",
+    "eligibility_verdict_identity",
+    "score_card_identity",
+    "dimension_vector",
+    "feedback",
+}
+
+
+def _validate_policy(policy):
+    _closed(policy, POLICY_KEYS, "policy")
+    if policy["schema"] != "search-policy/v1":
+        raise ProtocolError("unsupported policy schema")
+    if not SHA256_RE.fullmatch(policy["identity"]):
+        raise ProtocolError("policy identity is malformed")
+    payload = {key: value for key, value in policy.items() if key != "identity"}
+    if policy["identity"] != _tagged_identity("search-policy/v1", payload):
+        raise ProtocolError("policy identity mismatch")
+    for key in (
+        "planner_revision",
+        "target_owner_identity",
+        "benchmark_revision",
+        "scoring_identity",
+        "ordering_seed",
+    ):
+        _string(policy[key], "policy." + key)
+    surfaces = _unique_strings(
+        policy["mutation_surface_identities"], "mutation surfaces"
+    )
+    feedback_sources = _unique_strings(
+        policy["feedback_source_identities"],
+        "feedback sources",
+        allow_empty=True,
+    )
+    if not isinstance(policy["dimensions"], list) or not policy["dimensions"]:
+        raise ProtocolError("dimensions must be a nonempty ordered list")
+    dimension_ids = []
+    for dimension in policy["dimensions"]:
+        _closed(dimension, DIMENSION_KEYS, "dimension")
+        dimension_ids.append(_string(dimension["identity"], "dimension identity"))
+        if dimension["direction"] not in ("maximize", "minimize"):
+            raise ProtocolError("dimension direction is invalid")
+        _string(dimension["source_identity"], "dimension source")
+        _decimal_string(dimension["resolution"], "dimension resolution", positive=True)
+    if len(dimension_ids) != len(set(dimension_ids)):
+        raise ProtocolError("dimension identities contain duplicates")
+    width = _integer(policy["generation_width"], "generation width", minimum=1)
+    merge_slots = _integer(policy["merge_slots"], "merge slots")
+    if merge_slots > width:
+        raise ProtocolError("merge slots exceed generation width")
+    bound_units = _unique_strings(policy["bound_unit_names"], "bound units")
+    _closed(policy["reservations"], {"reflect", "merge"}, "reservations")
+    for kind in ("reflect", "merge"):
+        _closed(policy["reservations"][kind], bound_units, kind + " reservation")
+        for unit in bound_units:
+            _integer(policy["reservations"][kind][unit], kind + " reservation")
+    return surfaces, feedback_sources, dimension_ids, bound_units
+
+
+def _validate_feedback(feedback, allowed_sources, dimension_ids):
+    if not isinstance(feedback, list):
+        raise ProtocolError("feedback must be an ordered list")
+    seen = set()
+    for item in feedback:
+        _closed(item, FEEDBACK_KEYS, "feedback reference")
+        source = _string(item["source_identity"], "feedback source")
+        dimension = _string(item["dimension_identity"], "feedback dimension")
+        reference = _string(item["reference_identity"], "feedback reference")
+        if source not in allowed_sources or dimension not in dimension_ids:
+            raise ProtocolError("feedback reference is not allowed")
+        identity = (source, dimension, reference)
+        if identity in seen:
+            raise ProtocolError("feedback contains duplicates")
+        seen.add(identity)
+
+
+def _validate_origin(outcome, policy, surfaces, feedback_sources, dimension_ids, units):
+    _closed(outcome, ADMITTED_KEYS, "generation-zero outcome")
+    if outcome["kind"] != "admitted" or outcome["slot_identity"] is not None:
+        raise ProtocolError("generation zero requires one admitted origin")
+    for key in (
+        "outcome_identity",
+        "candidate_identity",
+        "result_identity",
+        "evidence_identity",
+        "eligibility_verdict_identity",
+        "score_card_identity",
+    ):
+        _string(outcome[key], "origin." + key)
+    if outcome["parent_identities"] != []:
+        raise ProtocolError("origin must have no parents")
+    if outcome["target_owner_identity"] != policy["target_owner_identity"]:
+        raise ProtocolError("origin owner drift")
+    if outcome["mutation_surface_identities"] != surfaces:
+        raise ProtocolError("origin mutation-surface drift")
+    if outcome["benchmark_revision"] != policy["benchmark_revision"]:
+        raise ProtocolError("origin benchmark drift")
+    if outcome["eligibility_status"] != "PASS":
+        raise ProtocolError("origin must be covered PASS")
+    _closed(outcome["cost"], units, "origin cost")
+    for unit in units:
+        _integer(outcome["cost"][unit], "origin cost")
+    vector = outcome["dimension_vector"]
+    if not isinstance(vector, list) or len(vector) != len(dimension_ids):
+        raise ProtocolError("origin vector is incomplete")
+    for index, entry in enumerate(vector):
+        _closed(entry, {"identity", "value"}, "dimension-vector entry")
+        if entry["identity"] != dimension_ids[index]:
+            raise ProtocolError("origin vector order is invalid")
+        _decimal_string(entry["value"], "dimension value")
+    _validate_feedback(outcome["feedback"], feedback_sources, dimension_ids)
+
+
+def _fits(spent, reservation, remaining):
+    return all(spent[unit] + reservation[unit] <= remaining[unit] for unit in spent)
+
+
+def _advance_generation_zero(request):
+    _closed(request, {"policy", "projection", "settled", "remaining_bound"}, "request")
+    policy = request["policy"]
+    surfaces, feedback_sources, dimension_ids, units = _validate_policy(policy)
+    if request["projection"] is not None:
+        raise ProtocolError("this planner revision requires a generation-zero projection")
+    _closed(
+        request["settled"],
+        {"preferred_incumbent_identity", "outcomes"},
+        "settled",
+    )
+    preferred = _string(
+        request["settled"]["preferred_incumbent_identity"],
+        "preferred incumbent",
+    )
+    outcomes = request["settled"]["outcomes"]
+    if not isinstance(outcomes, list) or len(outcomes) != 1:
+        raise ProtocolError("generation zero requires exactly one origin")
+    origin = outcomes[0]
+    _validate_origin(
+        origin,
+        policy,
+        surfaces,
+        feedback_sources,
+        dimension_ids,
+        units,
+    )
+    if preferred != origin["candidate_identity"]:
+        raise ProtocolError("preferred incumbent does not name the origin")
+    _closed(request["remaining_bound"], units, "remaining bound")
+    remaining = request["remaining_bound"]
+    for unit in units:
+        _integer(remaining[unit], "remaining bound")
+
+    reservation = policy["reservations"]["reflect"]
+    spent = {unit: 0 for unit in units}
+    slots = []
+    for ordinal in range(policy["generation_width"]):
+        if not _fits(spent, reservation, remaining):
+            break
+        focus = dimension_ids[ordinal % len(dimension_ids)]
+        feedback = [
+            copy.deepcopy(item)
+            for item in origin["feedback"]
+            if item["dimension_identity"] == focus
+        ]
+        slot_payload = {
+            "generation": 1,
+            "ordinal": ordinal,
+            "kind": "reflect",
+            "parent_identities": [origin["candidate_identity"]],
+            "focus_dimension_identity": focus,
+            "complementary_dimension_identities": [],
+            "feedback": feedback,
+            "target_owner_identity": policy["target_owner_identity"],
+            "mutation_surface_identities": copy.deepcopy(surfaces),
+            "benchmark_revision": policy["benchmark_revision"],
+            "reservation": copy.deepcopy(reservation),
+        }
+        slots.append(_identified("search-slot/v1", slot_payload))
+        for unit in units:
+            spent[unit] += reservation[unit]
+
+    plan = None
+    if slots:
+        plan = _identified(
+            "search-plan/v1",
+            {
+                "schema": "search-plan/v1",
+                "policy_identity": policy["identity"],
+                "benchmark_revision": policy["benchmark_revision"],
+                "input_projection_identity": None,
+                "basis_outcome_identities": [origin["outcome_identity"]],
+                "generation": 1,
+                "slots": slots,
+            },
+        )
+    projection = _identified(
+        "search-projection/v1",
+        {
+            "schema": "search-projection/v1",
+            "policy_identity": policy["identity"],
+            "benchmark_revision": policy["benchmark_revision"],
+            "last_settled_generation": 0,
+            "last_plan": plan,
+            "preferred_incumbent_identity": preferred,
+            "nodes": [copy.deepcopy(origin)],
+            "archive": [origin["candidate_identity"]],
+            "seen_slot_identities": [slot["identity"] for slot in slots],
+            "incorporated_outcome_identities": [origin["outcome_identity"]],
+        },
+    )
+    return {
+        "schema": "search-advance/v1",
+        "status": "planned" if plan is not None else "no_fit",
+        "input_projection_identity": None,
+        "output_projection_identity": projection["identity"],
+        "projection": projection,
+        "plan": plan,
+        "missing_slot_identities": [],
+        "diagnostics": [],
+    }
 
 
 def main(argv):
     if argv != ["advance"]:
         sys.stderr.write("search-plan: expected advance\n")
         return 2
-    sys.stderr.write("search-plan: request not implemented\n")
-    return 2
+    try:
+        request = _load_request(sys.stdin.buffer.read(MAX_INPUT_BYTES + 1))
+        response = _advance_generation_zero(request)
+    except (ProtocolError, TypeError, ValueError):
+        sys.stderr.write("search-plan: invalid request\n")
+        return 2
+    sys.stdout.buffer.write(_canonical_bytes(response) + b"\n")
+    return 0
 
 
 if __name__ == "__main__":

--- a/skills/utilities/orch-search-plan/scripts/search_plan.py
+++ b/skills/utilities/orch-search-plan/scripts/search_plan.py
@@ -151,6 +151,43 @@ ADMITTED_KEYS = {
     "dimension_vector",
     "feedback",
 }
+PROJECTION_KEYS = {
+    "schema",
+    "identity",
+    "policy_identity",
+    "benchmark_revision",
+    "last_settled_generation",
+    "last_plan",
+    "preferred_incumbent_identity",
+    "nodes",
+    "archive",
+    "seen_slot_identities",
+    "incorporated_outcome_identities",
+}
+PLAN_KEYS = {
+    "schema",
+    "identity",
+    "policy_identity",
+    "benchmark_revision",
+    "input_projection_identity",
+    "basis_outcome_identities",
+    "generation",
+    "slots",
+}
+SLOT_KEYS = {
+    "identity",
+    "generation",
+    "ordinal",
+    "kind",
+    "parent_identities",
+    "focus_dimension_identity",
+    "complementary_dimension_identities",
+    "feedback",
+    "target_owner_identity",
+    "mutation_surface_identities",
+    "benchmark_revision",
+    "reservation",
+}
 
 
 def _validate_policy(policy):
@@ -220,10 +257,29 @@ def _validate_feedback(feedback, allowed_sources, dimension_ids):
         seen.add(identity)
 
 
-def _validate_origin(outcome, policy, surfaces, feedback_sources, dimension_ids, units):
-    _closed(outcome, ADMITTED_KEYS, "generation-zero outcome")
-    if outcome["kind"] != "admitted" or outcome["slot_identity"] is not None:
-        raise ProtocolError("generation zero requires one admitted origin")
+def _validate_admitted(
+    outcome,
+    policy,
+    surfaces,
+    feedback_sources,
+    dimension_ids,
+    units,
+    origin=False,
+):
+    _closed(outcome, ADMITTED_KEYS, "admitted outcome")
+    if outcome["kind"] != "admitted":
+        raise ProtocolError("outcome kind is invalid")
+    if origin:
+        if outcome["slot_identity"] is not None or outcome["parent_identities"] != []:
+            raise ProtocolError("generation zero requires one admitted origin")
+    else:
+        _string(outcome["slot_identity"], "outcome slot")
+        if not isinstance(outcome["parent_identities"], list) or len(
+            outcome["parent_identities"]
+        ) not in (1, 2):
+            raise ProtocolError("produced candidate requires one or two parents")
+        for parent in outcome["parent_identities"]:
+            _string(parent, "outcome parent")
     for key in (
         "outcome_identity",
         "candidate_identity",
@@ -232,9 +288,7 @@ def _validate_origin(outcome, policy, surfaces, feedback_sources, dimension_ids,
         "eligibility_verdict_identity",
         "score_card_identity",
     ):
-        _string(outcome[key], "origin." + key)
-    if outcome["parent_identities"] != []:
-        raise ProtocolError("origin must have no parents")
+        _string(outcome[key], "outcome." + key)
     if outcome["target_owner_identity"] != policy["target_owner_identity"]:
         raise ProtocolError("origin owner drift")
     if outcome["mutation_surface_identities"] != surfaces:
@@ -243,9 +297,9 @@ def _validate_origin(outcome, policy, surfaces, feedback_sources, dimension_ids,
         raise ProtocolError("origin benchmark drift")
     if outcome["eligibility_status"] != "PASS":
         raise ProtocolError("origin must be covered PASS")
-    _closed(outcome["cost"], units, "origin cost")
+    _closed(outcome["cost"], units, "outcome cost")
     for unit in units:
-        _integer(outcome["cost"][unit], "origin cost")
+        _integer(outcome["cost"][unit], "outcome cost")
     vector = outcome["dimension_vector"]
     if not isinstance(vector, list) or len(vector) != len(dimension_ids):
         raise ProtocolError("origin vector is incomplete")
@@ -257,8 +311,398 @@ def _validate_origin(outcome, policy, surfaces, feedback_sources, dimension_ids,
     _validate_feedback(outcome["feedback"], feedback_sources, dimension_ids)
 
 
+def _validate_origin(outcome, policy, surfaces, feedback_sources, dimension_ids, units):
+    _validate_admitted(
+        outcome,
+        policy,
+        surfaces,
+        feedback_sources,
+        dimension_ids,
+        units,
+        origin=True,
+    )
+
+
+def _decimal_parts(value):
+    negative = value.startswith("-")
+    unsigned = value[1:] if negative else value
+    if "." in unsigned:
+        whole, fraction = unsigned.split(".", 1)
+    else:
+        whole, fraction = unsigned, ""
+    coefficient = int(whole + fraction)
+    return (-coefficient if negative else coefficient), len(fraction)
+
+
+def _relation(left, right, resolution, direction):
+    left_coefficient, left_scale = _decimal_parts(left)
+    right_coefficient, right_scale = _decimal_parts(right)
+    resolution_coefficient, resolution_scale = _decimal_parts(resolution)
+    scale = max(left_scale, right_scale, resolution_scale)
+    delta = left_coefficient * 10 ** (scale - left_scale)
+    delta -= right_coefficient * 10 ** (scale - right_scale)
+    if direction == "minimize":
+        delta = -delta
+    threshold = resolution_coefficient * 10 ** (scale - resolution_scale)
+    if delta >= threshold:
+        return 1
+    if delta <= -threshold:
+        return -1
+    return 0
+
+
+def _vector(node):
+    return {item["identity"]: item["value"] for item in node["dimension_vector"]}
+
+
+def _dominates(left, right, dimensions):
+    left_vector = _vector(left)
+    right_vector = _vector(right)
+    relations = [
+        _relation(
+            left_vector[dimension["identity"]],
+            right_vector[dimension["identity"]],
+            dimension["resolution"],
+            dimension["direction"],
+        )
+        for dimension in dimensions
+    ]
+    return 1 in relations and -1 not in relations
+
+
+def _pareto_archive(nodes, dimensions):
+    admitted = [node for node in nodes if node["kind"] == "admitted"]
+    return [
+        node["candidate_identity"]
+        for node in admitted
+        if not any(
+            other is not node and _dominates(other, node, dimensions)
+            for other in admitted
+        )
+    ]
+
+
+def _stable_key(seed, *identities):
+    material = "\0".join((seed,) + identities).encode("utf-8")
+    return hashlib.sha256(material).hexdigest(), identities
+
+
+def _validate_slot(slot, policy, surfaces, feedback_sources, dimension_ids, units):
+    _closed(slot, SLOT_KEYS, "plan slot")
+    payload = {key: value for key, value in slot.items() if key != "identity"}
+    if slot["identity"] != _tagged_identity("search-slot/v1", payload):
+        raise ProtocolError("slot identity mismatch")
+    _integer(slot["generation"], "slot generation", minimum=1)
+    _integer(slot["ordinal"], "slot ordinal")
+    parents = _unique_strings(slot["parent_identities"], "slot parents")
+    if slot["kind"] == "reflect":
+        if len(parents) != 1 or slot["focus_dimension_identity"] not in dimension_ids:
+            raise ProtocolError("reflection slot is invalid")
+        if slot["complementary_dimension_identities"] != []:
+            raise ProtocolError("reflection cannot carry complementary dimensions")
+    elif slot["kind"] == "merge":
+        if len(parents) != 2 or slot["focus_dimension_identity"] is not None:
+            raise ProtocolError("merge slot is invalid")
+    else:
+        raise ProtocolError("slot kind is invalid")
+    _validate_feedback(slot["feedback"], feedback_sources, dimension_ids)
+    if slot["target_owner_identity"] != policy["target_owner_identity"]:
+        raise ProtocolError("slot owner drift")
+    if slot["mutation_surface_identities"] != surfaces:
+        raise ProtocolError("slot mutation-surface drift")
+    if slot["benchmark_revision"] != policy["benchmark_revision"]:
+        raise ProtocolError("slot benchmark drift")
+    _closed(slot["reservation"], units, "slot reservation")
+    for unit in units:
+        _integer(slot["reservation"][unit], "slot reservation")
+
+
+def _validate_plan(plan, policy, surfaces, feedback_sources, dimension_ids, units):
+    _closed(plan, PLAN_KEYS, "plan")
+    payload = {key: value for key, value in plan.items() if key != "identity"}
+    if plan["identity"] != _tagged_identity("search-plan/v1", payload):
+        raise ProtocolError("plan identity mismatch")
+    if plan["schema"] != "search-plan/v1":
+        raise ProtocolError("plan schema is invalid")
+    if plan["policy_identity"] != policy["identity"]:
+        raise ProtocolError("plan policy drift")
+    if plan["benchmark_revision"] != policy["benchmark_revision"]:
+        raise ProtocolError("plan benchmark drift")
+    if plan["input_projection_identity"] is not None:
+        _string(plan["input_projection_identity"], "plan input projection")
+    _unique_strings(plan["basis_outcome_identities"], "plan outcomes")
+    generation = _integer(plan["generation"], "plan generation", minimum=1)
+    if not isinstance(plan["slots"], list) or not plan["slots"]:
+        raise ProtocolError("plan slots must be nonempty")
+    for ordinal, slot in enumerate(plan["slots"]):
+        _validate_slot(
+            slot, policy, surfaces, feedback_sources, dimension_ids, units
+        )
+        if slot["generation"] != generation or slot["ordinal"] != ordinal:
+            raise ProtocolError("slot position is invalid")
+
+
+def _validate_projection(
+    projection, policy, surfaces, feedback_sources, dimension_ids, units
+):
+    _closed(projection, PROJECTION_KEYS, "projection")
+    payload = {key: value for key, value in projection.items() if key != "identity"}
+    if projection["identity"] != _tagged_identity("search-projection/v1", payload):
+        raise ProtocolError("projection identity mismatch")
+    if projection["schema"] != "search-projection/v1":
+        raise ProtocolError("projection schema is invalid")
+    if projection["policy_identity"] != policy["identity"]:
+        raise ProtocolError("projection policy drift")
+    if projection["benchmark_revision"] != policy["benchmark_revision"]:
+        raise ProtocolError("projection benchmark drift")
+    settled_generation = _integer(
+        projection["last_settled_generation"], "settled generation"
+    )
+    plan = projection["last_plan"]
+    if plan is not None:
+        _validate_plan(
+            plan, policy, surfaces, feedback_sources, dimension_ids, units
+        )
+        if plan["generation"] != settled_generation + 1:
+            raise ProtocolError("projection generation is inconsistent")
+    nodes = projection["nodes"]
+    if not isinstance(nodes, list) or not nodes:
+        raise ProtocolError("projection nodes must be complete")
+    candidates = set()
+    outcomes = set()
+    for index, node in enumerate(nodes):
+        _validate_admitted(
+            node,
+            policy,
+            surfaces,
+            feedback_sources,
+            dimension_ids,
+            units,
+            origin=index == 0,
+        )
+        candidate = node["candidate_identity"]
+        if candidate in candidates or node["outcome_identity"] in outcomes:
+            raise ProtocolError("projection node identity is duplicated")
+        if index and any(parent not in candidates for parent in node["parent_identities"]):
+            raise ProtocolError("projection lineage is cyclic or dangling")
+        candidates.add(candidate)
+        outcomes.add(node["outcome_identity"])
+    archive = _unique_strings(projection["archive"], "projection archive")
+    if archive != _pareto_archive(nodes, policy["dimensions"]):
+        raise ProtocolError("projection archive is incomplete")
+    preferred = _string(
+        projection["preferred_incumbent_identity"], "preferred incumbent"
+    )
+    if preferred not in candidates:
+        raise ProtocolError("preferred incumbent is not admitted")
+    seen_slots = _unique_strings(
+        projection["seen_slot_identities"], "seen slots", allow_empty=True
+    )
+    incorporated = _unique_strings(
+        projection["incorporated_outcome_identities"],
+        "incorporated outcomes",
+    )
+    if not outcomes.issubset(set(incorporated)):
+        raise ProtocolError("projection outcomes are incomplete")
+    if any(
+        node["slot_identity"] is not None
+        and node["slot_identity"] not in seen_slots
+        for node in nodes
+    ):
+        raise ProtocolError("projection slot lineage is incomplete")
+    return nodes, candidates
+
+
 def _fits(spent, reservation, remaining):
     return all(spent[unit] + reservation[unit] <= remaining[unit] for unit in spent)
+
+
+def _reflection_slots(policy, nodes, archive, preferred, count, generation):
+    by_candidate = {node["candidate_identity"]: node for node in nodes}
+    remaining = [candidate for candidate in archive if candidate != preferred]
+    remaining.sort(key=lambda candidate: _stable_key(policy["ordering_seed"], candidate))
+    parents = [preferred] + remaining
+    slots = []
+    uses = {candidate: 0 for candidate in parents}
+    for ordinal in range(count):
+        parent_identity = parents[ordinal % len(parents)]
+        parent = by_candidate[parent_identity]
+        parent_vector = _vector(parent)
+        trailing = []
+        for dimension in policy["dimensions"]:
+            dimension_id = dimension["identity"]
+            if any(
+                _relation(
+                    _vector(by_candidate[other])[dimension_id],
+                    parent_vector[dimension_id],
+                    dimension["resolution"],
+                    dimension["direction"],
+                )
+                == 1
+                for other in archive
+            ):
+                trailing.append(dimension_id)
+        focus_pool = trailing or [item["identity"] for item in policy["dimensions"]]
+        focus = focus_pool[uses[parent_identity] % len(focus_pool)]
+        uses[parent_identity] += 1
+        feedback = [
+            copy.deepcopy(item)
+            for item in parent["feedback"]
+            if item["dimension_identity"] == focus
+        ]
+        payload = {
+            "generation": generation,
+            "ordinal": ordinal,
+            "kind": "reflect",
+            "parent_identities": [parent_identity],
+            "focus_dimension_identity": focus,
+            "complementary_dimension_identities": [],
+            "feedback": feedback,
+            "target_owner_identity": policy["target_owner_identity"],
+            "mutation_surface_identities": copy.deepcopy(
+                policy["mutation_surface_identities"]
+            ),
+            "benchmark_revision": policy["benchmark_revision"],
+            "reservation": copy.deepcopy(policy["reservations"]["reflect"]),
+        }
+        slots.append(_identified("search-slot/v1", payload))
+    return slots
+
+
+def _pending_response(projection, missing):
+    return {
+        "schema": "search-advance/v1",
+        "status": "pending",
+        "input_projection_identity": projection["identity"],
+        "output_projection_identity": projection["identity"],
+        "projection": copy.deepcopy(projection),
+        "plan": None,
+        "missing_slot_identities": missing,
+        "diagnostics": [],
+    }
+
+
+def _advance_later(request, policy, surfaces, feedback_sources, dimension_ids, units):
+    projection = request["projection"]
+    nodes, candidates = _validate_projection(
+        projection, policy, surfaces, feedback_sources, dimension_ids, units
+    )
+    prior_plan = projection["last_plan"]
+    if prior_plan is None:
+        raise ProtocolError("projection has no open plan")
+    _closed(request["settled"], {"preferred_incumbent_identity", "outcomes"}, "settled")
+    preferred = _string(
+        request["settled"]["preferred_incumbent_identity"], "preferred incumbent"
+    )
+    outcomes = request["settled"]["outcomes"]
+    if not isinstance(outcomes, list):
+        raise ProtocolError("settled outcomes must be a list")
+    slots = {slot["identity"]: slot for slot in prior_plan["slots"]}
+    by_slot = {}
+    seen_candidates = set(candidates)
+    incorporated = set(projection["incorporated_outcome_identities"])
+    for outcome in outcomes:
+        _validate_admitted(
+            outcome,
+            policy,
+            surfaces,
+            feedback_sources,
+            dimension_ids,
+            units,
+        )
+        slot_identity = outcome["slot_identity"]
+        if slot_identity not in slots or slot_identity in by_slot:
+            raise ProtocolError("settled slot is extra or duplicated")
+        slot = slots[slot_identity]
+        if outcome["parent_identities"] != slot["parent_identities"]:
+            raise ProtocolError("settled lineage does not match the plan")
+        if outcome["candidate_identity"] in seen_candidates:
+            raise ProtocolError("produced candidate identity is reused")
+        if outcome["outcome_identity"] in incorporated:
+            raise ProtocolError("outcome identity is reused")
+        seen_candidates.add(outcome["candidate_identity"])
+        incorporated.add(outcome["outcome_identity"])
+        by_slot[slot_identity] = outcome
+    missing = [slot["identity"] for slot in prior_plan["slots"] if slot["identity"] not in by_slot]
+    if missing:
+        return _pending_response(projection, missing)
+    normalized_outcomes = [by_slot[slot["identity"]] for slot in prior_plan["slots"]]
+    updated_nodes = copy.deepcopy(nodes) + copy.deepcopy(normalized_outcomes)
+    admitted_candidates = {
+        node["candidate_identity"]
+        for node in updated_nodes
+        if node["kind"] == "admitted"
+    }
+    if preferred not in admitted_candidates:
+        raise ProtocolError("preferred incumbent is not admitted")
+    archive = _pareto_archive(updated_nodes, policy["dimensions"])
+
+    _closed(request["remaining_bound"], units, "remaining bound")
+    remaining_bound = request["remaining_bound"]
+    for unit in units:
+        _integer(remaining_bound[unit], "remaining bound")
+    generation = prior_plan["generation"] + 1
+    proposed = _reflection_slots(
+        policy,
+        updated_nodes,
+        archive,
+        preferred,
+        policy["generation_width"],
+        generation,
+    )
+    spent = {unit: 0 for unit in units}
+    fitting = []
+    for slot in proposed:
+        if not _fits(spent, slot["reservation"], remaining_bound):
+            break
+        fitting.append(slot)
+        for unit in units:
+            spent[unit] += slot["reservation"][unit]
+    next_plan = None
+    if fitting:
+        next_plan = _identified(
+            "search-plan/v1",
+            {
+                "schema": "search-plan/v1",
+                "policy_identity": policy["identity"],
+                "benchmark_revision": policy["benchmark_revision"],
+                "input_projection_identity": projection["identity"],
+                "basis_outcome_identities": [
+                    outcome["outcome_identity"] for outcome in normalized_outcomes
+                ],
+                "generation": generation,
+                "slots": fitting,
+            },
+        )
+    output_projection = _identified(
+        "search-projection/v1",
+        {
+            "schema": "search-projection/v1",
+            "policy_identity": policy["identity"],
+            "benchmark_revision": policy["benchmark_revision"],
+            "last_settled_generation": prior_plan["generation"],
+            "last_plan": next_plan,
+            "preferred_incumbent_identity": preferred,
+            "nodes": updated_nodes,
+            "archive": archive,
+            "seen_slot_identities": projection["seen_slot_identities"]
+            + [slot["identity"] for slot in fitting],
+            "incorporated_outcome_identities": projection[
+                "incorporated_outcome_identities"
+            ]
+            + [outcome["outcome_identity"] for outcome in normalized_outcomes],
+        },
+    )
+    return {
+        "schema": "search-advance/v1",
+        "status": "planned" if next_plan is not None else "no_fit",
+        "input_projection_identity": projection["identity"],
+        "output_projection_identity": output_projection["identity"],
+        "projection": output_projection,
+        "plan": next_plan,
+        "missing_slot_identities": [],
+        "diagnostics": [],
+    }
 
 
 def _advance_generation_zero(request):
@@ -365,13 +809,24 @@ def _advance_generation_zero(request):
     }
 
 
+def _advance(request):
+    _closed(request, {"policy", "projection", "settled", "remaining_bound"}, "request")
+    if request["projection"] is None:
+        return _advance_generation_zero(request)
+    policy = request["policy"]
+    surfaces, feedback_sources, dimension_ids, units = _validate_policy(policy)
+    return _advance_later(
+        request, policy, surfaces, feedback_sources, dimension_ids, units
+    )
+
+
 def main(argv):
     if argv != ["advance"]:
         sys.stderr.write("search-plan: expected advance\n")
         return 2
     try:
         request = _load_request(sys.stdin.buffer.read(MAX_INPUT_BYTES + 1))
-        response = _advance_generation_zero(request)
+        response = _advance(request)
     except (ProtocolError, TypeError, ValueError):
         sys.stderr.write("search-plan: invalid request\n")
         return 2

--- a/skills/utilities/orch-search-plan/scripts/search_plan.py
+++ b/skills/utilities/orch-search-plan/scripts/search_plan.py
@@ -1,0 +1,16 @@
+#!/usr/bin/env python3
+"""Static stdin/stdout entry point for canonical search planning."""
+
+import sys
+
+
+def main(argv):
+    if argv != ["advance"]:
+        sys.stderr.write("search-plan: expected advance\n")
+        return 2
+    sys.stderr.write("search-plan: request not implemented\n")
+    return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/skills/utilities/orch-search-plan/scripts/search_plan.py
+++ b/skills/utilities/orch-search-plan/scripts/search_plan.py
@@ -10,6 +10,7 @@ import sys
 
 
 MAX_INPUT_BYTES = 1_000_000
+MAX_IDENTITY_CHARS = 256
 MAX_DECIMAL_CHARS = 128
 DECIMAL_RE = re.compile(r"-?(?:0|[1-9][0-9]*)(?:\.[0-9]*[1-9])?\Z")
 SHA256_RE = re.compile(r"sha256:[0-9a-f]{64}\Z")
@@ -53,7 +54,7 @@ def _closed(value, keys, label):
 
 
 def _string(value, label):
-    if not isinstance(value, str) or not value or len(value) > 256:
+    if not isinstance(value, str) or not value or len(value) > MAX_IDENTITY_CHARS:
         raise ProtocolError(label + " must be a bounded identity string")
     return value
 
@@ -111,7 +112,7 @@ def _load_request(raw):
             parse_float=_reject_float,
             parse_constant=_reject_constant,
         )
-    except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+    except (UnicodeDecodeError, json.JSONDecodeError, RecursionError) as exc:
         raise ProtocolError("input is not one UTF-8 JSON object") from exc
 
 
@@ -511,6 +512,8 @@ def _validate_slot(slot, policy, surfaces, feedback_sources, dimension_ids, unit
     _closed(slot["reservation"], units, "slot reservation")
     for unit in units:
         _integer(slot["reservation"][unit], "slot reservation")
+    if slot["reservation"] != policy["reservations"][slot["kind"]]:
+        raise ProtocolError("slot reservation drifts from policy")
 
 
 def _validate_plan(plan, policy, surfaces, feedback_sources, dimension_ids, units):
@@ -592,10 +595,13 @@ def _validate_projection(
     archive = _unique_strings(projection["archive"], "projection archive")
     if archive != _pareto_archive(nodes, policy["dimensions"]):
         raise ProtocolError("projection archive is incomplete")
+    admitted_candidates = {
+        node["candidate_identity"] for node in nodes if node["kind"] == "admitted"
+    }
     preferred = _string(
         projection["preferred_incumbent_identity"], "preferred incumbent"
     )
-    if preferred not in candidates:
+    if preferred not in admitted_candidates:
         raise ProtocolError("preferred incumbent is not admitted")
     seen_slots = _unique_strings(
         projection["seen_slot_identities"], "seen slots", allow_empty=True
@@ -612,6 +618,29 @@ def _validate_projection(
         for node in nodes
     ):
         raise ProtocolError("projection slot lineage is incomplete")
+    if plan is not None:
+        if any(
+            parent not in admitted_candidates
+            for slot in plan["slots"]
+            for parent in slot["parent_identities"]
+        ):
+            raise ProtocolError("plan parent is not admitted")
+        if any(slot["identity"] not in seen_slots for slot in plan["slots"]):
+            raise ProtocolError("open plan is absent from seen slots")
+        proposals = _proposed_slots(
+            policy,
+            nodes,
+            archive,
+            preferred,
+            plan["generation"],
+        )
+        for slot in plan["slots"]:
+            try:
+                expected = next(proposals)
+            except StopIteration as exc:
+                raise ProtocolError("open plan is not a proposal prefix") from exc
+            if slot != expected:
+                raise ProtocolError("open plan is not a proposal prefix")
     return nodes, candidates
 
 
@@ -619,14 +648,14 @@ def _fits(spent, reservation, remaining):
     return all(spent[unit] + reservation[unit] <= remaining[unit] for unit in spent)
 
 
-def _reflection_slots(policy, nodes, archive, preferred, count, generation):
+def _reflection_slots(
+    policy, nodes, archive, preferred, start_ordinal, count, generation
+):
     by_candidate = {node["candidate_identity"]: node for node in nodes}
     remaining = [candidate for candidate in archive if candidate != preferred]
     remaining.sort(key=lambda candidate: _stable_key(policy["ordering_seed"], candidate))
     parents = [preferred] + remaining
-    slots = []
-    uses = {candidate: 0 for candidate in parents}
-    for ordinal in range(count):
+    for ordinal in range(start_ordinal, start_ordinal + count):
         parent_identity = parents[ordinal % len(parents)]
         parent = by_candidate[parent_identity]
         parent_vector = _vector(parent)
@@ -645,8 +674,8 @@ def _reflection_slots(policy, nodes, archive, preferred, count, generation):
             ):
                 trailing.append(dimension_id)
         focus_pool = trailing or [item["identity"] for item in policy["dimensions"]]
-        focus = focus_pool[uses[parent_identity] % len(focus_pool)]
-        uses[parent_identity] += 1
+        focus_index = generation - 1 + ordinal // len(parents)
+        focus = focus_pool[focus_index % len(focus_pool)]
         feedback = [
             copy.deepcopy(item)
             for item in parent["feedback"]
@@ -667,8 +696,7 @@ def _reflection_slots(policy, nodes, archive, preferred, count, generation):
             "benchmark_revision": policy["benchmark_revision"],
             "reservation": copy.deepcopy(policy["reservations"]["reflect"]),
         }
-        slots.append(_identified("search-slot/v1", payload))
-    return slots
+        yield _identified("search-slot/v1", payload)
 
 
 def _merge_pairs(policy, nodes, archive):
@@ -734,15 +762,26 @@ def _merge_feedback(policy, left, right, relations):
 
 def _proposed_slots(policy, nodes, archive, preferred, generation):
     by_candidate = {node["candidate_identity"]: node for node in nodes}
-    pairs = _merge_pairs(policy, nodes, archive)
-    merge_count = min(policy["merge_slots"], len(pairs))
-    reflection_count = policy["generation_width"] - merge_count
-    slots = _reflection_slots(
+    minimum_reflection_count = policy["generation_width"] - policy["merge_slots"]
+    yield from _reflection_slots(
         policy,
         nodes,
         archive,
         preferred,
-        reflection_count,
+        0,
+        minimum_reflection_count,
+        generation,
+    )
+    pairs = _merge_pairs(policy, nodes, archive)
+    merge_count = min(policy["merge_slots"], len(pairs))
+    reflection_count = policy["generation_width"] - merge_count
+    yield from _reflection_slots(
+        policy,
+        nodes,
+        archive,
+        preferred,
+        minimum_reflection_count,
+        reflection_count - minimum_reflection_count,
         generation,
     )
     for pair_index in range(merge_count):
@@ -754,7 +793,7 @@ def _proposed_slots(policy, nodes, archive, preferred, generation):
         ]
         payload = {
             "generation": generation,
-            "ordinal": len(slots),
+            "ordinal": reflection_count + pair_index,
             "kind": "merge",
             "parent_identities": [left_identity, right_identity],
             "focus_dimension_identity": None,
@@ -772,8 +811,14 @@ def _proposed_slots(policy, nodes, archive, preferred, generation):
             "benchmark_revision": policy["benchmark_revision"],
             "reservation": copy.deepcopy(policy["reservations"]["merge"]),
         }
-        slots.append(_identified("search-slot/v1", payload))
-    return slots
+        yield _identified("search-slot/v1", payload)
+
+
+def _validate_remaining_bound(value, units):
+    _closed(value, units, "remaining bound")
+    for unit in units:
+        _integer(value[unit], "remaining bound")
+    return value
 
 
 def _pending_response(projection, missing):
@@ -804,6 +849,7 @@ def _advance_later(request, policy, surfaces, feedback_sources, dimension_ids, u
     outcomes = request["settled"]["outcomes"]
     if not isinstance(outcomes, list):
         raise ProtocolError("settled outcomes must be a list")
+    remaining_bound = _validate_remaining_bound(request["remaining_bound"], units)
     slots = {slot["identity"]: slot for slot in prior_plan["slots"]}
     by_slot = {}
     seen_candidates = set(candidates)
@@ -856,6 +902,8 @@ def _advance_later(request, policy, surfaces, feedback_sources, dimension_ids, u
         by_slot[slot_identity] = outcome
     missing = [slot["identity"] for slot in prior_plan["slots"] if slot["identity"] not in by_slot]
     if missing:
+        if preferred != projection["preferred_incumbent_identity"]:
+            raise ProtocolError("pending settlement changes preferred incumbent")
         return _pending_response(projection, missing)
     normalized_outcomes = [by_slot[slot["identity"]] for slot in prior_plan["slots"]]
     updated_nodes = copy.deepcopy(nodes) + [
@@ -872,10 +920,6 @@ def _advance_later(request, policy, surfaces, feedback_sources, dimension_ids, u
         raise ProtocolError("preferred incumbent is not admitted")
     archive = _pareto_archive(updated_nodes, policy["dimensions"])
 
-    _closed(request["remaining_bound"], units, "remaining bound")
-    remaining_bound = request["remaining_bound"]
-    for unit in units:
-        _integer(remaining_bound[unit], "remaining bound")
     generation = prior_plan["generation"] + 1
     proposed = _proposed_slots(
         policy,
@@ -927,6 +971,14 @@ def _advance_later(request, policy, surfaces, feedback_sources, dimension_ids, u
             + [outcome["outcome_identity"] for outcome in normalized_outcomes],
         },
     )
+    _validate_projection(
+        output_projection,
+        policy,
+        surfaces,
+        feedback_sources,
+        dimension_ids,
+        units,
+    )
     return {
         "schema": "search-advance/v1",
         "status": "planned" if next_plan is not None else "no_fit",
@@ -968,10 +1020,7 @@ def _advance_generation_zero(request):
     )
     if preferred != origin["candidate_identity"]:
         raise ProtocolError("preferred incumbent does not name the origin")
-    _closed(request["remaining_bound"], units, "remaining bound")
-    remaining = request["remaining_bound"]
-    for unit in units:
-        _integer(remaining[unit], "remaining bound")
+    remaining = _validate_remaining_bound(request["remaining_bound"], units)
 
     reservation = policy["reservations"]["reflect"]
     spent = {unit: 0 for unit in units}
@@ -1031,6 +1080,14 @@ def _advance_generation_zero(request):
             "incorporated_outcome_identities": [origin["outcome_identity"]],
         },
     )
+    _validate_projection(
+        projection,
+        policy,
+        surfaces,
+        feedback_sources,
+        dimension_ids,
+        units,
+    )
     return {
         "schema": "search-advance/v1",
         "status": "planned" if plan is not None else "no_fit",
@@ -1061,7 +1118,7 @@ def main(argv):
     try:
         request = _load_request(sys.stdin.buffer.read(MAX_INPUT_BYTES + 1))
         response = _advance(request)
-    except (ProtocolError, TypeError, ValueError):
+    except (ProtocolError, TypeError, ValueError, RecursionError):
         sys.stderr.write("search-plan: invalid request\n")
         return 2
     sys.stdout.buffer.write(_canonical_bytes(response) + b"\n")

--- a/skills/utilities/orch-search-plan/scripts/search_plan.py
+++ b/skills/utilities/orch-search-plan/scripts/search_plan.py
@@ -151,6 +151,29 @@ ADMITTED_KEYS = {
     "dimension_vector",
     "feedback",
 }
+INELIGIBLE_KEYS = {
+    "kind",
+    "outcome_identity",
+    "slot_identity",
+    "cost",
+    "candidate_identity",
+    "parent_identities",
+    "target_owner_identity",
+    "mutation_surface_identities",
+    "benchmark_revision",
+    "result_identity",
+    "evidence_identity",
+    "eligibility_status",
+    "eligibility_verdict_identity",
+    "disposition",
+}
+NO_CANDIDATE_KEYS = {
+    "kind",
+    "outcome_identity",
+    "slot_identity",
+    "cost",
+    "disposition",
+}
 PROJECTION_KEYS = {
     "schema",
     "identity",
@@ -323,6 +346,71 @@ def _validate_origin(outcome, policy, surfaces, feedback_sources, dimension_ids,
     )
 
 
+def _validate_ineligible(outcome, policy, surfaces, units):
+    _closed(outcome, INELIGIBLE_KEYS, "ineligible outcome")
+    if outcome["kind"] != "ineligible":
+        raise ProtocolError("outcome kind is invalid")
+    for key in (
+        "outcome_identity",
+        "slot_identity",
+        "candidate_identity",
+        "result_identity",
+        "evidence_identity",
+        "eligibility_verdict_identity",
+        "disposition",
+    ):
+        _string(outcome[key], "outcome." + key)
+    parents = outcome["parent_identities"]
+    if not isinstance(parents, list) or len(parents) not in (1, 2):
+        raise ProtocolError("produced candidate requires one or two parents")
+    for parent in parents:
+        _string(parent, "outcome parent")
+    if outcome["target_owner_identity"] != policy["target_owner_identity"]:
+        raise ProtocolError("outcome owner drift")
+    if outcome["mutation_surface_identities"] != surfaces:
+        raise ProtocolError("outcome mutation-surface drift")
+    if outcome["benchmark_revision"] != policy["benchmark_revision"]:
+        raise ProtocolError("outcome benchmark drift")
+    if outcome["eligibility_status"] not in ("FAIL", "UNVERIFIED"):
+        raise ProtocolError("ineligible outcome must be covered non-PASS")
+    _closed(outcome["cost"], units, "outcome cost")
+    for unit in units:
+        _integer(outcome["cost"][unit], "outcome cost")
+
+
+def _validate_no_candidate(outcome, units):
+    _closed(outcome, NO_CANDIDATE_KEYS, "no-candidate outcome")
+    if outcome["kind"] != "no_candidate":
+        raise ProtocolError("outcome kind is invalid")
+    for key in ("outcome_identity", "slot_identity", "disposition"):
+        _string(outcome[key], "outcome." + key)
+    _closed(outcome["cost"], units, "outcome cost")
+    for unit in units:
+        _integer(outcome["cost"][unit], "outcome cost")
+
+
+def _validate_outcome(
+    outcome, policy, surfaces, feedback_sources, dimension_ids, units
+):
+    if not isinstance(outcome, dict):
+        raise ProtocolError("outcome is not an object")
+    if outcome.get("kind") == "admitted":
+        _validate_admitted(
+            outcome,
+            policy,
+            surfaces,
+            feedback_sources,
+            dimension_ids,
+            units,
+        )
+    elif outcome.get("kind") == "ineligible":
+        _validate_ineligible(outcome, policy, surfaces, units)
+    elif outcome.get("kind") == "no_candidate":
+        _validate_no_candidate(outcome, units)
+    else:
+        raise ProtocolError("outcome kind is invalid")
+
+
 def _decimal_parts(value):
     negative = value.startswith("-")
     unsigned = value[1:] if negative else value
@@ -403,6 +491,14 @@ def _validate_slot(slot, policy, surfaces, feedback_sources, dimension_ids, unit
     elif slot["kind"] == "merge":
         if len(parents) != 2 or slot["focus_dimension_identity"] is not None:
             raise ProtocolError("merge slot is invalid")
+        complementary = slot["complementary_dimension_identities"]
+        if (
+            not isinstance(complementary, list)
+            or not complementary
+            or len(complementary) != len(set(complementary))
+            or any(item not in dimension_ids for item in complementary)
+        ):
+            raise ProtocolError("merge complementary dimensions are invalid")
     else:
         raise ProtocolError("slot kind is invalid")
     _validate_feedback(slot["feedback"], feedback_sources, dimension_ids)
@@ -471,15 +567,21 @@ def _validate_projection(
     candidates = set()
     outcomes = set()
     for index, node in enumerate(nodes):
-        _validate_admitted(
-            node,
-            policy,
-            surfaces,
-            feedback_sources,
-            dimension_ids,
-            units,
-            origin=index == 0,
-        )
+        if index == 0:
+            _validate_origin(
+                node, policy, surfaces, feedback_sources, dimension_ids, units
+            )
+        elif isinstance(node, dict) and node.get("kind") == "admitted":
+            _validate_admitted(
+                node,
+                policy,
+                surfaces,
+                feedback_sources,
+                dimension_ids,
+                units,
+            )
+        else:
+            _validate_ineligible(node, policy, surfaces, units)
         candidate = node["candidate_identity"]
         if candidate in candidates or node["outcome_identity"] in outcomes:
             raise ProtocolError("projection node identity is duplicated")
@@ -569,6 +671,111 @@ def _reflection_slots(policy, nodes, archive, preferred, count, generation):
     return slots
 
 
+def _merge_pairs(policy, nodes, archive):
+    by_candidate = {node["candidate_identity"]: node for node in nodes}
+    ordered = sorted(
+        archive,
+        key=lambda candidate: _stable_key(policy["ordering_seed"], candidate),
+    )
+    pairs = []
+    for left_index, left_identity in enumerate(ordered):
+        left = by_candidate[left_identity]
+        for right_identity in ordered[left_index + 1 :]:
+            right = by_candidate[right_identity]
+            if (
+                left["target_owner_identity"] != right["target_owner_identity"]
+                or left["mutation_surface_identities"]
+                != right["mutation_surface_identities"]
+            ):
+                continue
+            relations = []
+            for dimension in policy["dimensions"]:
+                dimension_id = dimension["identity"]
+                relations.append(
+                    _relation(
+                        _vector(left)[dimension_id],
+                        _vector(right)[dimension_id],
+                        dimension["resolution"],
+                        dimension["direction"],
+                    )
+                )
+            if 1 in relations and -1 in relations:
+                pairs.append((left_identity, right_identity, relations))
+    pairs.sort(
+        key=lambda item: _stable_key(policy["ordering_seed"], item[0], item[1])
+    )
+    return pairs
+
+
+def _merge_feedback(policy, left, right, relations):
+    source_order = {
+        source: index
+        for index, source in enumerate(policy["feedback_source_identities"])
+    }
+    feedback = []
+    for parent, wanted_relation in ((left, 1), (right, -1)):
+        for dimension, relation in zip(policy["dimensions"], relations):
+            if relation != wanted_relation:
+                continue
+            matching = [
+                copy.deepcopy(item)
+                for item in parent["feedback"]
+                if item["dimension_identity"] == dimension["identity"]
+            ]
+            matching.sort(
+                key=lambda item: (
+                    source_order[item["source_identity"]],
+                    item["reference_identity"],
+                )
+            )
+            feedback.extend(matching)
+    return feedback
+
+
+def _proposed_slots(policy, nodes, archive, preferred, generation):
+    by_candidate = {node["candidate_identity"]: node for node in nodes}
+    pairs = _merge_pairs(policy, nodes, archive)
+    merge_count = min(policy["merge_slots"], len(pairs))
+    reflection_count = policy["generation_width"] - merge_count
+    slots = _reflection_slots(
+        policy,
+        nodes,
+        archive,
+        preferred,
+        reflection_count,
+        generation,
+    )
+    for pair_index in range(merge_count):
+        left_identity, right_identity, relations = pairs[pair_index]
+        complementary = [
+            dimension["identity"]
+            for dimension, relation in zip(policy["dimensions"], relations)
+            if relation != 0
+        ]
+        payload = {
+            "generation": generation,
+            "ordinal": len(slots),
+            "kind": "merge",
+            "parent_identities": [left_identity, right_identity],
+            "focus_dimension_identity": None,
+            "complementary_dimension_identities": complementary,
+            "feedback": _merge_feedback(
+                policy,
+                by_candidate[left_identity],
+                by_candidate[right_identity],
+                relations,
+            ),
+            "target_owner_identity": policy["target_owner_identity"],
+            "mutation_surface_identities": copy.deepcopy(
+                policy["mutation_surface_identities"]
+            ),
+            "benchmark_revision": policy["benchmark_revision"],
+            "reservation": copy.deepcopy(policy["reservations"]["merge"]),
+        }
+        slots.append(_identified("search-slot/v1", payload))
+    return slots
+
+
 def _pending_response(projection, missing):
     return {
         "schema": "search-advance/v1",
@@ -601,8 +808,23 @@ def _advance_later(request, policy, surfaces, feedback_sources, dimension_ids, u
     by_slot = {}
     seen_candidates = set(candidates)
     incorporated = set(projection["incorporated_outcome_identities"])
+    fresh_fields = (
+        "candidate_identity",
+        "result_identity",
+        "evidence_identity",
+        "eligibility_verdict_identity",
+    )
+    used_fresh = {
+        field: {node[field] for node in nodes}
+        for field in fresh_fields
+    }
+    used_scores = {
+        node["score_card_identity"]
+        for node in nodes
+        if node["kind"] == "admitted"
+    }
     for outcome in outcomes:
-        _validate_admitted(
+        _validate_outcome(
             outcome,
             policy,
             surfaces,
@@ -614,20 +836,33 @@ def _advance_later(request, policy, surfaces, feedback_sources, dimension_ids, u
         if slot_identity not in slots or slot_identity in by_slot:
             raise ProtocolError("settled slot is extra or duplicated")
         slot = slots[slot_identity]
-        if outcome["parent_identities"] != slot["parent_identities"]:
-            raise ProtocolError("settled lineage does not match the plan")
-        if outcome["candidate_identity"] in seen_candidates:
-            raise ProtocolError("produced candidate identity is reused")
+        if outcome["kind"] != "no_candidate":
+            if outcome["parent_identities"] != slot["parent_identities"]:
+                raise ProtocolError("settled lineage does not match the plan")
+            if outcome["candidate_identity"] in seen_candidates:
+                raise ProtocolError("produced candidate identity is reused")
+            for field in fresh_fields:
+                if outcome[field] in used_fresh[field]:
+                    raise ProtocolError("produced result identity is reused")
+                used_fresh[field].add(outcome[field])
+            if outcome["kind"] == "admitted":
+                if outcome["score_card_identity"] in used_scores:
+                    raise ProtocolError("score-card identity is reused")
+                used_scores.add(outcome["score_card_identity"])
+            seen_candidates.add(outcome["candidate_identity"])
         if outcome["outcome_identity"] in incorporated:
             raise ProtocolError("outcome identity is reused")
-        seen_candidates.add(outcome["candidate_identity"])
         incorporated.add(outcome["outcome_identity"])
         by_slot[slot_identity] = outcome
     missing = [slot["identity"] for slot in prior_plan["slots"] if slot["identity"] not in by_slot]
     if missing:
         return _pending_response(projection, missing)
     normalized_outcomes = [by_slot[slot["identity"]] for slot in prior_plan["slots"]]
-    updated_nodes = copy.deepcopy(nodes) + copy.deepcopy(normalized_outcomes)
+    updated_nodes = copy.deepcopy(nodes) + [
+        copy.deepcopy(outcome)
+        for outcome in normalized_outcomes
+        if outcome["kind"] != "no_candidate"
+    ]
     admitted_candidates = {
         node["candidate_identity"]
         for node in updated_nodes
@@ -642,12 +877,11 @@ def _advance_later(request, policy, surfaces, feedback_sources, dimension_ids, u
     for unit in units:
         _integer(remaining_bound[unit], "remaining bound")
     generation = prior_plan["generation"] + 1
-    proposed = _reflection_slots(
+    proposed = _proposed_slots(
         policy,
         updated_nodes,
         archive,
         preferred,
-        policy["generation_width"],
         generation,
     )
     spent = {unit: 0 for unit in units}

--- a/skills/workflows/orch-eval-design/SKILL.md
+++ b/skills/workflows/orch-eval-design/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: orch-eval-design
-description: Design one frozen candidate-blind evaluation from fixed evidence. Use when benchmark semantics must be defined before construction.
+description: Design one frozen candidate-blind evaluation from fixed evidence. Use before benchmark construction or direct judged scoring.
 role: none
 ---
 
@@ -40,6 +40,8 @@ intended coverage; source identities and provenance; and expected
 execution cost. Freeze the result at one package-owned
 evaluation-design identity before benchmark construction or candidate
 scoring.
+
+For judged evaluation, it also freezes one candidate-blind Judge brief: target, intended outcome, criteria, scale, anchors, exclusions, and aggregation.
 
 Never: gather research; materialize or execute cases; inspect or compare
 candidates; generate or promote variants; revise the design from scores;

--- a/tests/test_benchmark_architecture.py
+++ b/tests/test_benchmark_architecture.py
@@ -11,6 +11,7 @@ OLD_BENCH = ROOT / "skills" / "workflows" / "orch-bench"
 OLD_EVOLVE = ROOT / "skills" / "workflows" / "orch-evolve"
 # Demoted per contracts/composition.md: evolve is a named composition.
 EVOLVE = ROOT / "compositions" / "evolve.md"
+EVOLVE_EVALUATION = ROOT / "compositions" / "references" / "evolve-evaluation.md"
 EVOLVE_GENERATION = ROOT / "compositions" / "references" / "evolve-generation.md"
 TOURNAMENT = ROOT / "compositions" / "skill-tournament.md"
 PANEL = ROOT / "skills" / "engines" / "orch-panel" / "SKILL.md"
@@ -127,6 +128,7 @@ class TestEvaluationDesign(unittest.TestCase):
             "intended coverage",
             "source identities",
             "expected execution cost",
+            "candidate-blind judge brief",
             "smallest",
             "discrimination",
             "explicit gaps",
@@ -166,7 +168,7 @@ class TestFrozenBenchmarkEvolution(unittest.TestCase):
             "frozen evolve spec",
             "`evidence`",
             "incumbent identity",
-            "qualified benchmark revision",
+            "frozen evaluation identity",
             "`affected_surfaces`",
             "`authority`",
             "intersection",
@@ -179,26 +181,24 @@ class TestFrozenBenchmarkEvolution(unittest.TestCase):
         combined = body + read(EVOLVE_GENERATION)
         self.assertLess(combined.index("`orch-verify`"), combined.index("`orch-panel`"))
         contract = normalized(combined)
-        self.assertIn("required eligibility", contract)
-        self.assertIn("verified survivors", contract)
-        self.assertIn("required deterministic", contract)
+        self.assertIn("required admission", contract)
+        self.assertIn("eligible candidates", contract)
+        self.assertIn("required admission criterion", contract)
         self.assertIn("cannot compensate", contract)
-        self.assertIn("covered-pass result/evidence identity", contract)
-        self.assertIn("score card cites the admitted evidence", contract)
+        self.assertIn("fixed result/evidence", contract)
+        self.assertIn("score card cites admitted evidence", contract)
 
-    def test_owns_generation_and_promotion_against_one_frozen_benchmark(self):
+    def test_owns_generation_and_promotion_against_one_frozen_evaluation(self):
         _, body = split_skill(EVOLVE)
         combined = body + read(EVOLVE_GENERATION)
         contract = normalized(combined)
         for required in (
             "generation direction",
-            "incumbent score card",
-            "judge-owned incumbent score card",
-            # Sealing goes; freezing the benchmark for the campaign's duration
-            # does not. A campaign comparing candidates across a moving
-            # benchmark measures nothing.
-            "freeze the benchmark revision",
+            "score the fixed incumbent",
+            "frozen evaluation",
+            "freeze the evaluation identity",
             "result/evidence identity",
+            "evaluation mode",
             "runner",
             "scoring",
             "protected evidence policy",
@@ -209,7 +209,7 @@ class TestFrozenBenchmarkEvolution(unittest.TestCase):
             "new campaign",
             "retained candidate",
             "blocked partial result",
-            "separate benchmaker run",
+            "evaluation-design gap",
         ):
             self.assertIn(required, contract)
 
@@ -218,10 +218,10 @@ class TestFrozenBenchmarkEvolution(unittest.TestCase):
             if "runner" in sentence:
                 self.assertNotIn("score card", sentence)
         self.assertNotIn("orch-bench", calls)
-        self.assertNotIn("orch-eval-design", calls)
         self.assertNotIn("orch-benchmaker", calls)
         self.assertTrue(
             {
+                "orch-eval-design",
                 "orch-loop",
                 "orch-delegate",
                 "orch-integrate",
@@ -233,6 +233,32 @@ class TestFrozenBenchmarkEvolution(unittest.TestCase):
             }
             <= calls
         )
+
+    def test_missing_evaluation_defaults_to_a_frozen_judge_brief(self):
+        _, body = split_skill(EVOLVE)
+        combined = normalized(body + read(EVOLVE_GENERATION))
+        self.assertTrue(EVOLVE_EVALUATION.is_file())
+        mapping = normalized(read(EVOLVE_EVALUATION))
+        self.assertIn("when no frozen evaluation is supplied", combined)
+        self.assertIn("candidate-blind judge brief", combined)
+        self.assertIn("before generation", combined)
+        self.assertIn("frozen panel binding before the first plan", combined)
+        self.assertIn("score card identity and complete numeric dimension vector", combined)
+        self.assertIn("benchmark mode", combined)
+        self.assertIn("judged mode", combined)
+        self.assertIn("never: change evaluation after campaign open", combined)
+        self.assertNotIn("`orch-benchmaker`", combined)
+        for carrier in (
+            "`objective`",
+            "`inputs`",
+            "`authority`",
+            "`bounds`",
+            "`return_contract`",
+            "`reply_to`",
+        ):
+            self.assertIn(carrier, mapping)
+        self.assertIn("evaluation-design write scope", mapping)
+        self.assertIn("candidate mutation authority", mapping)
 
     def test_skill_tournament_campaigns_over_one_fixed_benchmark_revision(self):
         fields, body = split_skill(TOURNAMENT)
@@ -280,7 +306,15 @@ class TestPanelPacketShape(unittest.TestCase):
         self.assertIn("exactly one fixed candidate identity", active_procedure)
         self.assertIn("frozen scoring criteria", active_procedure)
         self.assertIn("exact result/evidence identity", active_procedure)
-        self.assertIn("frozen benchmark and scoring identities", active_procedure)
+        self.assertIn("frozen evaluation and scoring identities", active_procedure)
+        self.assertIn("frozen evaluation mode", active_procedure)
+        self.assertIn("frozen candidate-blind judge brief", active_procedure)
+        self.assertIn(
+            "carry the frozen candidate-blind judge brief verbatim",
+            active_procedure,
+        )
+        self.assertIn("static artifact snapshot", active_procedure)
+        self.assertNotIn("render one candidate-blind judge brief", active_procedure)
         self.assertIn("score card citing the exact evidence identity", active_procedure)
         self.assertNotIn("candidate set as the packet", active_procedure)
         self.assertEqual(
@@ -303,6 +337,7 @@ class TestPanelPacketShape(unittest.TestCase):
         self.assertIn("aggregate exactly by the declared method", active_procedure)
         self.assertIn("disagreement", active_procedure)
         never = normalized(paragraph(body, "Never:"))
+        self.assertIn("replace or alter the frozen brief", never)
         self.assertIn("change the aggregation method", never)
         self.assertIn("drop a dissenting lane", never)
         self.assertIn("re-execute or substitute admitted evidence", never)

--- a/tests/test_benchmark_architecture.py
+++ b/tests/test_benchmark_architecture.py
@@ -11,6 +11,7 @@ OLD_BENCH = ROOT / "skills" / "workflows" / "orch-bench"
 OLD_EVOLVE = ROOT / "skills" / "workflows" / "orch-evolve"
 # Demoted per contracts/composition.md: evolve is a named composition.
 EVOLVE = ROOT / "compositions" / "evolve.md"
+EVOLVE_GENERATION = ROOT / "compositions" / "references" / "evolve-generation.md"
 TOURNAMENT = ROOT / "compositions" / "skill-tournament.md"
 PANEL = ROOT / "skills" / "engines" / "orch-panel" / "SKILL.md"
 
@@ -175,8 +176,9 @@ class TestFrozenBenchmarkEvolution(unittest.TestCase):
 
     def test_verifies_required_eligibility_before_ranking_survivors(self):
         _, body = split_skill(EVOLVE)
-        self.assertLess(body.index("`orch-verify`"), body.index("`orch-panel`"))
-        contract = normalized(body)
+        combined = body + read(EVOLVE_GENERATION)
+        self.assertLess(combined.index("`orch-verify`"), combined.index("`orch-panel`"))
+        contract = normalized(combined)
         self.assertIn("required eligibility", contract)
         self.assertIn("verified survivors", contract)
         self.assertIn("required deterministic", contract)
@@ -186,7 +188,8 @@ class TestFrozenBenchmarkEvolution(unittest.TestCase):
 
     def test_owns_generation_and_promotion_against_one_frozen_benchmark(self):
         _, body = split_skill(EVOLVE)
-        contract = normalized(body)
+        combined = body + read(EVOLVE_GENERATION)
+        contract = normalized(combined)
         for required in (
             "generation direction",
             "incumbent score card",
@@ -210,7 +213,7 @@ class TestFrozenBenchmarkEvolution(unittest.TestCase):
         ):
             self.assertIn(required, contract)
 
-        calls = set(CALL_EDGE_RE.findall(body))
+        calls = set(CALL_EDGE_RE.findall(combined))
         for sentence in re.split(r"(?<=[.!?])\s+", normalized(procedure(body))):
             if "runner" in sentence:
                 self.assertNotIn("score card", sentence)
@@ -225,6 +228,8 @@ class TestFrozenBenchmarkEvolution(unittest.TestCase):
                 "orch-verify",
                 "orch-panel",
                 "orch-judge",
+                "orch-search-plan",
+                "orch-worklog",
             }
             <= calls
         )
@@ -241,17 +246,25 @@ class TestFrozenBenchmarkEvolution(unittest.TestCase):
         self.assertNotIn("seal", contract)
         # A done check naming something a run can check.
         done = normalized(paragraph(body, "Done check:"))
-        self.assertIn("closing score card", done)
+        self.assertIn("final score card", done)
         self.assertIn("benchmark revision", done)
+        self.assertEqual(
+            set(),
+            set(CALL_EDGE_RE.findall(body)),
+            "Tournament binds Evolve and its writer, never Evolve internals",
+        )
+        self.assertIn("writer binding orch-build", contract)
+        self.assertNotIn("promotion", contract)
 
-    def test_judged_done_check_gets_a_fresh_closing_score_card(self):
+    def test_loop_supplies_the_fresh_final_score_card_without_a_wrapper(self):
         _, body = split_skill(EVOLVE)
-        self.assertLess(body.index("`orch-panel`"), body.index("`orch-judge`"))
-        contract = normalized(body)
-        self.assertIn("judged done-check pass is provisional", contract)
+        combined = body + read(EVOLVE_GENERATION)
+        self.assertLess(combined.index("`orch-panel`"), combined.index("`orch-judge`"))
+        contract = normalized(combined)
         self.assertIn("final incumbent identity", contract)
-        self.assertIn("fresh `orch-judge`", contract)
-        self.assertIn("closing score card", contract)
+        self.assertIn("fresh `orch-judge` done-check", contract)
+        self.assertIn("final score card", contract)
+        self.assertNotRegex(body, r"(?im)^-\s*closing\b")
 
 
 class TestPanelPacketShape(unittest.TestCase):

--- a/tests/test_roles.py
+++ b/tests/test_roles.py
@@ -38,6 +38,7 @@ ROLE_TABLE = {
     "orch-worklog": "none",
     # none: named utility
     "orch-off": "none",
+    "orch-search-plan": "none",
     # planner
     "orch-critique": "planner",
     "orch-judge": "planner",

--- a/tests/test_search_plan.py
+++ b/tests/test_search_plan.py
@@ -192,6 +192,28 @@ def admitted_outcome(slot, candidate, quality, cost, suffix=None):
     }
 
 
+def ineligible_outcome(slot, candidate, suffix=None):
+    suffix = suffix or candidate.rsplit(":", 1)[-1]
+    return {
+        "kind": "ineligible",
+        "outcome_identity": f"outcome:{suffix}",
+        "slot_identity": slot["identity"],
+        "cost": {"runs": 1},
+        "candidate_identity": candidate,
+        "parent_identities": copy.deepcopy(slot["parent_identities"]),
+        "target_owner_identity": slot["target_owner_identity"],
+        "mutation_surface_identities": copy.deepcopy(
+            slot["mutation_surface_identities"]
+        ),
+        "benchmark_revision": slot["benchmark_revision"],
+        "result_identity": f"result:{suffix}",
+        "evidence_identity": f"evidence:{suffix}",
+        "eligibility_status": "FAIL",
+        "eligibility_verdict_identity": f"verdict:{suffix}",
+        "disposition": "failed-required-check",
+    }
+
+
 def settled_request(policy, response, outcomes, preferred, remaining=20):
     return {
         "policy": copy.deepcopy(policy),
@@ -532,6 +554,174 @@ class TestParetoReflection(unittest.TestCase):
                 ]
         response = self.run_ok(request)
         self.assertNotIn("candidate:dominated", response["projection"]["archive"])
+
+
+class TestMergeLineage(unittest.TestCase):
+    def run_ok(self, request):
+        result = run_advance(request)
+        self.assertEqual(0, result.returncode, result.stderr.decode())
+        self.assertEqual(b"", result.stderr)
+        return json.loads(result.stdout)
+
+    def assert_rejected(self, request):
+        result = run_advance(request)
+        self.assertEqual(2, result.returncode)
+        self.assertEqual(b"", result.stdout)
+
+    def merge_fixture(self):
+        initial_request = two_dimension_request()
+        initial = self.run_ok(initial_request)
+        slots = initial["plan"]["slots"]
+        outcomes = [
+            admitted_outcome(slots[0], "candidate:a", "0.8", "0.6", "a"),
+            admitted_outcome(slots[1], "candidate:b", "0.4", "0.2", "b"),
+            admitted_outcome(slots[2], "candidate:dominated", "0.3", "0.8", "d"),
+        ]
+        request = settled_request(
+            initial_request["policy"],
+            initial,
+            outcomes,
+            "candidate:dominated",
+        )
+        return initial_request["policy"], self.run_ok(request)
+
+    def test_complementary_merge_and_complete_fresh_lineage(self):
+        policy, generation_two = self.merge_fixture()
+        slots = generation_two["plan"]["slots"]
+        self.assertEqual(["reflect", "reflect", "merge"], [s["kind"] for s in slots])
+        merge = slots[-1]
+        self.assertEqual(2, len(merge["parent_identities"]))
+        self.assertEqual(
+            {"dimension:quality", "dimension:cost"},
+            set(merge["complementary_dimension_identities"]),
+        )
+
+        outcomes = [
+            admitted_outcome(slots[0], "candidate:reflected", "0.7", "0.4", "r"),
+            ineligible_outcome(slots[1], "candidate:ineligible", "i"),
+            admitted_outcome(merge, "candidate:merged", "0.9", "0.1", "m"),
+        ]
+        request = settled_request(
+            policy, generation_two, outcomes, "candidate:merged"
+        )
+        advanced = self.run_ok(request)
+        nodes = advanced["projection"]["nodes"]
+        self.assertEqual(7, len(nodes))
+        self.assertIn("candidate:ineligible", [node["candidate_identity"] for node in nodes])
+        self.assertNotIn("candidate:ineligible", advanced["projection"]["archive"])
+        seen = set()
+        for node in nodes:
+            self.assertTrue(set(node["parent_identities"]) <= seen)
+            self.assertNotIn(node["candidate_identity"], seen)
+            seen.add(node["candidate_identity"])
+
+        merged = next(node for node in nodes if node["candidate_identity"] == "candidate:merged")
+        parents = [
+            node for node in nodes if node["candidate_identity"] in merged["parent_identities"]
+        ]
+        for field in (
+            "candidate_identity",
+            "result_identity",
+            "evidence_identity",
+            "eligibility_verdict_identity",
+            "score_card_identity",
+        ):
+            self.assertNotIn(merged[field], [parent[field] for parent in parents])
+
+        for slot in generation_two["plan"]["slots"]:
+            self.assertEqual(
+                slot["identity"],
+                tagged_identity(
+                    "search-slot/v1",
+                    {key: value for key, value in slot.items() if key != "identity"},
+                ),
+            )
+            self.assertNotIn("plan_identity", slot)
+        self.assertEqual(
+            generation_two["plan"]["identity"],
+            tagged_identity(
+                "search-plan/v1",
+                {
+                    key: value
+                    for key, value in generation_two["plan"].items()
+                    if key != "identity"
+                },
+            ),
+        )
+        projection = advanced["projection"]
+        self.assertEqual(
+            projection["identity"],
+            tagged_identity(
+                "search-projection/v1",
+                {key: value for key, value in projection.items() if key != "identity"},
+            ),
+        )
+
+    def test_settlement_is_exact_and_atomic(self):
+        policy, generation_two = self.merge_fixture()
+        slots = generation_two["plan"]["slots"]
+        partial = settled_request(
+            policy,
+            generation_two,
+            [admitted_outcome(slots[0], "candidate:partial", "0.6", "0.4", "p")],
+            "candidate:partial",
+        )
+        pending = self.run_ok(partial)
+        self.assertEqual("pending", pending["status"])
+        self.assertEqual(generation_two["projection"], pending["projection"])
+        self.assertEqual(
+            generation_two["projection"]["identity"],
+            pending["output_projection_identity"],
+        )
+        self.assertIsNone(pending["plan"])
+        self.assertEqual([slot["identity"] for slot in slots[1:]], pending["missing_slot_identities"])
+
+        malformed = copy.deepcopy(partial)
+        malformed["settled"]["atomic"] = True
+        self.assert_rejected(malformed)
+
+    def test_cycle_dangling_reuse_and_inherited_score_are_rejected(self):
+        policy, generation_two = self.merge_fixture()
+        slots = generation_two["plan"]["slots"]
+        outcomes = [
+            admitted_outcome(slots[0], "candidate:reflected", "0.7", "0.4", "r"),
+            ineligible_outcome(slots[1], "candidate:ineligible", "i"),
+            admitted_outcome(slots[2], "candidate:merged", "0.9", "0.1", "m"),
+        ]
+
+        reused = settled_request(policy, generation_two, outcomes, "candidate:merged")
+        reused["settled"]["outcomes"][0]["candidate_identity"] = "candidate:origin"
+        self.assert_rejected(reused)
+
+        inherited = settled_request(policy, generation_two, outcomes, "candidate:merged")
+        merge_outcome = inherited["settled"]["outcomes"][2]
+        parent_identity = merge_outcome["parent_identities"][0]
+        parent = next(
+            node
+            for node in inherited["projection"]["nodes"]
+            if node["candidate_identity"] == parent_identity
+        )
+        merge_outcome["score_card_identity"] = parent["score_card_identity"]
+        self.assert_rejected(inherited)
+
+        valid = settled_request(policy, generation_two, outcomes, "candidate:merged")
+        advanced = self.run_ok(valid)
+        for replacement in ("candidate:missing", "candidate:merged"):
+            broken = copy.deepcopy(advanced)
+            broken_node = broken["projection"]["nodes"][1]
+            broken_node["parent_identities"] = [replacement]
+            payload = {
+                key: value
+                for key, value in broken["projection"].items()
+                if key != "identity"
+            }
+            broken["projection"]["identity"] = tagged_identity(
+                "search-projection/v1", payload
+            )
+            next_request = settled_request(
+                policy, broken, [], "candidate:merged"
+            )
+            self.assert_rejected(next_request)
 
 
 if __name__ == "__main__":

--- a/tests/test_search_plan.py
+++ b/tests/test_search_plan.py
@@ -1,0 +1,107 @@
+"""Public-seam checks for deterministic search planning."""
+
+from pathlib import Path
+import re
+import unittest
+
+
+ROOT = Path(__file__).resolve().parents[1]
+EVOLVE = ROOT / "compositions" / "evolve.md"
+EVOLVE_GENERATION = ROOT / "compositions" / "references" / "evolve-generation.md"
+TOURNAMENT = ROOT / "compositions" / "skill-tournament.md"
+SEARCH_SKILL = ROOT / "skills" / "utilities" / "orch-search-plan" / "SKILL.md"
+SEARCH_SCRIPT = (
+    ROOT
+    / "skills"
+    / "utilities"
+    / "orch-search-plan"
+    / "scripts"
+    / "search_plan.py"
+)
+
+CALL_EDGE_RE = re.compile(r"`(orch-[a-z0-9-]+)`")
+
+
+def read(path: Path) -> str:
+    return path.read_text(encoding="utf-8")
+
+
+def normalized(text: str) -> str:
+    return " ".join(text.lower().split())
+
+
+def architecture_errors(evolve: str, generation: str, tournament: str, leaf: str):
+    errors = []
+    combined_evolve = evolve + generation
+    evolve_calls = set(CALL_EDGE_RE.findall(combined_evolve))
+    required = {
+        "orch-delegate",
+        "orch-integrate",
+        "orch-judge",
+        "orch-loop",
+        "orch-panel",
+        "orch-search-plan",
+        "orch-verify",
+        "orch-worklog",
+    }
+    if not required <= evolve_calls:
+        errors.append("evolve-call-graph")
+    if re.search(r"^-\s*closing\b", evolve, re.IGNORECASE | re.MULTILINE):
+        errors.append("closing-wrapper")
+    if normalized(combined_evolve).count("`orch-judge`") != 1:
+        errors.append("judge-owner")
+
+    tournament_calls = set(CALL_EDGE_RE.findall(tournament))
+    if tournament_calls:
+        errors.append("tournament-internal-call")
+    if "writer binding orch-build" not in normalized(tournament):
+        errors.append("tournament-writer-binding")
+    if "promotion" in normalized(tournament):
+        errors.append("tournament-promotion")
+
+    leaf_calls = set(CALL_EDGE_RE.findall(leaf)) - {"orch-search-plan"}
+    if leaf_calls:
+        errors.append("leaf-call")
+    return errors
+
+
+class TestArchitecture(unittest.TestCase):
+    def test_thin_evolve_owns_one_campaign_call_graph(self):
+        for path in (EVOLVE, EVOLVE_GENERATION, TOURNAMENT, SEARCH_SKILL, SEARCH_SCRIPT):
+            self.assertTrue(path.is_file(), f"missing search-planning surface: {path}")
+
+        evolve = read(EVOLVE)
+        generation = read(EVOLVE_GENERATION)
+        tournament = read(TOURNAMENT)
+        leaf = read(SEARCH_SKILL)
+        self.assertEqual([], architecture_errors(evolve, generation, tournament, leaf))
+        self.assertIn("role: none", leaf)
+        command = "python skills/utilities/orch-search-plan/scripts/search_plan.py advance"
+        self.assertEqual(1, leaf.count(command))
+        self.assertNotIn("operation registry", normalized(leaf))
+
+    def test_known_wrong_ownership_fixtures_are_rejected(self):
+        evolve = read(EVOLVE)
+        generation = read(EVOLVE_GENERATION)
+        tournament = read(TOURNAMENT)
+        leaf = read(SEARCH_SKILL)
+
+        closing = evolve + "\n- closing — a fresh `orch-judge` wrapper.\n"
+        self.assertIn(
+            "closing-wrapper",
+            architecture_errors(closing, generation, tournament, leaf),
+        )
+        direct_panel = tournament + "\nDirectly call `orch-panel`.\n"
+        self.assertIn(
+            "tournament-internal-call",
+            architecture_errors(evolve, generation, direct_panel, leaf),
+        )
+        extra_leaf_call = leaf + "\nCall `orch-verify`.\n"
+        self.assertIn(
+            "leaf-call",
+            architecture_errors(evolve, generation, tournament, extra_leaf_call),
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_search_plan.py
+++ b/tests/test_search_plan.py
@@ -66,7 +66,7 @@ def generation_zero_request():
             "planner_revision": "git:planner-1",
             "target_owner_identity": "owner:fixture",
             "mutation_surface_identities": ["surface:prompt"],
-            "benchmark_revision": "git:benchmark-1",
+            "evaluation_identity": "evaluation:judged-fixture",
             "scoring_identity": "scoring:fixture",
             "dimensions": [
                 {
@@ -96,7 +96,7 @@ def generation_zero_request():
         "parent_identities": [],
         "target_owner_identity": "owner:fixture",
         "mutation_surface_identities": ["surface:prompt"],
-        "benchmark_revision": "git:benchmark-1",
+        "evaluation_identity": "evaluation:judged-fixture",
         "result_identity": "result:origin",
         "evidence_identity": "evidence:origin",
         "eligibility_status": "PASS",
@@ -176,7 +176,7 @@ def admitted_outcome(slot, candidate, quality, cost, suffix=None):
         "mutation_surface_identities": copy.deepcopy(
             slot["mutation_surface_identities"]
         ),
-        "benchmark_revision": slot["benchmark_revision"],
+        "evaluation_identity": slot["evaluation_identity"],
         "result_identity": f"result:{suffix}",
         "evidence_identity": f"evidence:{suffix}",
         "eligibility_status": "PASS",
@@ -214,7 +214,7 @@ def ineligible_outcome(slot, candidate, suffix=None):
         "mutation_surface_identities": copy.deepcopy(
             slot["mutation_surface_identities"]
         ),
-        "benchmark_revision": slot["benchmark_revision"],
+        "evaluation_identity": slot["evaluation_identity"],
         "result_identity": f"result:{suffix}",
         "evidence_identity": f"evidence:{suffix}",
         "eligibility_status": "FAIL",
@@ -367,6 +367,7 @@ def architecture_errors(evolve: str, generation: str, tournament: str, leaf: str
     evolve_calls = Counter(CALL_EDGE_RE.findall(combined_evolve))
     required = {
         "orch-delegate",
+        "orch-eval-design",
         "orch-integrate",
         "orch-judge",
         "orch-loop",
@@ -416,6 +417,14 @@ class TestArchitecture(unittest.TestCase):
         command = "python skills/utilities/orch-search-plan/scripts/search_plan.py advance"
         self.assertEqual(1, leaf.count(command))
         self.assertNotIn("operation registry", normalized(leaf))
+
+    def test_planner_is_evaluation_mode_agnostic(self):
+        protocol = read(SEARCH_PROTOCOL)
+        script = read(SEARCH_SCRIPT)
+        self.assertIn("evaluation_identity", protocol)
+        self.assertIn('"evaluation_identity"', script)
+        self.assertNotIn("benchmark_revision", protocol)
+        self.assertNotIn('"benchmark_revision"', script)
 
     def test_known_wrong_ownership_fixtures_are_rejected(self):
         evolve = read(EVOLVE)
@@ -513,6 +522,40 @@ class TestCanonicalAdvance(unittest.TestCase):
                 {key: value for key, value in slot.items() if key != "identity"},
             ),
         )
+
+    def test_opaque_evaluation_identity_has_no_mode_branch(self):
+        judged = generation_zero_request()
+        benchmark = copy.deepcopy(judged)
+        benchmark["policy"]["evaluation_identity"] = "evaluation:benchmark-fixture"
+        benchmark["policy"]["identity"] = tagged_identity(
+            "search-policy/v1",
+            {
+                key: value
+                for key, value in benchmark["policy"].items()
+                if key != "identity"
+            },
+        )
+        benchmark["settled"]["outcomes"][0]["evaluation_identity"] = (
+            "evaluation:benchmark-fixture"
+        )
+
+        judged_result = run_advance(judged)
+        benchmark_result = run_advance(benchmark)
+        self.assertEqual(0, judged_result.returncode, judged_result.stderr.decode())
+        self.assertEqual(0, benchmark_result.returncode, benchmark_result.stderr.decode())
+        judged_response = json.loads(judged_result.stdout)
+        benchmark_response = json.loads(benchmark_result.stdout)
+        self.assertEqual(judged_response["status"], benchmark_response["status"])
+        self.assertEqual(
+            [slot["kind"] for slot in judged_response["plan"]["slots"]],
+            [slot["kind"] for slot in benchmark_response["plan"]["slots"]],
+        )
+
+        drift = copy.deepcopy(judged)
+        drift["settled"]["outcomes"][0]["evaluation_identity"] = (
+            "evaluation:benchmark-fixture"
+        )
+        self.assert_rejected(drift)
 
     def test_closed_schema_identity_numeric_and_reference_failures_exit_two(self):
         cases = []

--- a/tests/test_search_plan.py
+++ b/tests/test_search_plan.py
@@ -2,7 +2,13 @@
 
 from pathlib import Path
 from collections import Counter
+import copy
+import hashlib
+import json
 import re
+import subprocess
+import sys
+import tempfile
 import unittest
 
 
@@ -21,6 +27,115 @@ SEARCH_SCRIPT = (
 )
 
 CALL_EDGE_RE = re.compile(r"`(orch-[a-z0-9-]+)`")
+
+
+def canonical_bytes(value):
+    return json.dumps(
+        value,
+        ensure_ascii=False,
+        separators=(",", ":"),
+        sort_keys=True,
+    ).encode("utf-8")
+
+
+def tagged_identity(tag, payload):
+    digest = hashlib.sha256(tag.encode("utf-8") + b"\0" + canonical_bytes(payload))
+    return "sha256:" + digest.hexdigest()
+
+
+def with_identity(tag, payload):
+    value = copy.deepcopy(payload)
+    value["identity"] = tagged_identity(tag, payload)
+    return value
+
+
+def generation_zero_request():
+    policy = with_identity(
+        "search-policy/v1",
+        {
+            "schema": "search-policy/v1",
+            "planner_revision": "git:planner-1",
+            "target_owner_identity": "owner:fixture",
+            "mutation_surface_identities": ["surface:prompt"],
+            "benchmark_revision": "git:benchmark-1",
+            "scoring_identity": "scoring:fixture",
+            "dimensions": [
+                {
+                    "identity": "dimension:quality",
+                    "direction": "maximize",
+                    "source_identity": "source:public-score",
+                    "resolution": "0.1",
+                }
+            ],
+            "feedback_source_identities": ["source:public-feedback"],
+            "ordering_seed": "seed:fixture",
+            "generation_width": 1,
+            "merge_slots": 0,
+            "bound_unit_names": ["runs"],
+            "reservations": {
+                "reflect": {"runs": 1},
+                "merge": {"runs": 2},
+            },
+        },
+    )
+    origin = {
+        "kind": "admitted",
+        "outcome_identity": "outcome:origin",
+        "slot_identity": None,
+        "cost": {"runs": 0},
+        "candidate_identity": "candidate:origin",
+        "parent_identities": [],
+        "target_owner_identity": "owner:fixture",
+        "mutation_surface_identities": ["surface:prompt"],
+        "benchmark_revision": "git:benchmark-1",
+        "result_identity": "result:origin",
+        "evidence_identity": "evidence:origin",
+        "eligibility_status": "PASS",
+        "eligibility_verdict_identity": "verdict:origin",
+        "score_card_identity": "score-card:origin",
+        "dimension_vector": [
+            {"identity": "dimension:quality", "value": "0.5"}
+        ],
+        "feedback": [
+            {
+                "source_identity": "source:public-feedback",
+                "dimension_identity": "dimension:quality",
+                "reference_identity": "feedback:origin",
+            }
+        ],
+    }
+    return {
+        "policy": policy,
+        "projection": None,
+        "settled": {
+            "preferred_incumbent_identity": "candidate:origin",
+            "outcomes": [origin],
+        },
+        "remaining_bound": {"runs": 1},
+    }
+
+
+def reverse_object_keys(value):
+    if isinstance(value, dict):
+        return {
+            key: reverse_object_keys(value[key])
+            for key in reversed(list(value))
+        }
+    if isinstance(value, list):
+        return [reverse_object_keys(item) for item in value]
+    return value
+
+
+def run_advance(payload=None, raw=None, cwd=None):
+    data = raw if raw is not None else canonical_bytes(payload)
+    return subprocess.run(
+        [sys.executable, str(SEARCH_SCRIPT), "advance"],
+        input=data,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        cwd=cwd,
+        check=False,
+    )
 
 
 def read(path: Path) -> str:
@@ -102,6 +217,119 @@ class TestArchitecture(unittest.TestCase):
             "leaf-call",
             architecture_errors(evolve, generation, tournament, extra_leaf_call),
         )
+
+
+class TestCanonicalAdvance(unittest.TestCase):
+    def assert_rejected(self, payload=None, raw=None):
+        result = run_advance(payload=payload, raw=raw)
+        self.assertEqual(2, result.returncode)
+        self.assertEqual(b"", result.stdout)
+        self.assertTrue(result.stderr.startswith(b"search-plan: "))
+        self.assertLessEqual(len(result.stderr), 512)
+
+    def test_generation_zero_is_byte_stable_and_read_only(self):
+        request = generation_zero_request()
+        with tempfile.TemporaryDirectory() as directory:
+            first = run_advance(request, cwd=directory)
+            second = run_advance(reverse_object_keys(request), cwd=directory)
+            self.assertEqual([], list(Path(directory).iterdir()))
+
+        self.assertEqual(0, first.returncode, first.stderr.decode())
+        self.assertEqual(b"", first.stderr)
+        self.assertEqual(first.stdout, second.stdout)
+        self.assertTrue(first.stdout.endswith(b"\n"))
+        self.assertNotEqual(b"\n\n", first.stdout[-2:])
+
+        response = json.loads(first.stdout)
+        self.assertEqual("search-advance/v1", response["schema"])
+        self.assertEqual("planned", response["status"])
+        self.assertIsNone(response["input_projection_identity"])
+        self.assertEqual([], response["missing_slot_identities"])
+        self.assertEqual([], response["diagnostics"])
+
+        projection = response["projection"]
+        plan = response["plan"]
+        self.assertEqual(projection["identity"], response["output_projection_identity"])
+        self.assertEqual(
+            projection["identity"],
+            tagged_identity(
+                "search-projection/v1",
+                {key: value for key, value in projection.items() if key != "identity"},
+            ),
+        )
+        self.assertEqual(
+            plan["identity"],
+            tagged_identity(
+                "search-plan/v1",
+                {key: value for key, value in plan.items() if key != "identity"},
+            ),
+        )
+        self.assertEqual(0, projection["last_settled_generation"])
+        self.assertEqual(plan, projection["last_plan"])
+        self.assertEqual(["candidate:origin"], projection["archive"])
+        self.assertEqual([request["settled"]["outcomes"][0]], projection["nodes"])
+        self.assertEqual(["outcome:origin"], plan["basis_outcome_identities"])
+        self.assertEqual(1, plan["generation"])
+
+        self.assertEqual(1, len(plan["slots"]))
+        slot = plan["slots"][0]
+        self.assertEqual("reflect", slot["kind"])
+        self.assertEqual(["candidate:origin"], slot["parent_identities"])
+        self.assertEqual("dimension:quality", slot["focus_dimension_identity"])
+        self.assertEqual([], slot["complementary_dimension_identities"])
+        self.assertEqual({"runs": 1}, slot["reservation"])
+        self.assertEqual(request["settled"]["outcomes"][0]["feedback"], slot["feedback"])
+        self.assertEqual(
+            slot["identity"],
+            tagged_identity(
+                "search-slot/v1",
+                {key: value for key, value in slot.items() if key != "identity"},
+            ),
+        )
+
+    def test_closed_schema_identity_numeric_and_reference_failures_exit_two(self):
+        cases = []
+
+        protected = generation_zero_request()
+        protected["settled"]["outcomes"][0]["protected_locator"] = "secret:item"
+        cases.append(protected)
+
+        feedback = generation_zero_request()
+        feedback["settled"]["outcomes"][0]["feedback"][0][
+            "source_identity"
+        ] = "source:held-back"
+        cases.append(feedback)
+
+        identity = generation_zero_request()
+        identity["policy"]["identity"] = "sha256:" + "0" * 64
+        cases.append(identity)
+
+        numeric = generation_zero_request()
+        numeric["policy"]["dimensions"][0]["resolution"] = "0.10"
+        numeric["policy"]["identity"] = tagged_identity(
+            "search-policy/v1",
+            {key: value for key, value in numeric["policy"].items() if key != "identity"},
+        )
+        cases.append(numeric)
+
+        reference = generation_zero_request()
+        reference["settled"]["preferred_incumbent_identity"] = "candidate:absent"
+        cases.append(reference)
+
+        for case in cases:
+            with self.subTest(case=cases.index(case)):
+                self.assert_rejected(case)
+
+        floating = generation_zero_request()
+        floating["remaining_bound"]["runs"] = 1.0
+        self.assert_rejected(floating)
+
+        duplicate = canonical_bytes(generation_zero_request()).replace(
+            b'"projection":null',
+            b'"projection":null,"projection":null',
+            1,
+        )
+        self.assert_rejected(raw=duplicate)
 
 
 if __name__ == "__main__":

--- a/tests/test_search_plan.py
+++ b/tests/test_search_plan.py
@@ -275,6 +275,42 @@ def worklog_restart_errors(generation: str):
     return errors
 
 
+def plan_shape(response):
+    return [
+        {
+            key: copy.deepcopy(value)
+            for key, value in slot.items()
+            if key not in {"identity", "target_owner_identity"}
+        }
+        for slot in response["plan"]["slots"]
+    ]
+
+
+def recursive_target_errors(evolve: str, generation: str, tournament: str):
+    evolve_contract = normalized(evolve)
+    generation_contract = normalized(generation)
+    tournament_contract = normalized(tournament)
+    errors = []
+    if (
+        "active controller and planner revisions remain outside candidate mutation authority"
+        not in generation_contract
+    ):
+        errors.append("active-revision-authority")
+    if (
+        "a self-target candidate remains non-control and cannot become the active campaign "
+        "controller or planner"
+        not in generation_contract
+    ):
+        errors.append("self-target-control")
+    if (
+        "activate a selected candidate" not in evolve_contract
+        or "selected result is never activated by this campaign" not in generation_contract
+        or "separate authorized integration before activation" not in tournament_contract
+    ):
+        errors.append("activation")
+    return errors
+
+
 def architecture_errors(evolve: str, generation: str, tournament: str, leaf: str):
     errors = []
     combined_evolve = evolve + generation
@@ -881,6 +917,106 @@ class TestBoundedResume(unittest.TestCase):
         for expected, wrong in controls.items():
             with self.subTest(control=expected):
                 self.assertIn(expected, worklog_restart_errors(wrong))
+
+
+class TestVisibilityAndSelfTarget(unittest.TestCase):
+    def run_ok(self, request):
+        result = run_advance(request)
+        self.assertEqual(0, result.returncode, result.stderr.decode())
+        self.assertEqual(b"", result.stderr)
+        return json.loads(result.stdout)
+
+    def assert_rejected(self, request):
+        result = run_advance(request)
+        self.assertEqual(2, result.returncode)
+        self.assertEqual(b"", result.stdout)
+
+    def test_closed_schema_rejects_protected_inputs(self):
+        cases = []
+
+        request_field = generation_zero_request()
+        request_field["protected_locator"] = "protected:item"
+        cases.append(request_field)
+
+        policy_field = generation_zero_request()
+        policy_field["policy"]["held_back_result_identity"] = "result:held-back"
+        cases.append(policy_field)
+
+        outcome_field = generation_zero_request()
+        outcome_field["settled"]["outcomes"][0][
+            "closing_verdict_identity"
+        ] = "verdict:closing"
+        cases.append(outcome_field)
+
+        feedback_field = generation_zero_request()
+        feedback_field["settled"]["outcomes"][0]["feedback"][0][
+            "protected_derived"
+        ] = True
+        cases.append(feedback_field)
+
+        for case in cases:
+            with self.subTest(field=cases.index(case)):
+                self.assert_rejected(case)
+
+    def test_target_renaming_preserves_plan_shape(self):
+        original_request = two_dimension_request()
+        original = self.run_ok(original_request)
+
+        renamed_request = copy.deepcopy(original_request)
+        renamed_request["policy"]["target_owner_identity"] = "owner:self-target"
+        renamed_request["policy"]["identity"] = tagged_identity(
+            "search-policy/v1",
+            {
+                key: value
+                for key, value in renamed_request["policy"].items()
+                if key != "identity"
+            },
+        )
+        renamed_request["settled"]["outcomes"][0][
+            "target_owner_identity"
+        ] = "owner:self-target"
+        renamed = self.run_ok(renamed_request)
+
+        self.assertEqual(plan_shape(original), plan_shape(renamed))
+        self.assertNotEqual(original["plan"]["identity"], renamed["plan"]["identity"])
+
+        target_branched = copy.deepcopy(renamed)
+        target_branched["plan"]["slots"][0][
+            "focus_dimension_identity"
+        ] = "dimension:target-special"
+        with self.assertRaises(AssertionError):
+            self.assertEqual(plan_shape(original), plan_shape(target_branched))
+
+    def test_recursive_target_authority_and_activation_have_failure_controls(self):
+        evolve = read(EVOLVE)
+        generation = read(EVOLVE_GENERATION)
+        tournament = read(TOURNAMENT)
+        self.assertEqual([], recursive_target_errors(evolve, generation, tournament))
+
+        controls = {
+            "active-revision-authority": generation.replace(
+                "remain outside candidate mutation authority",
+                "enter candidate mutation authority",
+            ),
+            "self-target-control": generation.replace(
+                "remains non-control and cannot become the active campaign controller or planner",
+                "becomes the active campaign controller",
+            ),
+            "activation": tournament.replace(
+                "separate authorized integration before activation",
+                "activation inside the campaign",
+            ),
+        }
+        for expected, wrong in controls.items():
+            with self.subTest(control=expected):
+                candidate_generation = wrong if expected != "activation" else generation
+                candidate_tournament = wrong if expected == "activation" else tournament
+                self.assertIn(
+                    expected,
+                    recursive_target_errors(
+                        evolve, candidate_generation, candidate_tournament
+                    ),
+                )
 
 
 if __name__ == "__main__":

--- a/tests/test_search_plan.py
+++ b/tests/test_search_plan.py
@@ -257,6 +257,24 @@ def normalized(text: str) -> str:
     return " ".join(text.lower().split())
 
 
+def worklog_restart_errors(generation: str):
+    contract = normalized(generation)
+    errors = []
+    if (
+        "latest worklog entry persists the accepted response's complete projection, "
+        "including every archive member"
+        not in contract
+    ):
+        errors.append("archive-persistence")
+    if "`in_flight` in the same worklog entry before delegation" not in contract:
+        errors.append("in-flight-order")
+    if "a `pending` response launches nothing" not in contract:
+        errors.append("pending-replan")
+    if "never redispatch a live slot" not in contract:
+        errors.append("duplicate-restart-dispatch")
+    return errors
+
+
 def architecture_errors(evolve: str, generation: str, tournament: str, leaf: str):
     errors = []
     combined_evolve = evolve + generation
@@ -722,6 +740,147 @@ class TestMergeLineage(unittest.TestCase):
                 policy, broken, [], "candidate:merged"
             )
             self.assert_rejected(next_request)
+
+
+class TestBoundedResume(unittest.TestCase):
+    def run_ok(self, request):
+        result = run_advance(request)
+        self.assertEqual(0, result.returncode, result.stderr.decode())
+        self.assertEqual(b"", result.stderr)
+        return json.loads(result.stdout)
+
+    def bounded_request(self, remaining):
+        request = generation_zero_request()
+        policy = request["policy"]
+        policy["generation_width"] = 3
+        policy["bound_unit_names"] = ["runs", "tokens"]
+        policy["reservations"] = {
+            "reflect": {"runs": 2, "tokens": 3},
+            "merge": {"runs": 1, "tokens": 1},
+        }
+        policy["identity"] = tagged_identity(
+            "search-policy/v1",
+            {key: value for key, value in policy.items() if key != "identity"},
+        )
+        request["settled"]["outcomes"][0]["cost"] = {"runs": 0, "tokens": 0}
+        request["remaining_bound"] = remaining
+        return request
+
+    def assert_within_bound(self, response, remaining):
+        spent = {unit: 0 for unit in remaining}
+        plan = response["plan"]
+        if plan is not None:
+            for slot in plan["slots"]:
+                for unit in remaining:
+                    spent[unit] += slot["reservation"][unit]
+        self.assertTrue(
+            all(spent[unit] <= remaining[unit] for unit in remaining),
+            f"reservation {spent} exceeds {remaining}",
+        )
+
+    def test_componentwise_maximal_prefix_exact_fit_and_no_fit(self):
+        for remaining in ({"runs": 4, "tokens": 100}, {"runs": 100, "tokens": 6}):
+            with self.subTest(remaining=remaining):
+                response = self.run_ok(self.bounded_request(remaining))
+                self.assertEqual("planned", response["status"])
+                self.assertEqual(2, len(response["plan"]["slots"]))
+                self.assert_within_bound(response, remaining)
+                reservation = response["plan"]["slots"][0]["reservation"]
+                spent = {
+                    unit: sum(slot["reservation"][unit] for slot in response["plan"]["slots"])
+                    for unit in remaining
+                }
+                self.assertTrue(
+                    any(spent[unit] + reservation[unit] > remaining[unit] for unit in remaining)
+                )
+
+        exact_bound = {"runs": 6, "tokens": 9}
+        exact = self.run_ok(self.bounded_request(exact_bound))
+        self.assertEqual(3, len(exact["plan"]["slots"]))
+        self.assert_within_bound(exact, exact_bound)
+        self.assertEqual(
+            exact_bound,
+            {
+                unit: sum(slot["reservation"][unit] for slot in exact["plan"]["slots"])
+                for unit in exact_bound
+            },
+        )
+
+        no_fit = self.run_ok(self.bounded_request({"runs": 1, "tokens": 100}))
+        self.assertEqual("no_fit", no_fit["status"])
+        self.assertIsNone(no_fit["plan"])
+        self.assertIsNone(no_fit["projection"]["last_plan"])
+        self.assertEqual(["candidate:origin"], no_fit["projection"]["archive"])
+
+        over_reserved = copy.deepcopy(exact)
+        over_reserved["plan"]["slots"].append(
+            copy.deepcopy(over_reserved["plan"]["slots"][-1])
+        )
+        with self.assertRaises(AssertionError):
+            self.assert_within_bound(over_reserved, exact_bound)
+
+    def test_partial_settlement_keeps_projection_and_complete_archive(self):
+        initial_request = two_dimension_request()
+        initial = self.run_ok(initial_request)
+        slots = initial["plan"]["slots"]
+        outcomes = [
+            admitted_outcome(slots[0], "candidate:a", "0.8", "0.6", "a"),
+            admitted_outcome(slots[1], "candidate:b", "0.4", "0.2", "b"),
+            admitted_outcome(slots[2], "candidate:dominated", "0.3", "0.8", "d"),
+        ]
+        generation_two = self.run_ok(
+            settled_request(
+                initial_request["policy"], initial, outcomes, "candidate:origin"
+            )
+        )
+        generation_two_slots = generation_two["plan"]["slots"]
+        partial = settled_request(
+            initial_request["policy"],
+            generation_two,
+            [
+                admitted_outcome(
+                    generation_two_slots[0], "candidate:partial", "0.7", "0.4", "p"
+                )
+            ],
+            "candidate:origin",
+        )
+        pending = self.run_ok(partial)
+        self.assertEqual("pending", pending["status"])
+        self.assertIsNone(pending["plan"])
+        self.assertEqual(generation_two["projection"], pending["projection"])
+        self.assertEqual(
+            generation_two["projection"]["archive"], pending["projection"]["archive"]
+        )
+        self.assertEqual(
+            [slot["identity"] for slot in generation_two_slots[1:]],
+            pending["missing_slot_identities"],
+        )
+
+    def test_worklog_launch_and_restart_contract_has_failure_controls(self):
+        generation = read(EVOLVE_GENERATION)
+        self.assertEqual([], worklog_restart_errors(generation))
+
+        controls = {
+            "archive-persistence": generation.replace(
+                "complete projection, including every archive member",
+                "projection without the full archive",
+            ),
+            "in-flight-order": generation.replace(
+                "same Worklog entry before delegation",
+                "same Worklog entry after delegation",
+            ),
+            "pending-replan": generation.replace(
+                "a `pending` response launches nothing",
+                "a `pending` response launches a replacement",
+            ),
+            "duplicate-restart-dispatch": generation.replace(
+                "never redispatch a live slot",
+                "redispatch a live slot",
+            ),
+        }
+        for expected, wrong in controls.items():
+            with self.subTest(control=expected):
+                self.assertIn(expected, worklog_restart_errors(wrong))
 
 
 if __name__ == "__main__":

--- a/tests/test_search_plan.py
+++ b/tests/test_search_plan.py
@@ -1,6 +1,7 @@
 """Public-seam checks for deterministic search planning."""
 
 from pathlib import Path
+from collections import Counter
 import re
 import unittest
 
@@ -33,7 +34,7 @@ def normalized(text: str) -> str:
 def architecture_errors(evolve: str, generation: str, tournament: str, leaf: str):
     errors = []
     combined_evolve = evolve + generation
-    evolve_calls = set(CALL_EDGE_RE.findall(combined_evolve))
+    evolve_calls = Counter(CALL_EDGE_RE.findall(combined_evolve))
     required = {
         "orch-delegate",
         "orch-integrate",
@@ -44,7 +45,7 @@ def architecture_errors(evolve: str, generation: str, tournament: str, leaf: str
         "orch-verify",
         "orch-worklog",
     }
-    if not required <= evolve_calls:
+    if evolve_calls != Counter({name: 1 for name in required}):
         errors.append("evolve-call-graph")
     if re.search(r"^-\s*closing\b", evolve, re.IGNORECASE | re.MULTILINE):
         errors.append("closing-wrapper")

--- a/tests/test_search_plan.py
+++ b/tests/test_search_plan.py
@@ -115,6 +115,95 @@ def generation_zero_request():
     }
 
 
+def two_dimension_request(width=3, merge_slots=1, resolution="0.1"):
+    request = generation_zero_request()
+    policy = request["policy"]
+    policy["dimensions"] = [
+        {
+            "identity": "dimension:quality",
+            "direction": "maximize",
+            "source_identity": "source:public-score",
+            "resolution": resolution,
+        },
+        {
+            "identity": "dimension:cost",
+            "direction": "minimize",
+            "source_identity": "source:public-cost",
+            "resolution": resolution,
+        },
+    ]
+    policy["generation_width"] = width
+    policy["merge_slots"] = merge_slots
+    policy["identity"] = tagged_identity(
+        "search-policy/v1",
+        {key: value for key, value in policy.items() if key != "identity"},
+    )
+    origin = request["settled"]["outcomes"][0]
+    origin["dimension_vector"] = [
+        {"identity": "dimension:quality", "value": "0.5"},
+        {"identity": "dimension:cost", "value": "0.5"},
+    ]
+    origin["feedback"].append(
+        {
+            "source_identity": "source:public-feedback",
+            "dimension_identity": "dimension:cost",
+            "reference_identity": "feedback:origin-cost",
+        }
+    )
+    request["remaining_bound"] = {"runs": width * 2}
+    return request
+
+
+def admitted_outcome(slot, candidate, quality, cost, suffix=None):
+    suffix = suffix or candidate.rsplit(":", 1)[-1]
+    return {
+        "kind": "admitted",
+        "outcome_identity": f"outcome:{suffix}",
+        "slot_identity": slot["identity"],
+        "cost": {"runs": 1},
+        "candidate_identity": candidate,
+        "parent_identities": copy.deepcopy(slot["parent_identities"]),
+        "target_owner_identity": slot["target_owner_identity"],
+        "mutation_surface_identities": copy.deepcopy(
+            slot["mutation_surface_identities"]
+        ),
+        "benchmark_revision": slot["benchmark_revision"],
+        "result_identity": f"result:{suffix}",
+        "evidence_identity": f"evidence:{suffix}",
+        "eligibility_status": "PASS",
+        "eligibility_verdict_identity": f"verdict:{suffix}",
+        "score_card_identity": f"score-card:{suffix}",
+        "dimension_vector": [
+            {"identity": "dimension:quality", "value": quality},
+            {"identity": "dimension:cost", "value": cost},
+        ],
+        "feedback": [
+            {
+                "source_identity": "source:public-feedback",
+                "dimension_identity": "dimension:quality",
+                "reference_identity": f"feedback:{suffix}-quality",
+            },
+            {
+                "source_identity": "source:public-feedback",
+                "dimension_identity": "dimension:cost",
+                "reference_identity": f"feedback:{suffix}-cost",
+            },
+        ],
+    }
+
+
+def settled_request(policy, response, outcomes, preferred, remaining=20):
+    return {
+        "policy": copy.deepcopy(policy),
+        "projection": copy.deepcopy(response["projection"]),
+        "settled": {
+            "preferred_incumbent_identity": preferred,
+            "outcomes": copy.deepcopy(outcomes),
+        },
+        "remaining_bound": {"runs": remaining},
+    }
+
+
 def reverse_object_keys(value):
     if isinstance(value, dict):
         return {
@@ -330,6 +419,119 @@ class TestCanonicalAdvance(unittest.TestCase):
             1,
         )
         self.assert_rejected(raw=duplicate)
+
+
+class TestParetoReflection(unittest.TestCase):
+    def run_ok(self, request):
+        result = run_advance(request)
+        self.assertEqual(0, result.returncode, result.stderr.decode())
+        self.assertEqual(b"", result.stderr)
+        return json.loads(result.stdout)
+
+    def settled_fixture(self, resolution="0.1"):
+        initial_request = two_dimension_request(resolution=resolution)
+        initial = self.run_ok(initial_request)
+        slots = initial["plan"]["slots"]
+        outcomes = [
+            admitted_outcome(slots[0], "candidate:a", "0.8", "0.6", "a"),
+            admitted_outcome(slots[1], "candidate:b", "0.4", "0.2", "b"),
+            admitted_outcome(slots[2], "candidate:dominated", "0.3", "0.8", "d"),
+        ]
+        request = settled_request(
+            initial_request["policy"],
+            initial,
+            list(reversed(outcomes)),
+            "candidate:dominated",
+        )
+        return request, outcomes
+
+    def assert_pareto_response(self, response):
+        projection = response["projection"]
+        self.assertEqual(
+            {"candidate:origin", "candidate:a", "candidate:b"},
+            set(projection["archive"]),
+        )
+        self.assertEqual(4, len(projection["nodes"]))
+        first = response["plan"]["slots"][0]
+        self.assertEqual("reflect", first["kind"])
+        self.assertEqual(["candidate:dominated"], first["parent_identities"])
+        self.assertIn(
+            first["focus_dimension_identity"],
+            {"dimension:quality", "dimension:cost"},
+        )
+        self.assertTrue(first["feedback"])
+        self.assertTrue(
+            all(
+                item["dimension_identity"] == first["focus_dimension_identity"]
+                for item in first["feedback"]
+            )
+        )
+
+    def test_resolution_aware_archive_reflection_and_replay(self):
+        request, _ = self.settled_fixture()
+        response = self.run_ok(request)
+        replay = run_advance(reverse_object_keys(request))
+        self.assertEqual(0, replay.returncode, replay.stderr.decode())
+        self.assertEqual(canonical_bytes(response) + b"\n", replay.stdout)
+        self.assert_pareto_response(response)
+
+        dominated_retained = copy.deepcopy(response)
+        dominated_retained["projection"]["archive"].append("candidate:dominated")
+        with self.assertRaises(AssertionError):
+            self.assert_pareto_response(dominated_retained)
+
+    def test_feedback_changes_the_reflection_packet_identity(self):
+        request, outcomes = self.settled_fixture()
+        original = self.run_ok(request)
+        changed = copy.deepcopy(request)
+        dominated = next(
+            item
+            for item in changed["settled"]["outcomes"]
+            if item.get("candidate_identity") == "candidate:dominated"
+        )
+        dominated["feedback"][0]["reference_identity"] = "feedback:d-quality-v2"
+        revised = self.run_ok(changed)
+        original_slot = original["plan"]["slots"][0]
+        revised_slot = revised["plan"]["slots"][0]
+        self.assertNotEqual(original_slot["feedback"], revised_slot["feedback"])
+        self.assertNotEqual(original_slot["identity"], revised_slot["identity"])
+
+        ignored_feedback = copy.deepcopy(revised_slot)
+        ignored_feedback["identity"] = original_slot["identity"]
+        with self.assertRaises(AssertionError):
+            self.assertEqual(
+                ignored_feedback["identity"],
+                tagged_identity(
+                    "search-slot/v1",
+                    {
+                        key: value
+                        for key, value in ignored_feedback.items()
+                        if key != "identity"
+                    },
+                ),
+            )
+
+    def test_comparison_exceeds_decimal_context_precision(self):
+        resolution = "0.123456789012345678901234567890123456789"
+        request, _ = self.settled_fixture(resolution=resolution)
+        for outcome in request["settled"]["outcomes"]:
+            if outcome["candidate_identity"] == "candidate:a":
+                outcome["dimension_vector"] = [
+                    {"identity": "dimension:quality", "value": resolution},
+                    {"identity": "dimension:cost", "value": "0"},
+                ]
+            elif outcome["candidate_identity"] == "candidate:b":
+                outcome["dimension_vector"] = [
+                    {"identity": "dimension:quality", "value": "0"},
+                    {"identity": "dimension:cost", "value": resolution},
+                ]
+            else:
+                outcome["dimension_vector"] = [
+                    {"identity": "dimension:quality", "value": "0"},
+                    {"identity": "dimension:cost", "value": "1"},
+                ]
+        response = self.run_ok(request)
+        self.assertNotIn("candidate:dominated", response["projection"]["archive"])
 
 
 if __name__ == "__main__":

--- a/tests/test_search_plan.py
+++ b/tests/test_search_plan.py
@@ -4,6 +4,7 @@ from pathlib import Path
 from collections import Counter
 import copy
 import hashlib
+import importlib.util
 import json
 import re
 import subprocess
@@ -17,6 +18,14 @@ EVOLVE = ROOT / "compositions" / "evolve.md"
 EVOLVE_GENERATION = ROOT / "compositions" / "references" / "evolve-generation.md"
 TOURNAMENT = ROOT / "compositions" / "skill-tournament.md"
 SEARCH_SKILL = ROOT / "skills" / "utilities" / "orch-search-plan" / "SKILL.md"
+SEARCH_PROTOCOL = (
+    ROOT
+    / "skills"
+    / "utilities"
+    / "orch-search-plan"
+    / "references"
+    / "protocol.md"
+)
 SEARCH_SCRIPT = (
     ROOT
     / "skills"
@@ -214,6 +223,16 @@ def ineligible_outcome(slot, candidate, suffix=None):
     }
 
 
+def no_candidate_outcome(slot, suffix):
+    return {
+        "kind": "no_candidate",
+        "outcome_identity": f"outcome:{suffix}",
+        "slot_identity": slot["identity"],
+        "cost": {unit: 0 for unit in slot["reservation"]},
+        "disposition": "no-candidate",
+    }
+
+
 def settled_request(policy, response, outcomes, preferred, remaining=20):
     return {
         "policy": copy.deepcopy(policy),
@@ -251,6 +270,37 @@ def run_advance(payload=None, raw=None, cwd=None):
 
 def read(path: Path) -> str:
     return path.read_text(encoding="utf-8")
+
+
+def load_search_module():
+    spec = importlib.util.spec_from_file_location("search_plan_test_module", SEARCH_SCRIPT)
+    if spec is None or spec.loader is None:
+        raise AssertionError("search-plan module could not be loaded")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def rehash_open_plan_slot(projection, index):
+    plan = projection["last_plan"]
+    slot = plan["slots"][index]
+    old_slot_identity = slot["identity"]
+    slot["identity"] = tagged_identity(
+        "search-slot/v1",
+        {key: value for key, value in slot.items() if key != "identity"},
+    )
+    projection["seen_slot_identities"] = [
+        slot["identity"] if identity == old_slot_identity else identity
+        for identity in projection["seen_slot_identities"]
+    ]
+    plan["identity"] = tagged_identity(
+        "search-plan/v1",
+        {key: value for key, value in plan.items() if key != "identity"},
+    )
+    projection["identity"] = tagged_identity(
+        "search-projection/v1",
+        {key: value for key, value in projection.items() if key != "identity"},
+    )
 
 
 def normalized(text: str) -> str:
@@ -327,6 +377,12 @@ def architecture_errors(evolve: str, generation: str, tournament: str, leaf: str
     }
     if evolve_calls != Counter({name: 1 for name in required}):
         errors.append("evolve-call-graph")
+    eligibility = evolve[evolve.index("- eligibility") : evolve.index("- campaign")]
+    campaign = evolve[evolve.index("- campaign") : evolve.index("Edges:")]
+    if "`orch-verify`" not in eligibility:
+        errors.append("eligibility-unit")
+    if "eligibility Verify binding" not in campaign:
+        errors.append("generation-verify-binding")
     if re.search(r"^-\s*closing\b", evolve, re.IGNORECASE | re.MULTILINE):
         errors.append("closing-wrapper")
     if normalized(combined_evolve).count("`orch-judge`") != 1:
@@ -381,6 +437,12 @@ class TestArchitecture(unittest.TestCase):
         self.assertIn(
             "leaf-call",
             architecture_errors(evolve, generation, tournament, extra_leaf_call),
+        )
+
+        unresolved = evolve.replace("`orch-verify`", "Verify", 1)
+        self.assertIn(
+            "eligibility-unit",
+            architecture_errors(unresolved, generation, tournament, leaf),
         )
 
 
@@ -496,6 +558,124 @@ class TestCanonicalAdvance(unittest.TestCase):
         )
         self.assert_rejected(raw=duplicate)
 
+    def test_deep_json_recursion_is_invalid_input(self):
+        raw = b'{"policy":' + b"[" * 5_000 + b"0" + b"]" * 5_000 + b"}"
+        self.assert_rejected(raw=raw)
+
+    def test_public_request_identity_and_decimal_caps_are_exact(self):
+        protocol = read(SEARCH_PROTOCOL)
+        self.assertIn("1,000,000 UTF-8 bytes", protocol)
+        self.assertIn("256 Unicode code points", protocol)
+        self.assertIn("128 characters", protocol)
+
+        module = load_search_module()
+        at_request_cap = b"0" + b" " * (module.MAX_INPUT_BYTES - 1)
+        self.assertEqual(0, module._load_request(at_request_cap))
+        with self.assertRaises(module.ProtocolError):
+            module._load_request(at_request_cap + b" ")
+
+        identity_at_cap = generation_zero_request()
+        identity_at_cap["policy"]["planner_revision"] = "x" * 256
+        identity_at_cap["policy"]["identity"] = tagged_identity(
+            "search-policy/v1",
+            {
+                key: value
+                for key, value in identity_at_cap["policy"].items()
+                if key != "identity"
+            },
+        )
+        self.assertEqual(0, run_advance(identity_at_cap).returncode)
+        identity_over_cap = copy.deepcopy(identity_at_cap)
+        identity_over_cap["policy"]["planner_revision"] += "x"
+        identity_over_cap["policy"]["identity"] = tagged_identity(
+            "search-policy/v1",
+            {
+                key: value
+                for key, value in identity_over_cap["policy"].items()
+                if key != "identity"
+            },
+        )
+        self.assert_rejected(identity_over_cap)
+
+        decimal_at_cap = generation_zero_request()
+        decimal_at_cap["policy"]["dimensions"][0]["resolution"] = "1" + "0" * 127
+        decimal_at_cap["policy"]["identity"] = tagged_identity(
+            "search-policy/v1",
+            {
+                key: value
+                for key, value in decimal_at_cap["policy"].items()
+                if key != "identity"
+            },
+        )
+        self.assertEqual(0, run_advance(decimal_at_cap).returncode)
+        decimal_over_cap = copy.deepcopy(decimal_at_cap)
+        decimal_over_cap["policy"]["dimensions"][0]["resolution"] += "0"
+        decimal_over_cap["policy"]["identity"] = tagged_identity(
+            "search-policy/v1",
+            {
+                key: value
+                for key, value in decimal_over_cap["policy"].items()
+                if key != "identity"
+            },
+        )
+        self.assert_rejected(decimal_over_cap)
+
+    def test_rehashed_open_plans_must_be_current_lawful_policy_prefixes(self):
+        request = two_dimension_request()
+        initial_result = run_advance(request)
+        self.assertEqual(0, initial_result.returncode, initial_result.stderr.decode())
+        initial = json.loads(initial_result.stdout)
+
+        cases = []
+        dangling = copy.deepcopy(initial["projection"])
+        dangling["last_plan"]["slots"][0]["parent_identities"] = ["candidate:missing"]
+        rehash_open_plan_slot(dangling, 0)
+        cases.append(dangling)
+
+        reservation_drift = copy.deepcopy(initial["projection"])
+        reservation_drift["last_plan"]["slots"][0]["reservation"]["runs"] = 0
+        rehash_open_plan_slot(reservation_drift, 0)
+        cases.append(reservation_drift)
+
+        proposal_drift = copy.deepcopy(initial["projection"])
+        proposal_drift["last_plan"]["slots"][0][
+            "focus_dimension_identity"
+        ] = "dimension:cost"
+        rehash_open_plan_slot(proposal_drift, 0)
+        cases.append(proposal_drift)
+
+        unseen = copy.deepcopy(initial["projection"])
+        unseen["seen_slot_identities"].remove(
+            unseen["last_plan"]["slots"][0]["identity"]
+        )
+        unseen["identity"] = tagged_identity(
+            "search-projection/v1",
+            {key: value for key, value in unseen.items() if key != "identity"},
+        )
+        cases.append(unseen)
+
+        for projection in cases:
+            with self.subTest(case=cases.index(projection)):
+                replay = settled_request(
+                    request["policy"],
+                    {"projection": projection},
+                    [],
+                    "candidate:origin",
+                )
+                self.assert_rejected(replay)
+
+    def test_emitted_projection_replays_as_valid_pending_state(self):
+        request = two_dimension_request()
+        first = run_advance(request)
+        self.assertEqual(0, first.returncode, first.stderr.decode())
+        response = json.loads(first.stdout)
+        replay = settled_request(
+            request["policy"], response, [], "candidate:origin"
+        )
+        pending = run_advance(replay)
+        self.assertEqual(0, pending.returncode, pending.stderr.decode())
+        self.assertEqual("pending", json.loads(pending.stdout)["status"])
+
 
 class TestParetoReflection(unittest.TestCase):
     def run_ok(self, request):
@@ -565,9 +745,15 @@ class TestParetoReflection(unittest.TestCase):
             for item in changed["settled"]["outcomes"]
             if item.get("candidate_identity") == "candidate:dominated"
         )
-        dominated["feedback"][0]["reference_identity"] = "feedback:d-quality-v2"
-        revised = self.run_ok(changed)
         original_slot = original["plan"]["slots"][0]
+        focused_feedback = next(
+            item
+            for item in dominated["feedback"]
+            if item["dimension_identity"]
+            == original_slot["focus_dimension_identity"]
+        )
+        focused_feedback["reference_identity"] += "-v2"
+        revised = self.run_ok(changed)
         revised_slot = revised["plan"]["slots"][0]
         self.assertNotEqual(original_slot["feedback"], revised_slot["feedback"])
         self.assertNotEqual(original_slot["identity"], revised_slot["identity"])
@@ -608,6 +794,36 @@ class TestParetoReflection(unittest.TestCase):
                 ]
         response = self.run_ok(request)
         self.assertNotIn("candidate:dominated", response["projection"]["archive"])
+
+    def test_width_one_focus_rotates_across_generations(self):
+        initial_request = two_dimension_request(width=1, merge_slots=0)
+        generation_one = self.run_ok(initial_request)
+        first_slot = generation_one["plan"]["slots"][0]
+        generation_two = self.run_ok(
+            settled_request(
+                initial_request["policy"],
+                generation_one,
+                [admitted_outcome(first_slot, "candidate:best", "0.8", "0.2")],
+                "candidate:origin",
+            )
+        )
+        second_slot = generation_two["plan"]["slots"][0]
+        generation_three = self.run_ok(
+            settled_request(
+                initial_request["policy"],
+                generation_two,
+                [no_candidate_outcome(second_slot, "generation-two")],
+                "candidate:origin",
+            )
+        )
+        self.assertEqual(
+            ["dimension:quality", "dimension:cost", "dimension:quality"],
+            [
+                first_slot["focus_dimension_identity"],
+                second_slot["focus_dimension_identity"],
+                generation_three["plan"]["slots"][0]["focus_dimension_identity"],
+            ],
+        )
 
 
 class TestMergeLineage(unittest.TestCase):
@@ -718,7 +934,7 @@ class TestMergeLineage(unittest.TestCase):
             policy,
             generation_two,
             [admitted_outcome(slots[0], "candidate:partial", "0.6", "0.4", "p")],
-            "candidate:partial",
+            "candidate:dominated",
         )
         pending = self.run_ok(partial)
         self.assertEqual("pending", pending["status"])
@@ -733,6 +949,12 @@ class TestMergeLineage(unittest.TestCase):
         malformed = copy.deepcopy(partial)
         malformed["settled"]["atomic"] = True
         self.assert_rejected(malformed)
+
+        changed_incumbent = copy.deepcopy(partial)
+        changed_incumbent["settled"][
+            "preferred_incumbent_identity"
+        ] = "candidate:partial"
+        self.assert_rejected(changed_incumbent)
 
     def test_cycle_dangling_reuse_and_inherited_score_are_rejected(self):
         policy, generation_two = self.merge_fixture()
@@ -891,6 +1113,40 @@ class TestBoundedResume(unittest.TestCase):
             [slot["identity"] for slot in generation_two_slots[1:]],
             pending["missing_slot_identities"],
         )
+
+        invalid_bound = copy.deepcopy(partial)
+        invalid_bound["remaining_bound"] = {"unexpected": -1}
+        result = run_advance(invalid_bound)
+        self.assertEqual(2, result.returncode)
+        self.assertEqual(b"", result.stdout)
+
+    def test_first_no_fit_does_not_materialize_the_proposal_suffix(self):
+        initial_request = two_dimension_request(width=5, merge_slots=0)
+        initial = self.run_ok(initial_request)
+        outcomes = [
+            no_candidate_outcome(slot, f"generation-one-{index}")
+            for index, slot in enumerate(initial["plan"]["slots"])
+        ]
+        request = settled_request(
+            initial_request["policy"],
+            initial,
+            outcomes,
+            "candidate:origin",
+            remaining=0,
+        )
+        module = load_search_module()
+        original_identified = module._identified
+        produced_slots = []
+
+        def tracking_identified(tag, payload):
+            if tag == "search-slot/v1" and payload["generation"] == 2:
+                produced_slots.append(payload["ordinal"])
+            return original_identified(tag, payload)
+
+        module._identified = tracking_identified
+        response = module._advance(copy.deepcopy(request))
+        self.assertEqual("no_fit", response["status"])
+        self.assertEqual([0], produced_slots)
 
     def test_worklog_launch_and_restart_contract_has_failure_controls(self):
         generation = read(EVOLVE_GENERATION)


### PR DESCRIPTION
## What changed

- adds the deterministic `orch-search-plan` utility for Pareto reflection, complementary merges, bounded planning, and restart-stable projections
- keeps Evolve artifact-agnostic and evaluation-agnostic
- accepts a separately created benchmark when supplied
- otherwise freezes a candidate-blind Judge brief and Panel before candidate generation
- keeps Benchmaker optional and outside Evolve's call graph

## Why

Evolve should improve arbitrary artifacts—writing, code, architecture, images, and other targets—without requiring Benchmaker or embedding benchmark-specific logic in the search planner.

## Impact

Callers can either provide a qualified benchmark-backed evaluation or let Evolve create a judged evaluation. The planner receives only a frozen evaluation identity, score vectors, and public feedback.

## Validation

- `tools/validate.py`
- `python -m unittest discover -s tests -v` — 604 tests passed
- `python install.py --dry-run`
- `git diff --check`
- independent `orch-critique` review passed