### PR TITLE
Add a read-only local web viewer for orchflows run state

### DIFF
--- a/install.py
+++ b/install.py
@@ -98,7 +98,7 @@ CANONICAL_DIRS = (
     "compositions",
     "templates",
 )
-SCRIPT_NAMES = ("friction.py", "tickets.py", "trace.py")
+SCRIPT_NAMES = ("friction.py", "tickets.py", "trace.py", "ui.py")
 CLAUDE_CLI_CANDIDATES = ("claude", "claude.exe", "claude.cmd")
 CODEX_CLI_CANDIDATES = ("codex", "codex.exe", "codex.cmd")
 PROFILES_MD = REPO_ROOT / "skills" / "kernel" / "orch-delegate" / "references" / "profiles.md"

--- a/scripts/ui.py
+++ b/scripts/ui.py
@@ -11,8 +11,13 @@ worktree's ``.git`` pointer is dereferenced to it, per
 ``contracts/work-item.md`` -- so every worktree of a repository shows one
 run's tickets at one path. Binds loopback only, never ``0.0.0.0``.
 
+It also lists the Claude Code sessions under ``~/.claude/projects``, as
+labels and structure alone: a transcript holds the operator's prompts,
+file contents and command output for every project on the machine, and
+this is not a transcript reader. That tree is read-only, forever.
+
 Usage:
-    ui.py [--root <path>] [--port <n>]
+    ui.py [--root <path>] [--port <n>] [--transcripts <path>]
 """
 
 from __future__ import annotations
@@ -54,10 +59,19 @@ INDEX_ROUTE = "/"
 TICKET_ROUTE = "/ticket"
 GRAPH_ROUTE = "/graph"
 FRICTION_ROUTE = "/friction"
+SESSIONS_ROUTE = "/sessions"
+SESSION_ROUTE = "/session"
 # Every served path lives here. The read-only and no-network tests iterate
 # this tuple, so a route added by branching inside ``render_route`` instead
 # would be silently unguarded.
-ROUTES = (INDEX_ROUTE, TICKET_ROUTE, GRAPH_ROUTE, FRICTION_ROUTE)
+ROUTES = (
+    INDEX_ROUTE,
+    TICKET_ROUTE,
+    GRAPH_ROUTE,
+    FRICTION_ROUTE,
+    SESSIONS_ROUTE,
+    SESSION_ROUTE,
+)
 
 # Every directory the reader reads, named once. The conditional request's
 # digest and the readers that render these have to agree about what is
@@ -82,6 +96,15 @@ EMPTY_NO_METER = "no elapsed meter"
 EMPTY_NO_RUN = "no run by that name under this root"
 EMPTY_NO_FRICTION = "no friction log under this root"
 EMPTY_UNSET = "unset"
+EMPTY_NO_TRANSCRIPTS = "no transcript root at this path"
+EMPTY_NO_SESSIONS = "no sessions under this transcript root"
+EMPTY_NO_TITLE = "no title recorded"
+EMPTY_NO_CWD = "no working directory recorded"
+EMPTY_NO_SESSION = "no session by that id under this transcript root"
+EMPTY_NO_AGENTS = "this session spawned no subagents"
+EMPTY_NO_TYPE = "no agent type recorded"
+EMPTY_NO_DESCRIPTION = "no description recorded"
+EMPTY_NO_DEPTH = "no spawn depth recorded"
 
 # `contracts/work-item.md`: `suspended` "stays claimed", so the lease keeps
 # running and elapsed-against-bound still measures something. Under every
@@ -180,6 +203,36 @@ def status_presentation(status: str) -> StatusPresentation:
     return STATUS_PRESENTATION.get(status, STATUS_FALLBACK)
 
 
+# A subagent's activity is not a ticket status: nobody writes it down, and
+# it is read off whatever evidence the session transcript happens to carry.
+# `unknown` is the honest answer for most of a real tree and it is a state,
+# not a failure to have one, so it reuses the fallback's own presentation
+# rather than being dressed as a wait.
+ACTIVITY_RUNNING = "running"
+ACTIVITY_FINISHED = "finished"
+ACTIVITY_UNKNOWN = STATUS_FALLBACK.word
+ACTIVITY_STATES = (ACTIVITY_RUNNING, ACTIVITY_FINISHED, ACTIVITY_UNKNOWN)
+
+# Four channels and the same closed set of hue tokens as above; no palette
+# is invented here. U+25D0 and cyan for in flight, U+2713 and green for
+# terminal-good -- what both families already mean elsewhere on the page.
+ACTIVITY_PRESENTATION = {
+    ACTIVITY_RUNNING: StatusPresentation(
+        "◐", ACTIVITY_RUNNING, "--st-running", "2px solid"
+    ),
+    ACTIVITY_FINISHED: StatusPresentation(
+        "✓", ACTIVITY_FINISHED, "--st-ok", "1px solid"
+    ),
+    ACTIVITY_UNKNOWN: STATUS_FALLBACK,
+}
+
+
+def activity_presentation(state: str) -> StatusPresentation:
+    """Total over every state, and over anything that is not one."""
+
+    return ACTIVITY_PRESENTATION.get(state, STATUS_FALLBACK)
+
+
 # An SVG rect has no `border`, so the border style that separates the two
 # pairs sharing a hue is restated as a stroke pattern. Same four channels,
 # same owner: both renderings are generated from STATUS_PRESENTATION.
@@ -194,8 +247,10 @@ def _svg_stroke(presentation: StatusPresentation) -> tuple:
 
 
 def _status_css() -> str:
-    """Derived from STATUS_PRESENTATION so a status cannot carry one hue in
-    the module and another in the stylesheet."""
+    """Derived from both presentation tables, so neither a ticket status nor
+    a subagent's activity can carry one hue in the module and another in the
+    stylesheet -- and so a state cannot be drawn in a class the stylesheet
+    never declares, which renders as no state at all."""
 
     lines = [
         "  /* Hue tokens are names, not colours: the palette is the design",
@@ -206,7 +261,9 @@ def _status_css() -> str:
         "        white-space: nowrap; }",
         "  .st .glyph { font-style: normal; }",
     ]
-    for presentation in [STATUS_FALLBACK] + list(STATUS_PRESENTATION.values()):
+    every = [STATUS_FALLBACK] + list(STATUS_PRESENTATION.values())
+    every += [seen for seen in ACTIVITY_PRESENTATION.values() if seen not in every]
+    for presentation in every:
         stroke_width, dash = _svg_stroke(presentation)
         lines.append(
             "  .st-{word} {{ border: {border} var({hue}); }}".format(
@@ -259,6 +316,12 @@ PAGE_CSS = (
   .graph text { font: 12px/1 ui-monospace, monospace; fill: currentColor; }
   .graph .nd-state { font-size: 11px; }
   .graph a { text-decoration: none; }
+  /* An edge that is a guess is drawn like one. The page says so in words
+     too: a dash pattern alone is not a channel a reader can decode. */
+  .graph .edge-inferred { stroke-dasharray: 5 3; }
+  /* The session flowchart's own node. It is not in an activity state, so
+     it borrows no state's presentation. */
+  .graph .nd-root rect { stroke: currentColor; stroke-width: 2; }
 """
     + _status_css()
 )
@@ -670,30 +733,41 @@ def _stamp_order(entry: dict) -> tuple:
     return (stamp is not None, stamp or _EPOCH)
 
 
+def _json_object(line: str):
+    """One JSONL line as a JSON object, or ``None`` when it is not one.
+
+    Every JSONL this module reads -- the friction log, the events seam, a
+    Claude Code transcript -- is append-only and written by a process that
+    may be killed mid-line, so a half-written tail is expected rather than
+    exceptional, and so is a line that parses to something other than a
+    record. A blank line is neither: the caller drops those before asking.
+    """
+
+    try:
+        entry = json.loads(line)
+    except ValueError:
+        return None
+    return entry if isinstance(entry, dict) else None
+
+
 def _read_jsonl(text: str, entries: list) -> int:
     """Append every JSON object in ``text`` to ``entries``; return the count
     of lines that were not one.
 
-    Both logs this reader shows are append-only JSONL written by a process
-    that may be killed mid-line, so a half-written tail is expected rather
-    than exceptional. One bad line costs that line and nothing else: the
-    friction law's whole point is that observations survive, and the events
-    seam is held to the same handling by sharing this code rather than by
-    resembling it.
+    One bad line costs that line and nothing else: the friction law's whole
+    point is that observations survive, and the events seam is held to the
+    same handling by sharing this code rather than by resembling it.
     """
 
     skipped = 0
     for line in text.splitlines():
         if not line.strip():
             continue
-        try:
-            entry = json.loads(line)
-        except ValueError:
-            entry = None
-        if isinstance(entry, dict):
-            entries.append(entry)
-        else:
+        entry = _json_object(line)
+        if entry is None:
             skipped += 1
+        else:
+            entries.append(entry)
     return skipped
 
 
@@ -1028,25 +1102,785 @@ LAYOUT_CACHE = {}
 LAYOUT_CACHE_LIMIT = 32
 
 
+def _make_room(cache: dict, limit: int):
+    """Evict oldest-first until one insertion fits under ``limit``.
+
+    Insertion-ordered and bounded, because the process outlives every run
+    and every session it is ever asked about. A cache already below its
+    limit evicts nothing: a negative slice here would drop the *newest*
+    entries instead, which is the opposite of the policy.
+    """
+
+    excess = len(cache) - limit + 1
+    for stale in list(cache)[:excess] if excess > 0 else ():
+        cache.pop(stale, None)
+
+
 def cached_layout(node_ids, edges) -> dict:
     """``graph_layout`` memoized on the node-and-edge set alone.
 
     Status is deliberately absent from the key: a poll that repaints a
     ticket from claimed to complete moved no node, so it must not pay for
-    a layout. Bounded and insertion-ordered, because the process outlives
-    every run it is asked about.
+    a layout.
     """
 
     key = layout_key(node_ids, edges)
     layout = LAYOUT_CACHE.get(key)
     if layout is None:
         layout = graph_layout(node_ids, edges)
-        if len(LAYOUT_CACHE) >= LAYOUT_CACHE_LIMIT:
-            excess = len(LAYOUT_CACHE) - LAYOUT_CACHE_LIMIT + 1
-            for stale in list(LAYOUT_CACHE)[:excess]:
-                LAYOUT_CACHE.pop(stale, None)
+        _make_room(LAYOUT_CACHE, LAYOUT_CACHE_LIMIT)
         LAYOUT_CACHE[key] = layout
     return layout
+
+
+# --- Claude Code sessions -----------------------------------------------------
+
+# A second data source, and a far more dangerous one than ``.orch/``. A
+# transcript holds the operator's prompts, the contents of the files they
+# opened and the output of the commands they ran, for every project on the
+# machine. The spec's `binding_constraints` close the renderable set to
+# labels and structure: ``sessionId``, ``aiTitle``, the ``worktree-state``
+# fields, timestamps, sizes, counts, and a subagent's own metadata. So the
+# reader below parses *for* the two record types it renders and drops every
+# other line before anything is taken from it -- there is no render-time
+# filter to get wrong, because nothing else is ever held.
+#
+# The layout is an undocumented implementation detail of another program,
+# not a contract. Every field access degrades to a named diagnostic, so a
+# Claude Code release that moves a key produces a visibly degraded page
+# rather than a traceback or a silently empty one that looks correct.
+
+DEFAULT_TRANSCRIPTS = (".claude", "projects")
+SUBAGENTS_DIR = "subagents"
+# Two files carry one subagent: its metadata, which is read, and its own
+# conversation, which is only ever stat'd. Both are listed, because the
+# later of the two mtimes is when the subagent was last heard from.
+AGENT_FILE_GLOB = "agent-*"
+AGENT_META_SUFFIX = ".meta.json"
+
+RECORD_TYPE_KEY = "type"
+AI_TITLE_RECORD = "ai-title"
+AI_TITLE_KEY = "aiTitle"
+WORKTREE_RECORD = "worktree-state"
+# Observed on a live host: the worktree fields sit one level down under
+# ``worktreeSession``, though the spec's evidence records them flat. Both
+# shapes are read, because neither is anybody's contract.
+WORKTREE_SESSION_KEY = "worktreeSession"
+# ``worktreePath`` first: a session inside a linked worktree runs there, and
+# that is the path the project directory name encodes.
+WORKTREE_CWD_KEYS = ("worktreePath", "originalCwd")
+
+# The one piece of evidence in the tree that a subagent ever ran. Observed
+# on a live host over 305 subagents, and nobody's contract: an `assistant`
+# record carries a `tool_use` block named `Agent` whose `id` is the
+# subagent's `toolUseId`, and a later `user` record carries a `tool_result`
+# block quoting that same id back once it has returned. Nothing else says
+# it -- `tool-results/` names no subagent's id at all.
+MESSAGE_KEY = "message"
+CONTENT_KEY = "content"
+TOOL_USE_BLOCK = "tool_use"
+TOOL_RESULT_BLOCK = "tool_result"
+TOOL_USE_ID_KEY = "tool_use_id"
+BLOCK_ID_KEY = "id"
+BLOCK_NAME_KEY = "name"
+AGENT_TOOL_NAME = "Agent"
+
+DIAGNOSTIC_UNREADABLE_TRANSCRIPT = "transcript could not be read"
+DIAGNOSTIC_UNREADABLE_LINES = "unreadable transcript lines"
+DIAGNOSTIC_NO_RECORDS = "transcript holds no records"
+DIAGNOSTIC_UNDECODABLE_SLUG = "project directory name is not an encoded path"
+DIAGNOSTIC_UNRENDERABLE_STAMP = "last activity time is outside the calendar"
+# A row is a promise that the link on it opens. `/session` takes its id in a
+# query string and `_safe_name` is the boundary that query crosses, so a
+# filename the walk finds and the boundary refuses is named here instead of
+# being listed under a link that answers "no such session" about a file this
+# very page just drew.
+DIAGNOSTIC_UNADDRESSABLE_SESSION = "session file cannot be addressed by name"
+
+# Where a working directory came from, said on the page. The two are not
+# equally trustworthy and the difference is not the reader's to hide.
+CWD_FROM_RECORD = "from worktree-state"
+CWD_FROM_NAME = "decoded from the directory name"
+
+# The row, named once. Widening it is how the content wall gets breached, so
+# it is a constant a test can hold rather than a shape spread over a format
+# string.
+SESSION_COLUMNS = ("sid", "title", "cwd", "when", "size", "agents", "notes")
+SESSION_HEADINGS = (
+    "session",
+    "title",
+    "working directory",
+    "last activity",
+    "bytes",
+    "subagents",
+    "notes",
+)
+
+# The subagent metadata this reader draws, named once for the same reason
+# as SESSION_COLUMNS. `parentAgentId` is read and is deliberately not here:
+# what it resolves to is drawn as an edge between two nodes already on the
+# page, so the field's own value never reaches a reader.
+AGENT_TYPE_KEY = "agentType"
+AGENT_DESCRIPTION_KEY = "description"
+AGENT_TOOL_USE_KEY = "toolUseId"
+AGENT_DEPTH_KEY = "spawnDepth"
+AGENT_PARENT_KEY = "parentAgentId"
+
+AGENT_COLUMNS = ("agent", "type", "description", "depth", "state", "attached", "when")
+AGENT_HEADINGS = (
+    "subagent",
+    "agent type",
+    "description",
+    "spawn depth",
+    "activity",
+    "attached to",
+    "last activity",
+)
+
+DIAGNOSTIC_UNREADABLE_AGENT = "subagent metadata could not be read"
+DIAGNOSTIC_INFERRED_EDGE = (
+    "a dashed edge is inferred: the subagent records no parent, so it is "
+    "drawn on the orchestrator by its spawn depth alone"
+)
+# The second guess, which is not the first one. Saying "records no parent"
+# of a subagent that recorded one would be a false statement about another
+# program's data, and it is the reader who would go looking for the parent
+# that was supposedly never written down. No clause about spawn depth here
+# either: a depth-3 record drawn on the orchestrator is not drawn by its
+# depth, and a sentence claiming so contradicts the number beside it.
+DIAGNOSTIC_UNRESOLVED_PARENT = (
+    "a dashed edge is inferred: the subagent records a parent that names no "
+    "other subagent of this session, so it is drawn on the orchestrator"
+)
+
+# The flowchart's own node, which is the session itself. Every subagent
+# node is named for a file matching ``agent-*``, so no metadata file can
+# collide with it.
+ORCHESTRATOR_NODE = "orchestrator"
+ORCHESTRATOR_ANCHOR = "session"
+
+# What an edge was read off, said on the row it belongs to. A subagent at
+# depth 1 was spawned by the session and nothing else could have spawned
+# it; a recorded parent that resolves to a node on this page is a fact; a
+# depth-2 subagent that records no parent is neither, and the guess is
+# labelled a guess.
+EDGE_FROM_DEPTH = "spawn depth 1"
+EDGE_FROM_PARENT = "recorded parent"
+EDGE_INFERRED = "inferred: no parent recorded"
+# A fourth case, and the one the other three are not: a pointer was
+# written down and resolved to nothing on this page. One sentence covers
+# every shape that reaches here -- a stranger, the agent itself, and the
+# orchestrator, which `agent_ids` deliberately withholds.
+EDGE_PARENT_UNRESOLVED = (
+    "inferred: recorded parent names no other subagent of this session"
+)
+
+# What the state was read off, said beside it. A state whose evidence is
+# not on the page is indistinguishable from a guess.
+EVIDENCE_CALLED = "called, no result yet"
+EVIDENCE_RETURNED = "result recorded"
+EVIDENCE_NONE = "no call in this transcript"
+
+
+def transcript_root(value=None) -> Path:
+    """The transcript root: ``value`` when given, else ``~/.claude/projects``.
+
+    Path arithmetic and nothing else -- the tree is never opened here. This
+    is also the only place the default is resolved, and ``main`` is its only
+    caller, so a reader handed no root renders a named empty state instead
+    of falling back to the operator's real transcripts.
+    """
+
+    if value:
+        return Path(value).expanduser()
+    return Path.home().joinpath(*DEFAULT_TRANSCRIPTS)
+
+
+def decode_slug(slug) -> str:
+    """A project directory name as the working directory it encodes, or ``""``.
+
+    Claude Code names the directory after the working directory with every
+    separator replaced by ``-``, which is not invertible: ``.`` encodes to
+    ``-`` as well, and a ``-`` already in a directory name is
+    indistinguishable from either, so ``…-orchflows--claude-worktrees-a-b``
+    decodes wrong in three places. What comes back is a guess, named as one
+    wherever it is the only source; a name that does not even open with the
+    separator marker is refused rather than guessed at.
+    """
+
+    if not isinstance(slug, str) or not slug.startswith("-"):
+        return ""
+    return "/" + slug[1:].replace("-", "/")
+
+
+def _stat_identity(path: Path):
+    """``(name, size, mtime)`` for one file, or ``None`` when the path layer
+    will not answer. The parse cache's key and the validator's contribution
+    are these same three facts, so the page and the tag it is served under
+    cannot disagree about which file they saw."""
+
+    try:
+        stat = path.stat()
+    except OSError:
+        return None
+    return (str(path), stat.st_size, stat.st_mtime_ns)
+
+
+def _worktree_cwd(record: dict) -> str:
+    """The working directory one ``worktree-state`` record states, or ``""``."""
+
+    nested = record.get(WORKTREE_SESSION_KEY)
+    holders = (nested, record) if isinstance(nested, dict) else (record,)
+    for holder in holders:
+        for key in WORKTREE_CWD_KEYS:
+            value = holder.get(key)
+            if isinstance(value, str) and value.strip():
+                return value.strip()
+    return ""
+
+
+def _content_blocks(record: dict) -> list:
+    """The content blocks of one conversation record, or none.
+
+    Observed shape: the blocks sit under ``message.content``. The record is
+    another program's JSON, so anything else there is not a block list.
+    """
+
+    message = record.get(MESSAGE_KEY)
+    blocks = message.get(CONTENT_KEY) if isinstance(message, dict) else None
+    if not isinstance(blocks, list):
+        return []
+    return [block for block in blocks if isinstance(block, dict)]
+
+
+def _agent_evidence(record: dict, calls: set, returns: set) -> None:
+    """Fold one record into the call and return sets.
+
+    The tool *name* is the discriminator and dropping it is the whole bug
+    this guards: a subagent's ``toolUseId`` is a tool-use id like any other,
+    and a finished ``Bash`` command under that id is not a finished
+    subagent. A return is only counted for a call already seen, which is
+    also the order a transcript writes them in.
+    """
+
+    for block in _content_blocks(record):
+        kind = block.get(RECORD_TYPE_KEY)
+        if kind == TOOL_USE_BLOCK and block.get(BLOCK_NAME_KEY) == AGENT_TOOL_NAME:
+            identifier = block.get(BLOCK_ID_KEY)
+            if isinstance(identifier, str) and identifier:
+                calls.add(identifier)
+        elif kind == TOOL_RESULT_BLOCK:
+            identifier = block.get(TOOL_USE_ID_KEY)
+            if identifier in calls:
+                returns.add(identifier)
+
+
+def _transcript_summary(path: Path) -> dict:
+    """The two labels the index draws from one transcript, the evidence that
+    each subagent ever ran, and nothing else.
+
+    Streamed a line at a time, and every line that is not one of the
+    rendered record types is dropped before a single value is taken from it.
+    A real transcript is megabytes of conversation; none of it is ever held
+    long enough to be filtered later, and what survives this pass is a
+    handful of tool-use ids -- one per subagent the session spawned.
+    """
+
+    calls, returns = set(), set()
+    summary = {
+        "title": "",
+        "cwd": "",
+        "records": 0,
+        "skipped": 0,
+        "unreadable": False,
+        "agent_calls": calls,
+        "agent_returns": returns,
+    }
+    try:
+        with path.open(encoding="utf-8", errors="replace") as handle:
+            for line in handle:
+                if not line.strip():
+                    continue
+                record = _json_object(line)
+                if record is None:
+                    summary["skipped"] += 1
+                    continue
+                summary["records"] += 1
+                kind = record.get(RECORD_TYPE_KEY)
+                if kind == AI_TITLE_RECORD:
+                    title = record.get(AI_TITLE_KEY)
+                    # Last one wins: the title is rewritten as the session
+                    # goes on, and the reader wants the current one.
+                    if isinstance(title, str) and title.strip():
+                        summary["title"] = title.strip()
+                elif kind == WORKTREE_RECORD:
+                    cwd = _worktree_cwd(record)
+                    if cwd:
+                        summary["cwd"] = cwd
+                else:
+                    _agent_evidence(record, calls, returns)
+    except OSError:
+        # Unreadable, or gone between the listing and the open. Whatever was
+        # read before that stands; the absence is named, not guessed at.
+        summary["unreadable"] = True
+    return summary
+
+
+TRANSCRIPT_CACHE = {}
+TRANSCRIPT_CACHE_LIMIT = 256
+
+
+def cached_transcript(path: Path, identity) -> dict:
+    """``_transcript_summary`` memoized on the file's stat identity.
+
+    The index draws one title and one working directory out of a file that
+    is routinely megabytes, for every session on the machine, and the poll
+    asks for the page every second. Keyed on name, size and mtime -- the
+    same three facts the page's own validator is built from -- so an
+    unchanged transcript is parsed once and a changed one is parsed again.
+    """
+
+    summary = TRANSCRIPT_CACHE.get(identity)
+    if summary is None:
+        summary = _transcript_summary(path)
+        _make_room(TRANSCRIPT_CACHE, TRANSCRIPT_CACHE_LIMIT)
+        TRANSCRIPT_CACHE[identity] = summary
+    return summary
+
+
+def _subagent_files(path: Path) -> tuple:
+    """Every subagent file beside one transcript, metadata and conversation
+    alike.
+
+    The conversation is listed and never opened: it is megabytes of the
+    same content the transcript holds, and the only thing read off it is
+    the mtime the flowchart draws as a last activity. A session directory
+    that does not exist is no subagents, not an error -- most sessions
+    spawn nothing.
+    """
+
+    directory = _in_tree(path.parent, path.stem, SUBAGENTS_DIR)
+    if directory is None:
+        return ()
+    try:
+        return tuple(sorted(directory.glob(AGENT_FILE_GLOB))) if directory.is_dir() else ()
+    except OSError:
+        return ()
+
+
+def _agent_id(path: Path) -> str:
+    """The subagent one of its files is named for: ``agent-aa11.meta.json``
+    and ``agent-aa11.jsonl`` are two files about one subagent."""
+
+    for suffix in (AGENT_META_SUFFIX, JSONL_SUFFIX):
+        if path.name.endswith(suffix):
+            return path.name[: -len(suffix)]
+    return path.name
+
+
+def _subagent_identities(files) -> tuple:
+    """The stat identity of every subagent file beside one transcript.
+
+    This is the validator's contribution for the subagent tree, so it
+    covers what the pages read: the metadata they parse and the mtime they
+    draw. A narrower basis would answer 304 to a flowchart that has moved.
+    """
+
+    return tuple(
+        identity
+        for identity in (_stat_identity(file) for file in files)
+        if identity is not None
+    )
+
+
+def _agent_count(files) -> int:
+    """How many subagents one session spawned: one per metadata file, not
+    one per file."""
+
+    return sum(1 for file in files if file.name.endswith(AGENT_META_SUFFIX))
+
+
+def _agent_text(value) -> str:
+    """One metadata string field, or ``""``. Another program's undocumented
+    JSON can hold anything at any key, so a value of the wrong type is an
+    absence rather than something to render."""
+
+    return value.strip() if isinstance(value, str) and value.strip() else ""
+
+
+def _agent_depth(value):
+    """``spawnDepth`` as an integer, or ``None``. ``True`` is an ``int`` in
+    Python and is not a depth."""
+
+    return value if isinstance(value, int) and not isinstance(value, bool) else None
+
+
+def _agent_record(meta: Path, modified: int) -> dict:
+    """The named metadata fields of one subagent, each degrading to an
+    absence rather than to a traceback."""
+
+    record = {
+        "id": _agent_id(meta),
+        "type": "",
+        "description": "",
+        "tool_use_id": "",
+        "depth": None,
+        "parent": "",
+        "modified": modified,
+        "unreadable": False,
+    }
+    try:
+        parsed = _json_object(meta.read_text(encoding="utf-8", errors="replace"))
+    except OSError:
+        parsed = None
+    if parsed is None:
+        record["unreadable"] = True
+        return record
+    record["type"] = _agent_text(parsed.get(AGENT_TYPE_KEY))
+    record["description"] = _agent_text(parsed.get(AGENT_DESCRIPTION_KEY))
+    record["tool_use_id"] = _agent_text(parsed.get(AGENT_TOOL_USE_KEY))
+    record["depth"] = _agent_depth(parsed.get(AGENT_DEPTH_KEY))
+    record["parent"] = _agent_text(parsed.get(AGENT_PARENT_KEY))
+    return record
+
+
+def read_agents(path: Path) -> list:
+    """Every subagent recorded beside one transcript, in the tree's order.
+
+    A metadata file is a few hundred bytes and a session has a few dozen of
+    them, so this is the one place the detail view reads that the index
+    does not. Its cost is a directory listing plus one small read per
+    subagent -- no transcript is opened here at all.
+    """
+
+    activity = {}
+    metas = []
+    for file in _subagent_files(path):
+        identity = _stat_identity(file)
+        if identity is not None:
+            agent = _agent_id(file)
+            activity[agent] = max(activity.get(agent, 0), identity[2])
+        if file.name.endswith(AGENT_META_SUFFIX):
+            metas.append(file)
+    return [_agent_record(meta, activity.get(_agent_id(meta), 0)) for meta in metas]
+
+
+def _project_directories(root: Path) -> list:
+    """Every project directory that is actually inside the transcript root.
+
+    A directory *entry* is not the same thing as a directory in this tree.
+    `~/.claude/projects` is a path anything on the machine can be linked
+    into, and a symlink there answers ``is_dir`` like any other project and
+    would then be walked for transcripts -- which is how a viewer whose whole
+    defence is a closed renderable set starts rendering titles out of files
+    outside its own root. Containment is the same question `_subagent_files`
+    asks one level down, so it is asked with the same helper. The entry's own
+    name is what is kept: that is the name the operator sees in the listing
+    and the slug this reader decodes.
+    """
+
+    try:
+        entries = sorted(path for path in root.iterdir() if path.is_dir())
+    except OSError:
+        return []
+    return [path for path in entries if _in_tree(root, path.name) is not None]
+
+
+def discover_sessions(transcripts=None) -> dict:
+    """Every session under one transcript root, newest activity first.
+
+    Listing only: no transcript is opened here, so this is what the
+    validator can afford to walk on a request it answers 304. ``None`` is
+    the case where no root was configured at all, and it reads nothing.
+    """
+
+    if transcripts is None:
+        return {
+            "root": None,
+            "present": False,
+            "projects": (),
+            "sessions": [],
+            "unaddressable": (),
+            "diagnostics": [],
+            "empty": EMPTY_NO_TRANSCRIPTS,
+        }
+    root = Path(transcripts)
+    try:
+        present = root.is_dir()
+    except OSError:
+        present = False
+    if not present:
+        return {
+            "root": root,
+            "present": False,
+            "projects": (),
+            "sessions": [],
+            "unaddressable": (),
+            "diagnostics": [],
+            "empty": EMPTY_NO_TRANSCRIPTS,
+        }
+    projects = _project_directories(root)
+    sessions = []
+    unaddressable = []
+    diagnostics = []
+    for project in projects:
+        cwd = decode_slug(project.name)
+        if not cwd:
+            diagnostics.append(
+                "{0}: {1}".format(DIAGNOSTIC_UNDECODABLE_SLUG, project.name)
+            )
+        for path in sorted(project.glob("*" + JSONL_SUFFIX)):
+            identity = _stat_identity(path)
+            if identity is None:
+                continue
+            if not _safe_name(path.stem):
+                # The detail route looks a session up by this id and
+                # `find_session` refuses the name before it gets there, so
+                # listing the row would offer a link to a 404 about a file
+                # this walk just found. Named once, here, where the name is.
+                unaddressable.append(identity)
+                diagnostics.append(
+                    "{0}: {1}".format(DIAGNOSTIC_UNADDRESSABLE_SESSION, path.name)
+                )
+                continue
+            files = _subagent_files(path)
+            sessions.append(
+                {
+                    "id": path.stem,
+                    "path": path,
+                    "project": project.name,
+                    "named_cwd": cwd,
+                    "identity": identity,
+                    "size": identity[1],
+                    "modified": identity[2],
+                    "subagents": _subagent_identities(files),
+                    "agent_count": _agent_count(files),
+                }
+            )
+    # Newest first, and on the id where two files share a timestamp, so the
+    # order is a property of the tree rather than of the walk.
+    sessions.sort(key=lambda session: (-session["modified"], session["id"]))
+    return {
+        "root": root,
+        "present": True,
+        "projects": tuple(project.name for project in projects),
+        "sessions": sessions,
+        # Not sessions, and not nothing: a file whose diagnostic is on the
+        # page is part of what the page was rendered from, so the validator
+        # has to be able to see it arrive and leave.
+        "unaddressable": tuple(unaddressable),
+        "diagnostics": diagnostics,
+        "empty": "" if sessions else EMPTY_NO_SESSIONS,
+    }
+
+
+def _session_diagnostics(summary: dict) -> list:
+    """What one transcript could not be read to say."""
+
+    diagnostics = []
+    if summary["unreadable"]:
+        diagnostics.append(DIAGNOSTIC_UNREADABLE_TRANSCRIPT)
+    if summary["skipped"]:
+        diagnostics.append(
+            "{0}: {1}".format(DIAGNOSTIC_UNREADABLE_LINES, summary["skipped"])
+        )
+    # An empty transcript and a healthy one must not look alike: a layout
+    # change that stopped every line parsing would otherwise render a page
+    # of blanks that reads as "nothing happened here".
+    if not summary["records"] and not summary["unreadable"]:
+        diagnostics.append(DIAGNOSTIC_NO_RECORDS)
+    return diagnostics
+
+
+def _label_session(session: dict) -> dict:
+    """One session's labels, from the cached parse of its own transcript.
+    Returns the summary, so a caller that needs more than the labels does
+    not parse the file a second time."""
+
+    summary = cached_transcript(session["path"], session["identity"])
+    session["title"] = summary["title"]
+    session["cwd"] = summary["cwd"] or session["named_cwd"]
+    if summary["cwd"]:
+        session["cwd_source"] = CWD_FROM_RECORD
+    else:
+        session["cwd_source"] = CWD_FROM_NAME if session["named_cwd"] else ""
+    session["diagnostics"] = _session_diagnostics(summary)
+    return summary
+
+
+def read_sessions(transcripts=None) -> dict:
+    """Every session under one transcript root, labelled.
+
+    ``discover_sessions`` lists; this labels. The parse is the expensive
+    half and it is cached on each transcript's stat identity, so a poll over
+    an unchanged root costs one directory listing and no parse at all.
+    """
+
+    found = discover_sessions(transcripts)
+    for session in found["sessions"]:
+        _label_session(session)
+    return found
+
+
+def find_session(transcripts, session_id: str):
+    """One session by id, or ``None``.
+
+    The listing is the lookup: a session id names a file, but the project
+    directory it sits under is not derivable from the id, and the slug is
+    not invertible. Listing costs no parse, which is what the detail view
+    can afford -- it then parses exactly the one transcript it draws.
+    """
+
+    if not _safe_name(session_id):
+        return None
+    for session in discover_sessions(transcripts)["sessions"]:
+        if session["id"] == session_id:
+            return session
+    return None
+
+
+def _agent_activity(agent: dict, summary: dict) -> tuple:
+    """``(state, what it was read off)`` for one subagent.
+
+    Ordered by strength of evidence, and it runs out fast: a result quoting
+    the call is the only thing that says finished, an unanswered call is the
+    only thing that says running, and everything else is `unknown`. Nothing
+    here has a default branch that claims a state -- the absence of evidence
+    is the third state, not a reason to pick one of the other two.
+    """
+
+    called = agent["tool_use_id"]
+    if called and called in summary["agent_returns"]:
+        return ACTIVITY_FINISHED, EVIDENCE_RETURNED
+    if called and called in summary["agent_calls"]:
+        return ACTIVITY_RUNNING, EVIDENCE_CALLED
+    return ACTIVITY_UNKNOWN, EVIDENCE_NONE
+
+
+def read_session(session: dict) -> dict:
+    """One session, labelled, with every subagent recorded beside it and
+    each subagent's activity read off the session's own transcript.
+
+    The parse is the one ``_label_session`` already made and cached, so the
+    states cost no second pass over the file.
+    """
+
+    summary = _label_session(session)
+    session["agents"] = read_agents(session["path"])
+    for agent in session["agents"]:
+        agent["state"], agent["evidence"] = _agent_activity(agent, summary)
+    return session
+
+
+def agent_ids(agents) -> frozenset:
+    """The nodes a recorded parent is allowed to resolve to: the session's
+    own subagents, and not the orchestrator, which no metadata names."""
+
+    return frozenset(agent["id"] for agent in agents)
+
+
+def _recorded_parent(agent: dict, known: frozenset) -> str:
+    """The node one subagent's own ``parentAgentId`` resolves to, or ``""``.
+
+    ``parentAgentId`` was observed on every depth-2 record and no depth-1
+    one, holding the bare id whose file is ``agent-<id>``; both spellings
+    are accepted because neither is anybody's contract. A pointer to an
+    agent this session does not have, or to the agent itself, resolves to
+    nothing rather than to a node that is not there or an edge nobody can
+    lay out.
+    """
+
+    for candidate in (agent["parent"], "agent-" + agent["parent"]):
+        if agent["parent"] and candidate in known and candidate != agent["id"]:
+            return candidate
+    return ""
+
+
+def _agent_parent(agent: dict, known: frozenset) -> str:
+    """The node one subagent hangs off, or ``""`` when nothing says.
+
+    Depth 1 is read before the pointer and outranks it: the session spawned
+    it and nothing else could have, so spec criterion 8's edge from the
+    orchestrator to *every* depth-1 agent holds even where the metadata also
+    names a sibling. Ordering the two the other way makes that criterion
+    hold only for the records that happen to omit the key.
+    """
+
+    if agent["depth"] == 1:
+        return ORCHESTRATOR_NODE
+    return _recorded_parent(agent, known)
+
+
+def session_graph(agents) -> tuple:
+    """``(node ids, edges, the subset of edges that is inferred)``.
+
+    The orchestrator is the session itself. A subagent at depth 1 was
+    spawned by it and nothing else could have been; a recorded parent that
+    resolves to a node on this page is a fact. Everything left over -- a
+    subagent that names no parent, and one whose named parent is not on this
+    page -- hangs off the orchestrator too, and that edge is returned as a
+    guess so the page can draw it as one. Inventing a parent for it would be
+    the one lie a flowchart of another program's tree must not tell. Which
+    of the two guesses was made is `edge_source`'s to say; the shape here is
+    the same either way.
+    """
+
+    nodes = (ORCHESTRATOR_NODE,) + tuple(agent["id"] for agent in agents)
+    known = agent_ids(agents)
+    edges, inferred = [], []
+    for agent in agents:
+        parent = _agent_parent(agent, known)
+        edges.append((parent or ORCHESTRATOR_NODE, agent["id"]))
+        if not parent:
+            inferred.append(edges[-1])
+    return nodes, tuple(edges), tuple(inferred)
+
+
+def edge_source(agent: dict, known: frozenset) -> str:
+    """What one subagent's edge was read off, said on its own row.
+
+    Two of the four are guesses and they are not the same guess. A record
+    that never named a parent and a record whose named parent is on no other
+    row here both land on the orchestrator; calling the second the first is
+    a false statement about another program's data, and the reader it
+    misleads goes looking for a pointer that was written down all along.
+    """
+
+    parent = _agent_parent(agent, known)
+    if parent == ORCHESTRATOR_NODE:
+        return EDGE_FROM_DEPTH
+    if parent:
+        return EDGE_FROM_PARENT
+    return EDGE_PARENT_UNRESOLVED if agent["parent"] else EDGE_INFERRED
+
+
+def transcript_state(transcripts=None) -> tuple:
+    """The stat identity of everything the session views read.
+
+    The same three facts per file the ``.orch/`` walk contributes, over the
+    set this reader actually opens -- and the project directory names, so a
+    directory appearing empty is a change too. Naming the validator's basis
+    as the route's whole read set, rather than one directory, is `U3`'s
+    lesson from the friction feed.
+    """
+
+    found = discover_sessions(transcripts)
+    # Configured or not, and present or not, before any file: three pages
+    # differ here -- no root configured, a root that is not there yet, and a
+    # root holding nothing -- and none of the three has a file to stat, so a
+    # walk alone cannot tell them apart. The middle-to-last transition is the
+    # ordinary one: a viewer left open from before Claude Code first ran.
+    root = found["root"]
+    state = [("transcripts", int(found["present"]), "" if root is None else str(root))]
+    state.extend(("projects", 0, name) for name in found["projects"])
+    for session in found["sessions"]:
+        state.append(session["identity"])
+        state.extend(session["subagents"])
+    # A file that is not a session still renders: it renders a diagnostic.
+    # No directory is stat'd on this walk, so without these the row-shaped
+    # hole in the page appears and disappears under an unchanged tag.
+    state.extend(found["unaddressable"])
+    return tuple(state)
 
 
 # --- rendering ---------------------------------------------------------------
@@ -1064,9 +1898,54 @@ def _cell(value: str, fallback: str) -> str:
     return '<span class="empty">{0}</span>'.format(html.escape(fallback))
 
 
+def _row(columns, values: dict, anchor: str = "") -> str:
+    """One table row, its cells derived from the tuple that closes the
+    renderable set.
+
+    The row is built *from* the constant rather than beside it, so a column
+    cannot reach the page without being admitted to the closed set first --
+    which is the whole mechanism behind the content wall. A tuple that
+    names a column with no value here fails at the first render rather than
+    emitting a blank cell nobody asked about; the two are module state and
+    can only disagree by a mistake made in this file.
+
+    ``anchor``, where given, is the element id the row's first cell carries
+    -- the target a flowchart node links to.
+    """
+
+    cells = []
+    for name in columns:
+        identifier = (
+            ' id="{0}"'.format(html.escape(anchor))
+            if anchor and name == columns[0]
+            else ""
+        )
+        cells.append(
+            '<td class="{name}"{id}>{value}</td>'.format(
+                name=name, id=identifier, value=values[name]
+            )
+        )
+    return "<tr>{0}</tr>\n".format("".join(cells))
+
+
+def _pill(seen: StatusPresentation, text: str) -> str:
+    """One state pill: glyph, word, and a class binding the hue token and
+    the border style.
+
+    The glyph is aria-hidden because the word beside it says the same
+    thing; a screen reader announcing the code point would only add noise.
+    ``text`` arrives escaped -- a caller that appends an untrusted value to
+    the word is the only reason this takes one at all.
+    """
+
+    return (
+        '<span class="st st-{word}">'
+        '<span class="glyph" aria-hidden="true">{glyph}</span> {text}</span>'
+    ).format(word=seen.word, glyph=seen.glyph, text=text)
+
+
 def render_status(status: str) -> str:
-    """The status pill: glyph, word, and a class binding the hue token and
-    the border style. A value outside the contract's set keeps its own
+    """The status pill. A value outside the contract's set keeps its own
     text, escaped, beside the named fallback -- hiding an unrecognized
     status would hide exactly the state a reader came to see. An absent
     status is an empty state rather than a state."""
@@ -1077,12 +1956,7 @@ def render_status(status: str) -> str:
     text = html.escape(seen.word)
     if status not in STATUS_PRESENTATION:
         text = "{0} {1}".format(text, html.escape(status))
-    # The glyph is aria-hidden because the word beside it says the same
-    # thing; a screen reader announcing the code point would only add noise.
-    return (
-        '<span class="st st-{word}">'
-        '<span class="glyph" aria-hidden="true">{glyph}</span> {text}</span>'
-    ).format(word=seen.word, glyph=seen.glyph, text=text)
+    return _pill(seen, text)
 
 
 def is_live(tickets) -> bool:
@@ -1126,6 +2000,21 @@ def graph_href(run: str) -> str:
     return html.escape(
         "{route}?run={run}".format(route=GRAPH_ROUTE, run=quote(run, safe=""))
     )
+
+
+def session_href(session_id: str) -> str:
+    """A session id is a file name from another program's tree, so it is
+    percent-encoded whole and then escaped as markup, like a ticket id."""
+
+    return html.escape(
+        "{route}?id={id}".format(route=SESSION_ROUTE, id=quote(session_id, safe=""))
+    )
+
+
+def anchor_href(anchor: str) -> str:
+    """A link to a row on this same page."""
+
+    return html.escape("#{0}".format(quote(anchor, safe="")))
 
 
 def _meter(ticket: dict) -> str:
@@ -1191,6 +2080,7 @@ def render_index(discovery: dict) -> str:
         "<h1>orchflows runs</h1>\n",
         '<p class="root">{0}</p>\n'.format(html.escape(str(discovery["root"]))),
         '<p class="back"><a href="{0}">friction log</a></p>\n'.format(FRICTION_ROUTE),
+        '<p class="back"><a href="{0}">claude sessions</a></p>\n'.format(SESSIONS_ROUTE),
         render_active_band(active_claims(discovery)),
     ]
     if discovery["empty"]:
@@ -1408,6 +2298,359 @@ def render_friction(log: dict) -> str:
     return _page("friction", "".join(body))
 
 
+def _stamp(mtime_ns: int) -> str:
+    """A file's mtime as a UTC instant, or a named diagnostic.
+
+    Rendered in UTC rather than local time because the sessions listed here
+    were opened in whatever zone the machine was in at the time, and a stamp
+    that silently means two things is worse than one that plainly means one.
+
+    An mtime is the filesystem's number, not this process's: APFS clamps at
+    2262, but an NTFS FILETIME reaches the year 30828 and ``datetime``
+    refuses anything past 9999. Unguarded that is a ``ValueError`` inside the
+    handler -- no HTTP response on the wire at all and the absolute module
+    path on stderr, which is the failure `U3` already shipped once. A time
+    that cannot be rendered is a named diagnostic like every other absence
+    on these pages.
+    """
+
+    try:
+        seconds = mtime_ns // 1000000000
+        return datetime.fromtimestamp(seconds, timezone.utc).strftime(
+            "%Y-%m-%dT%H:%M:%SZ"
+        )
+    except (OSError, OverflowError, ValueError):
+        return DIAGNOSTIC_UNRENDERABLE_STAMP
+
+
+def _session_cwd(session: dict) -> str:
+    """The working directory cell: the path, and where it came from.
+
+    The provenance is on the page because the two sources are not equally
+    good. A ``worktree-state`` record states the path; a directory name only
+    encodes it, through a substitution that is not invertible. Presenting a
+    guess as a fact is how a reader ends up looking for a repository that
+    was never there.
+    """
+
+    if not session["cwd"]:
+        return _cell("", EMPTY_NO_CWD)
+    return '{path} <span class="src">{source}</span>'.format(
+        path=html.escape(session["cwd"]), source=html.escape(session["cwd_source"])
+    )
+
+
+def render_sessions(found: dict) -> str:
+    """The Claude Code session index: one row per session, newest first.
+
+    Every cell here is a label, a count or a file fact. Nothing a session
+    said is on this page, and the reader behind it never held any of it --
+    see the section comment on the parser.
+    """
+
+    root = found["root"]
+    body = [
+        "<h1>claude sessions</h1>\n",
+        '<p class="root">{0}</p>\n'.format(
+            html.escape(str(root)) if root is not None else html.escape(EMPTY_UNSET)
+        ),
+    ]
+    sessions = found["sessions"]
+    if sessions:
+        body.append(
+            '<p class="count">{0} · {1}</p>\n'.format(
+                html.escape(_plural(len(sessions), "session", "sessions")),
+                html.escape(
+                    _plural(len(found["projects"]), "project directory", "project directories")
+                ),
+            )
+        )
+    body.append(render_diagnostics(found["diagnostics"]))
+    if found["empty"]:
+        body.append('<p class="empty">{0}</p>\n'.format(html.escape(found["empty"])))
+    else:
+        body.append(
+            "<table>\n<thead>\n<tr>{0}</tr>\n</thead>\n<tbody>\n".format(
+                "".join("<th>{0}</th>".format(html.escape(h)) for h in SESSION_HEADINGS)
+            )
+        )
+        for session in sessions:
+            body.append(
+                _row(
+                    SESSION_COLUMNS,
+                    {
+                        "sid": '<a href="{href}">{sid}</a>'.format(
+                            href=session_href(session["id"]),
+                            sid=html.escape(session["id"]),
+                        ),
+                        "title": _cell(session["title"], EMPTY_NO_TITLE),
+                        "cwd": _session_cwd(session),
+                        "when": html.escape(_stamp(session["modified"])),
+                        "size": session["size"],
+                        "agents": session["agent_count"],
+                        # Empty on a healthy session: a permanent warning
+                        # slot would train the reader to stop reading it.
+                        "notes": html.escape(" · ".join(session["diagnostics"])),
+                    },
+                )
+            )
+        body.append("</tbody>\n</table>\n")
+    body.append('<p class="back"><a href="/">all runs</a></p>\n')
+    return _page("claude sessions", "".join(body))
+
+
+# A node box is NODE_WIDTH wide in a 12px monospace face, so this is what
+# fits on its first line. Everything cut here is on the row the node links
+# to, untruncated.
+NODE_LABEL_CHARS = 16
+
+
+def _clipped(value: str) -> str:
+    """A label cut to what a node box holds, with the cut marked.
+
+    Cut before escaping, never after: an escape sequence sliced in half is
+    not markup, but it is not the value either.
+    """
+
+    if len(value) <= NODE_LABEL_CHARS:
+        return value
+    return value[: NODE_LABEL_CHARS - 1] + "…"
+
+
+def _depth_label(agent: dict) -> str:
+    """One subagent's spawn depth, spelled out, or the named absence."""
+
+    if agent["depth"] is None:
+        return EMPTY_NO_DEPTH
+    return "depth {0}".format(agent["depth"])
+
+
+def _node_faces(session: dict, agents) -> dict:
+    """What each flowchart node draws, by node id.
+
+    Built here rather than inside the drawing loop: the orchestrator and a
+    subagent carry different facts through the same four presentation
+    channels, and the SVG must not be where that difference is decided.
+    ``label`` is the accessible name, and it is what makes the truncation
+    on the face of the node safe to do at all.
+    """
+
+    faces = {
+        ORCHESTRATOR_NODE: {
+            "anchor": ORCHESTRATOR_ANCHOR,
+            "css": "root",
+            "top": ORCHESTRATOR_NODE,
+            "bottom": _plural(len(agents), "subagent", "subagents"),
+            "label": "{0}: {1}".format(
+                ORCHESTRATOR_NODE, session["title"] or EMPTY_NO_TITLE
+            ),
+        }
+    }
+    for agent in agents:
+        seen = activity_presentation(agent["state"])
+        kind = agent["type"] or EMPTY_NO_TYPE
+        faces[agent["id"]] = {
+            "anchor": agent["id"],
+            "css": seen.word,
+            "top": _clipped(kind),
+            "bottom": "{0} {1} · d{2}".format(
+                seen.glyph, seen.word, "?" if agent["depth"] is None else agent["depth"]
+            ),
+            "label": "{0}: {1} · {2} · {3} ({4})".format(
+                kind,
+                agent["description"] or EMPTY_NO_DESCRIPTION,
+                _depth_label(agent),
+                seen.word,
+                agent["evidence"],
+            ),
+        }
+    return faces
+
+
+def render_session_svg(session: dict, layout: dict, inferred) -> str:
+    """One session's flowchart, drawn with the dependency graph's own
+    geometry, node idiom and arrow marker. An inferred edge is dashed and
+    the page says what a dashed edge means -- a guess drawn like a fact is
+    the failure this whole view exists to avoid."""
+
+    at = dict((node.id, node) for node in layout["nodes"])
+    faces = _node_faces(session, session["agents"])
+    parts = [
+        '<div class="canvas">\n<svg class="graph" viewBox="0 0 {width} {height}" '
+        'width="{width}" height="{height}" role="img" '
+        'aria-label="subagents of session {id}: {title}">\n'.format(
+            width=layout["width"],
+            height=layout["height"],
+            id=html.escape(session["id"]),
+            title=html.escape(session["title"] or EMPTY_NO_TITLE),
+        ),
+        '<defs><marker id="dep-arrow" viewBox="0 0 8 8" refX="8" refY="4" '
+        'markerWidth="6" markerHeight="6" orient="auto">'
+        '<path class="arrow" d="M0 0 L8 4 L0 8 z" /></marker></defs>\n',
+    ]
+    for source, target in layout["edges"]:
+        tail, head = at[source], at[target]
+        parts.append(
+            '<line class="edge{guess}" x1="{x1}" y1="{y1}" x2="{x2}" y2="{y2}" '
+            'marker-end="url(#dep-arrow)" />\n'.format(
+                guess=" edge-inferred" if (source, target) in inferred else "",
+                x1=tail.x + NODE_WIDTH // 2,
+                y1=tail.y + NODE_HEIGHT,
+                x2=head.x + NODE_WIDTH // 2,
+                y2=head.y,
+            )
+        )
+    for node in layout["nodes"]:
+        face = faces[node.id]
+        parts.append(
+            '<a href="{href}" aria-label="{label}">'
+            '<g class="nd nd-{css}" transform="translate({x},{y})">'
+            '<rect width="{w}" height="{h}" rx="5" />'
+            '<text class="nd-id" x="10" y="19">{top}</text>'
+            '<text class="nd-state" x="10" y="35">{bottom}</text>'
+            "</g></a>\n".format(
+                href=anchor_href(face["anchor"]),
+                label=html.escape(face["label"]),
+                css=face["css"],
+                x=node.x,
+                y=node.y,
+                w=NODE_WIDTH,
+                h=NODE_HEIGHT,
+                top=html.escape(face["top"]),
+                bottom=html.escape(face["bottom"]),
+            )
+        )
+    parts.append("</svg>\n</div>\n")
+    return "".join(parts)
+
+
+def _attachment(agent: dict, known: frozenset) -> str:
+    """The attachment cell: the node this subagent hangs off, and how that
+    was known -- the same provenance idiom, and for the same reason, as the
+    working directory's."""
+
+    return '{parent} <span class="src">{source}</span>'.format(
+        parent=html.escape(_agent_parent(agent, known) or ORCHESTRATOR_NODE),
+        source=html.escape(edge_source(agent, known)),
+    )
+
+
+def render_agents(session: dict) -> str:
+    """The row behind each node: everything the box was too small to hold,
+    untruncated, and the anchor its node links to."""
+
+    agents = session["agents"]
+    if not agents:
+        return '<p class="agents empty">{0}</p>\n'.format(html.escape(EMPTY_NO_AGENTS))
+    known = agent_ids(agents)
+    rows = [
+        "<table>\n<thead>\n<tr>{0}</tr>\n</thead>\n<tbody>\n".format(
+            "".join("<th>{0}</th>".format(html.escape(h)) for h in AGENT_HEADINGS)
+        )
+    ]
+    for agent in agents:
+        seen = activity_presentation(agent["state"])
+        rows.append(
+            _row(
+                AGENT_COLUMNS,
+                {
+                    "agent": html.escape(agent["id"]),
+                    "type": _cell(agent["type"], EMPTY_NO_TYPE),
+                    "description": _cell(agent["description"], EMPTY_NO_DESCRIPTION),
+                    "depth": _cell(
+                        "" if agent["depth"] is None else str(agent["depth"]),
+                        EMPTY_NO_DEPTH,
+                    ),
+                    "state": _pill(seen, html.escape(seen.word))
+                    + ' <span class="src">{0}</span>'.format(
+                        html.escape(agent["evidence"])
+                    ),
+                    "attached": _attachment(agent, known),
+                    "when": html.escape(_stamp(agent["modified"])),
+                },
+                agent["id"],
+            )
+        )
+    rows.append("</tbody>\n</table>\n")
+    return "".join(rows)
+
+
+def _agent_diagnostics(agents) -> list:
+    """What a subagent's metadata could not be read to say, how much of the
+    tree below is therefore a guess, and which guess it was.
+
+    Counted off the same ``edge_source`` the rows carry rather than off the
+    graph's edge list, so the sentence at the top of the page and the cell
+    partway down it cannot come to disagree.
+    """
+
+    lines = [
+        "{0}: {1}".format(DIAGNOSTIC_UNREADABLE_AGENT, agent["id"])
+        for agent in agents
+        if agent["unreadable"]
+    ]
+    known = agent_ids(agents)
+    guesses = [edge_source(agent, known) for agent in agents]
+    for label, diagnostic in (
+        (EDGE_INFERRED, DIAGNOSTIC_INFERRED_EDGE),
+        (EDGE_PARENT_UNRESOLVED, DIAGNOSTIC_UNRESOLVED_PARENT),
+    ):
+        drawn = guesses.count(label)
+        if drawn:
+            lines.append(
+                "{0} ({1})".format(diagnostic, _plural(drawn, "edge", "edges"))
+            )
+    return lines
+
+
+def render_session(session: dict) -> str:
+    """One Claude Code session as a flowchart: the orchestrator, every
+    subagent it spawned, and what each of them is doing.
+
+    Same content wall as the index. Every value here is a label, a count or
+    a file fact out of the subagent metadata; nothing any session or any
+    subagent said is on this page.
+    """
+
+    nodes, edges, inferred = session_graph(session["agents"])
+    layout = cached_layout(nodes, edges)
+    body = [
+        "<h1>{0}</h1>\n".format(html.escape(session["id"])),
+        '<p class="title" id="{anchor}">{title}</p>\n'.format(
+            anchor=ORCHESTRATOR_ANCHOR, title=_cell(session["title"], EMPTY_NO_TITLE)
+        ),
+        '<p class="root">{0}</p>\n'.format(_session_cwd(session)),
+        '<p class="count">{0} · {1}</p>\n'.format(
+            html.escape(_plural(len(session["agents"]), "subagent", "subagents")),
+            html.escape(_stamp(session["modified"])),
+        ),
+        render_diagnostics(
+            session["diagnostics"]
+            + _agent_diagnostics(session["agents"])
+            + layout["diagnostics"]
+        ),
+        render_session_svg(session, layout, inferred),
+        render_agents(session),
+        '<p class="back"><a href="{0}">all sessions</a></p>\n'.format(SESSIONS_ROUTE),
+    ]
+    return _page("{0} · session".format(session["id"]), "".join(body))
+
+
+def render_missing_session(session_id: str) -> str:
+    """The id comes from the query string, so it is escaped before it is
+    echoed back."""
+
+    return _page(
+        "not found",
+        "<h1>not found</h1>\n<p>{empty}: {id}</p>\n"
+        '<p class="back"><a href="{route}">all sessions</a></p>\n'.format(
+            empty=html.escape(EMPTY_NO_SESSION),
+            id=_cell(session_id, EMPTY_UNSET),
+            route=SESSIONS_ROUTE,
+        ),
+    )
+
+
 def _prose(body: str) -> str:
     """Ticket bodies are markdown, and rendering untrusted markdown as
     markup is what ``rules/visibility.md`` §6 forbids. The text goes out
@@ -1526,8 +2769,13 @@ def render_not_found(route: str) -> str:
     )
 
 
-def render_route(start, path: str) -> tuple:
-    """``(status, html)`` for one request path. Pure: reads, never writes."""
+def render_route(start, path: str, transcripts=None) -> tuple:
+    """``(status, html)`` for one request path. Pure: reads, never writes.
+
+    ``transcripts`` is threaded rather than resolved: passing ``None`` reads
+    no transcript at all, so nothing short of the entry point can reach the
+    operator's real ``~/.claude/projects``.
+    """
 
     parsed = urlsplit(path)
     if parsed.path == INDEX_ROUTE:
@@ -1549,6 +2797,14 @@ def render_route(start, path: str) -> tuple:
         return 200, render_graph(run, tickets, read_events(root, run))
     if parsed.path == FRICTION_ROUTE:
         return 200, render_friction(read_friction(_resolve_root(start)))
+    if parsed.path == SESSIONS_ROUTE:
+        return 200, render_sessions(read_sessions(transcripts))
+    if parsed.path == SESSION_ROUTE:
+        session_id = parse_qs(parsed.query).get("id", [""])[0]
+        session = find_session(transcripts, session_id)
+        if session is None:
+            return 404, render_missing_session(session_id)
+        return 200, render_session(read_session(session))
     return 404, render_not_found(parsed.path)
 
 
@@ -1597,7 +2853,7 @@ def live_meter_state(root, now=None) -> tuple:
     return tuple(measured)
 
 
-def state_digest(root, now=None) -> str:
+def state_digest(root, now=None, transcripts=None) -> str:
     """A fingerprint of everything the served page depends on under ``root``.
 
     Each file contributes its name, its size and its ``st_mtime_ns``. Size
@@ -1610,6 +2866,11 @@ def state_digest(root, now=None) -> str:
     an absence and an empty presence are two different pages. Each live
     elapsed meter contributes the minute it currently renders, because the
     clock is an input the filesystem does not record.
+
+    The transcript root contributes on the same terms. `U3` recorded the
+    lesson: a validator built over one directory while the reader had grown
+    a route reading another served a 304 to a page that had moved. The
+    basis is the whole read set, not the first tree that needed one.
     """
 
     base = Path(root)
@@ -1638,15 +2899,42 @@ def state_digest(root, now=None) -> str:
             )
     for name, elapsed in live_meter_state(base, now):
         digest.update("{0}\0{1}\n".format(name, elapsed).encode("utf-8"))
+    for entry in transcript_state(transcripts):
+        digest.update(
+            "{0}\0{1}\0{2}\n".format(entry[0], entry[1], entry[2]).encode("utf-8")
+        )
     return digest.hexdigest()
 
 
-def entity_tag(root, path: str, now=None) -> str:
-    """One page's validator: the state of everything read, bound to the
-    resource it was read for, quoted as RFC 7232 requires."""
+# The routes whose body is a function of the transcript tree. Every other
+# route renders `.orch/` alone.
+TRANSCRIPT_ROUTES = (SESSIONS_ROUTE, SESSION_ROUTE)
+
+
+def reads_transcripts(path: str) -> bool:
+    """Whether the page served for one request path reads the transcript
+    tree at all. ``render_route`` is the owner of that fact and this is the
+    same dispatch on the same parsed path."""
+
+    return urlsplit(path).path in TRANSCRIPT_ROUTES
+
+
+def entity_tag(root, path: str, now=None, transcripts=None) -> str:
+    """One page's validator: the state of everything *this page* read, bound
+    to the resource it was read for, quoted as RFC 7232 requires.
+
+    `U3`'s lesson cuts both ways. A basis narrower than the route's read set
+    serves a 304 to a page that has already moved. A basis wider than it
+    denies the 304 to a page that has not -- and here that is not a corner:
+    a live Claude Code session rewrites its transcript continuously, so a
+    `.orch/` page carrying the whole tree in its tag would never answer 304
+    again, and the one-second poll would swap `main` once a second over a
+    byte-identical body for as long as the viewer is open.
+    """
 
     digest = hashlib.sha256(path.encode("utf-8"))
-    digest.update(state_digest(root, now).encode("ascii"))
+    read = transcripts if reads_transcripts(path) else None
+    digest.update(state_digest(root, now, read).encode("ascii"))
     return '"{0}"'.format(digest.hexdigest()[:32])
 
 
@@ -1670,7 +2958,7 @@ def _etag_matches(header, etag: str) -> bool:
     return any(_unweighted(item) == _unweighted(etag) for item in sent)
 
 
-def respond(start, path: str, if_none_match=None) -> tuple:
+def respond(start, path: str, if_none_match=None, transcripts=None) -> tuple:
     """``(status, etag, html)`` for one request.
 
     A page whose validator the client already holds costs no ticket read
@@ -1680,10 +2968,10 @@ def respond(start, path: str, if_none_match=None) -> tuple:
     """
 
     root = _resolve_root(start)
-    etag = entity_tag(root, path)
+    etag = entity_tag(root, path, None, transcripts)
     if _etag_matches(if_none_match, etag):
         return 304, etag, ""
-    status, page = render_route(root, path)
+    status, page = render_route(root, path, transcripts)
     return (status, etag, page) if status == 200 else (status, "", page)
 
 
@@ -1691,12 +2979,15 @@ def respond(start, path: str, if_none_match=None) -> tuple:
 
 
 class ReaderServer(ThreadingHTTPServer):
-    """Carries the root, so the handler needs neither a global nor a closure."""
+    """Carries the roots, so the handler needs neither a global nor a
+    closure. ``transcripts`` is ``None`` where none was configured, and the
+    session views read nothing at all in that case."""
 
     daemon_threads = True
 
-    def __init__(self, address, handler_class, root: Path):
+    def __init__(self, address, handler_class, root: Path, transcripts=None):
         self.root = root
+        self.transcripts = transcripts
         ThreadingHTTPServer.__init__(self, address, handler_class)
 
 
@@ -1706,7 +2997,10 @@ class ReaderHandler(BaseHTTPRequestHandler):
 
     def do_GET(self):
         status, etag, page = respond(
-            self.server.root, self.path, self.headers.get("If-None-Match")
+            self.server.root,
+            self.path,
+            self.headers.get("If-None-Match"),
+            self.server.transcripts,
         )
         self.send_response(status)
         if etag:
@@ -1729,14 +3023,14 @@ class ReaderHandler(BaseHTTPRequestHandler):
         """Silent. The one line worth reading is the URL printed at start."""
 
 
-def create_server(root, port: int) -> ReaderServer:
-    """Bind loopback only. Nothing here authenticates a request and
-    ``.orch/`` is not public data, so the socket never leaves this host.
-    Port 0 asks the OS for a free port; the caller reads back
-    ``server_address``.
+def create_server(root, port: int, transcripts=None) -> ReaderServer:
+    """Bind loopback only. Nothing here authenticates a request, and neither
+    ``.orch/`` nor a transcript is public data -- the second emphatically so
+    -- therefore the socket never leaves this host. Port 0 asks the OS for a
+    free port; the caller reads back ``server_address``.
     """
 
-    return ReaderServer((LOOPBACK_HOST, port), ReaderHandler, Path(root))
+    return ReaderServer((LOOPBACK_HOST, port), ReaderHandler, Path(root), transcripts)
 
 
 def main(argv=None):
@@ -1749,9 +3043,16 @@ def main(argv=None):
     parser.add_argument(
         "--port", type=int, default=DEFAULT_PORT, help="loopback port; 0 picks a free one"
     )
+    parser.add_argument(
+        "--transcripts",
+        default=None,
+        help="Claude Code transcript root; defaults to ~/.claude/projects",
+    )
     args = parser.parse_args(sys.argv[1:] if argv is None else argv)
     try:
-        server = create_server(Path(args.root), args.port)
+        server = create_server(
+            Path(args.root), args.port, transcript_root(args.transcripts)
+        )
     except OSError as error:
         # DEFAULT_PORT is fixed, so a second viewer on one host lands here.
         print(

--- a/scripts/ui.py
+++ b/scripts/ui.py
@@ -1,0 +1,1774 @@
+#!/usr/bin/env python3
+"""Read-only local HTTP view of orchflows run state under ``.orch/``.
+
+Stdlib-only, cross-platform, and offline: every CSS byte is inlined from a
+module constant, so the page fetches nothing at view time. The process
+opens no file under ``.orch/`` for writing and creates no directory there.
+``.orch/`` is untrusted data per ``rules/visibility.md`` §6, so every value
+reaching the page passes ``html.escape`` and no ticket content is ever
+emitted as markup. The root is the main repository root -- a linked
+worktree's ``.git`` pointer is dereferenced to it, per
+``contracts/work-item.md`` -- so every worktree of a repository shows one
+run's tickets at one path. Binds loopback only, never ``0.0.0.0``.
+
+Usage:
+    ui.py [--root <path>] [--port <n>]
+"""
+
+from __future__ import annotations
+
+import argparse
+import graphlib
+import hashlib
+import html
+import json
+import re
+import sys
+from collections import namedtuple
+from datetime import datetime, timezone
+from fractions import Fraction
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from pathlib import Path
+from urllib.parse import parse_qs, quote, urlsplit
+
+# ``scripts/ui.py`` and ``scripts/tickets.py`` are siblings in the
+# repository and again in ``~/.orchflows/bin`` after ``install.py`` copies
+# them, so neither is ever a package member and a plain sibling import is
+# the only shape that works in both. Appended, never prepended: this
+# directory also holds ``trace.py``, which at sys.path[0] would shadow the
+# stdlib ``trace`` module for the whole process.
+_SIBLING_DIR = str(Path(__file__).resolve().parent)
+if _SIBLING_DIR not in sys.path:
+    sys.path.append(_SIBLING_DIR)
+
+from tickets import (  # noqa: E402
+    DURATION_RE,
+    _find_repo_root,
+    _parse_frontmatter,
+    _parse_iso,
+)
+
+LOOPBACK_HOST = "127.0.0.1"
+DEFAULT_PORT = 8787
+INDEX_ROUTE = "/"
+TICKET_ROUTE = "/ticket"
+GRAPH_ROUTE = "/graph"
+FRICTION_ROUTE = "/friction"
+# Every served path lives here. The read-only and no-network tests iterate
+# this tuple, so a route added by branching inside ``render_route`` instead
+# would be silently unguarded.
+ROUTES = (INDEX_ROUTE, TICKET_ROUTE, GRAPH_ROUTE, FRICTION_ROUTE)
+
+# Every directory the reader reads, named once. The conditional request's
+# digest and the readers that render these have to agree about what is
+# observed: where they disagree the page moves and the validator does not,
+# and a poll is answered 304 against state that already changed.
+ORCH_DIR = (".orch",)
+TICKETS_DIR = (".orch", "tickets")
+FRICTION_DIR = (".orch", "friction")
+EVENTS_DIR = (".orch", "events")
+TICKET_SUFFIX = ".md"
+JSONL_SUFFIX = ".jsonl"
+
+# Named empty states. Absent data is normal in a live ``.orch/`` -- a run
+# can be cut before any ticket lands, a ticket can predate a section -- so
+# every absence renders as one of these rather than raising or vanishing.
+EMPTY_NO_ORCH = "no .orch directory under this root"
+EMPTY_NO_RUNS = "no runs under .orch/tickets"
+EMPTY_NO_TICKETS = "no tickets in this run"
+EMPTY_NO_OBJECTIVE = "no objective recorded"
+EMPTY_SECTION = "section is empty"
+EMPTY_NO_METER = "no elapsed meter"
+EMPTY_NO_RUN = "no run by that name under this root"
+EMPTY_NO_FRICTION = "no friction log under this root"
+EMPTY_UNSET = "unset"
+
+# `contracts/work-item.md`: `suspended` "stays claimed", so the lease keeps
+# running and elapsed-against-bound still measures something. Under every
+# other status the claim is not live and a growing meter would be a lie --
+# no ticket records when work stopped.
+LIVE_CLAIM_STATUSES = ("claimed", "suspended")
+
+# The band answers "who is working right now", which `suspended` is not: it
+# holds the lease with nobody at the keyboard. A wider set here would read
+# as more parallelism than the run has.
+ACTIVE_STATUS = "claimed"
+
+VERIFICATION_SECTION = "Verification"
+VERIFICATION_COLUMNS = ("#", "verdict", "oracle", "class", "evidence")
+VERIFICATION_ROWS = "rows"
+VERIFICATION_UNPARSED = "unparsed"
+VERIFICATION_UNPARSED_NOTE = (
+    "unparsed: not a five-column verdict table, shown verbatim"
+)
+
+SECTION_RE = re.compile(r"^## +(.+?)[ \t]*$", re.MULTILINE)
+UNESCAPED_PIPE_RE = re.compile(r"(?<!\\)\|")
+# Tickets quote markdown at each other -- a handoff record, a spec excerpt --
+# so a fenced block whose content starts with `## ` is ordinary corpus
+# content. Up to three leading spaces open a fence; deeper indentation is
+# already an indented code block, whose lines cannot match ``SECTION_RE``.
+FENCE_RE = re.compile(r"^[ \t]{0,3}(?P<marker>`{3,}|~{3,})(?P<info>.*)$")
+
+
+# --- status presentation -----------------------------------------------------
+
+# Four channels per status, because colour alone excludes a colourblind or
+# monochrome reader: the glyph carries the state on its own, the word names
+# it, the border separates the states that share a hue, and hue is
+# reinforcement only. Argo Workflows' graph node is icon + label + genre for
+# the same reason (`lane-ui-patterns.md` §2.3).
+StatusPresentation = namedtuple("StatusPresentation", ("glyph", "word", "hue", "border"))
+
+# Hue tokens are CSS custom property *names*, never colour values: the
+# palette is the design spec's deliverable and has to pass a contrast
+# oracle. The family recorded against each token is the part this module
+# does fix, sourced to Airflow 2.10.5 `airflow/utils/state.py` via
+# `lane-ui-patterns.md` §2 -- `upstream_failed: orange` is deliberately not
+# `failed: red`, and `running: lime` is deliberately not `success: green`.
+HUE_TOKENS = {
+    "--st-waiting": "slate",
+    "--st-ready": "blue",
+    "--st-running": "cyan",
+    "--st-attention": "amber",
+    "--st-ok": "green",
+    "--st-failed": "red",
+    # Not a state and deliberately not coloured as one: an unrecognized
+    # status tinted slate would read as a wait. See STATUS_FALLBACK.
+    "--st-unknown": "neutral",
+}
+
+# Eight statuses onto six hues, so exactly two pairs share one. The pairs
+# are the contract's own groupings (`contracts/work-item.md`): `pending` and
+# `suspended` are its two non-terminal waits, `blocked` and `limited` its
+# two terminal halts that are not failures. Red is reserved for `failed`
+# alone, so red anywhere on the page means one thing.
+#
+# Glyphs are single text-presentation code points from the system font
+# stack -- no icon font, no SVG, and nothing from the emoji blocks, which
+# render as colour images on Windows and would smuggle in a seventh hue.
+STATUS_PRESENTATION = {
+    # U+25CB WHITE CIRCLE: deps unmet, not eligible.
+    "pending": StatusPresentation("○", "pending", "--st-waiting", "1px dotted"),
+    # U+25D4 CIRCLE WITH UPPER RIGHT QUADRANT BLACK: eligible, unclaimed.
+    "ready": StatusPresentation("◔", "ready", "--st-ready", "1px solid"),
+    # U+25D0 CIRCLE WITH LEFT HALF BLACK: in flight.
+    "claimed": StatusPresentation("◐", "claimed", "--st-running", "2px solid"),
+    # U+2016 DOUBLE VERTICAL LINE: paused, resumable from its `## Handoff`.
+    "suspended": StatusPresentation("‖", "suspended", "--st-waiting", "2px dashed"),
+    # U+2713 CHECK MARK: terminal, every required criterion PASS.
+    "complete": StatusPresentation("✓", "complete", "--st-ok", "1px solid"),
+    # U+2298 CIRCLED DIVISION SLASH: halted by something upstream.
+    "blocked": StatusPresentation("⊘", "blocked", "--st-attention", "2px dashed"),
+    # U+2715 MULTIPLICATION X: terminal, bad.
+    "failed": StatusPresentation("✕", "failed", "--st-failed", "1px solid"),
+    # U+25A4 SQUARE WITH HORIZONTAL FILL: stopped at a bound, hence the
+    # doubled border -- a wall, and the channel that separates it from
+    # `blocked` on the shared amber.
+    "limited": StatusPresentation("▤", "limited", "--st-attention", "3px double"),
+}
+
+# `.orch/` is untrusted data, so the status field can hold anything. It gets
+# a hue of its own: borrowing a real state's colour would render an
+# unreadable value as a state the ticket is not in.
+STATUS_FALLBACK = StatusPresentation("?", "unknown", "--st-unknown", "1px dotted")
+
+
+def status_presentation(status: str) -> StatusPresentation:
+    """Total over every possible field value; never raises."""
+
+    return STATUS_PRESENTATION.get(status, STATUS_FALLBACK)
+
+
+# An SVG rect has no `border`, so the border style that separates the two
+# pairs sharing a hue is restated as a stroke pattern. Same four channels,
+# same owner: both renderings are generated from STATUS_PRESENTATION.
+SVG_DASH = {"solid": "none", "dashed": "5 3", "dotted": "1 3", "double": "9 2 1 2"}
+
+
+def _svg_stroke(presentation: StatusPresentation) -> tuple:
+    """``(stroke-width, stroke-dasharray)`` for one status's CSS border."""
+
+    width, _, style = presentation.border.partition(" ")
+    return width.replace("px", "").strip() or "1", SVG_DASH.get(style.strip(), "none")
+
+
+def _status_css() -> str:
+    """Derived from STATUS_PRESENTATION so a status cannot carry one hue in
+    the module and another in the stylesheet."""
+
+    lines = [
+        "  /* Hue tokens are names, not colours: the palette is the design",
+        "     spec's deliverable. Until it lands every token resolves to the",
+        "     inherited text colour, so this file asserts no colour at all. */",
+        "  :root { " + " ".join("{0}: currentColor;".format(t) for t in HUE_TOKENS) + " }",
+        "  .st { display: inline-block; padding: 0 .35rem; border-radius: .25rem;",
+        "        white-space: nowrap; }",
+        "  .st .glyph { font-style: normal; }",
+    ]
+    for presentation in [STATUS_FALLBACK] + list(STATUS_PRESENTATION.values()):
+        stroke_width, dash = _svg_stroke(presentation)
+        lines.append(
+            "  .st-{word} {{ border: {border} var({hue}); }}".format(
+                word=presentation.word, border=presentation.border, hue=presentation.hue
+            )
+        )
+        lines.append(
+            "  .nd-{word} rect {{ stroke: var({hue}); stroke-width: {stroke_width};"
+            " stroke-dasharray: {dash}; }}".format(
+                word=presentation.word,
+                hue=presentation.hue,
+                stroke_width=stroke_width,
+                dash=dash,
+            )
+        )
+    return "\n".join(lines) + "\n"
+
+
+# Structural only. Visual form is a later spec's deliverable; this is the
+# minimum that keeps a table legible. Carried as a constant rather than a
+# sidecar file because install.py's SCRIPT_NAMES ships flat filenames, so a
+# sidecar asset would never reach ~/.orchflows/bin.
+PAGE_CSS = (
+    """
+  body { margin: 0; font: 15px/1.5 system-ui, sans-serif; }
+  main { max-width: 64rem; margin: 0 auto; padding: 1.5rem; }
+  h1 { font-size: 1.2rem; }
+  h2 { font-size: 1rem; margin-top: 1.75rem; }
+  table { border-collapse: collapse; width: 100%; }
+  th, td { border-bottom: 1px solid #ccc; padding: .3rem .5rem;
+           text-align: left; vertical-align: top; }
+  th { font-weight: 600; white-space: nowrap; }
+  .root { font-family: ui-monospace, monospace; font-size: .85rem; }
+  .empty { font-style: italic; }
+  pre { white-space: pre-wrap; margin: .25rem 0; font-size: .9rem; }
+  .meta, .claim, .count, .back { margin: .25rem 0; }
+  .count { font-size: .85rem; }
+  .diagnostics { margin: .5rem 0; padding-left: 1.2rem; font-size: .9rem; }
+  .band { list-style: none; margin: .5rem 0; padding: 0; }
+  .band li { padding: .2rem 0; border-bottom: 1px solid #ccc; }
+  .feed { list-style: none; margin: .5rem 0; padding: 0; }
+  .entry, .event { padding: .4rem 0; border-bottom: 1px solid #ccc; }
+  .entry p, .event p { margin: .1rem 0; }
+  .ts { font-family: ui-monospace, monospace; font-size: .85rem; }
+  .canvas { overflow: auto; max-width: 100%; }
+  .graph { max-width: 100%; height: auto; }
+  .graph .edge { stroke: currentColor; stroke-width: 1; fill: none; }
+  .graph .arrow { fill: currentColor; }
+  .graph rect { fill: none; }
+  .graph text { font: 12px/1 ui-monospace, monospace; fill: currentColor; }
+  .graph .nd-state { font-size: 11px; }
+  .graph a { text-decoration: none; }
+"""
+    + _status_css()
+)
+
+# A ticket under one of these is a ticket something is about to happen to.
+# Under every other status the run only moves once one of these does, so
+# there is nothing for a one-second poll to catch. `suspended` holds the
+# lease with nobody at the keyboard and belongs on the slow interval.
+POLL_FAST_STATUSES = ("claimed", "ready")
+POLL_LIVE_MS = 1000
+POLL_IDLE_MS = 5000
+POLL_HIDDEN_MS = 15000
+
+# Inline for the same reason as the CSS: `install.py` ships flat filenames,
+# so a sidecar asset would never reach ~/.orchflows/bin -- and a remote one
+# is forbidden outright. Interpolated as a `.format` *value*, so its braces
+# are never a format field.
+_POLL_CONSTANTS = "  var LIVE_MS = {0}, IDLE_MS = {1}, HIDDEN_MS = {2};\n".format(
+    POLL_LIVE_MS, POLL_IDLE_MS, POLL_HIDDEN_MS
+)
+
+PAGE_JS = (
+    "\n(function () {\n"
+    + _POLL_CONSTANTS
+    + """  var tag = null;
+  var timer = null;
+  function delay() {
+    if (document.hidden) { return HIDDEN_MS; }
+    var here = document.querySelector('main');
+    return here && here.dataset.live === 'yes' ? LIVE_MS : IDLE_MS;
+  }
+  function schedule() {
+    window.clearTimeout(timer);
+    // A timeout the answer reschedules, never a fixed repeating timer: a
+    // slow answer must not queue the next request behind it, and the
+    // stdlib server serves one at a time.
+    timer = window.setTimeout(poll, delay());
+  }
+  function poll() {
+    var headers = tag ? {'If-None-Match': tag} : {};
+    window.fetch(window.location.href, {headers: headers}).then(function (r) {
+      var seen = r.headers.get('ETag');
+      if (seen) { tag = seen; }
+      return r.status === 304 ? null : r.text();
+    }).then(function (text) {
+      if (text === null) { return; }
+      var doc = new DOMParser().parseFromString(text, 'text/html');
+      var fresh = doc.querySelector('main');
+      var here = document.querySelector('main');
+      if (fresh && here) { here.replaceWith(fresh); }
+    }).catch(function () {
+      // The viewer outlives the server it reads: keep the loop alive so a
+      // restarted server is picked up without a manual reload.
+    }).then(schedule);
+  }
+  document.addEventListener('visibilitychange', schedule);
+  schedule();
+})();
+"""
+)
+
+
+# --- discovery ---------------------------------------------------------------
+
+
+def _scalar(value) -> str:
+    """Frontmatter values are scalars or lists; presentation wants a scalar."""
+
+    return value.strip() if isinstance(value, str) else ""
+
+
+def _sequence(value) -> tuple:
+    """A frontmatter list as a tuple of non-empty strings. A key written as
+    a bare scalar where the contract says list is one item, not an error:
+    ``.orch/`` is untrusted data and the graph reads what is there."""
+
+    if isinstance(value, str):
+        value = [value]
+    if not isinstance(value, list):
+        return ()
+    return tuple(item.strip() for item in value if isinstance(item, str) and item.strip())
+
+
+def _fenced_spans(text: str) -> list:
+    """``(start, end)`` offsets of every fenced code block. An unclosed
+    fence runs to the end of the text, as CommonMark says it does."""
+
+    spans = []
+    offset = 0
+    opener = None
+    start = 0
+    for line in text.splitlines(True):
+        match = FENCE_RE.match(line.rstrip("\r\n"))
+        if match is not None:
+            marker = match.group("marker")
+            if opener is None:
+                opener, start = marker, offset
+            elif marker[0] == opener[0] and len(marker) >= len(opener):
+                # A closing fence carries no info string.
+                if not match.group("info").strip():
+                    spans.append((start, offset + len(line)))
+                    opener = None
+        offset += len(line)
+    if opener is not None:
+        spans.append((start, len(text)))
+    return spans
+
+
+def split_sections(text: str) -> dict:
+    """Map each ``## Heading`` to its body text; first occurrence wins.
+    Headings inside a fenced block are content, not structure."""
+
+    sections = {}
+    spans = _fenced_spans(text)
+    matches = [
+        match
+        for match in SECTION_RE.finditer(text)
+        if not any(start <= match.start() < end for start, end in spans)
+    ]
+    for index, match in enumerate(matches):
+        end = matches[index + 1].start() if index + 1 < len(matches) else len(text)
+        name = match.group(1)
+        if name not in sections:
+            sections[name] = text[match.end() : end].strip()
+    return sections
+
+
+def _row_cells(line: str):
+    """The cells of one markdown table row, or ``None`` when the line is
+    not a row. A ``\\|`` is escaped content rather than a column boundary:
+    the corpus carries regexes with alternation in its evidence column."""
+
+    stripped = line.strip()
+    if not stripped.startswith("|"):
+        return None
+    cells = UNESCAPED_PIPE_RE.split(stripped)
+    # A leading and a trailing pipe each produce one empty edge cell.
+    if cells and not cells[0].strip():
+        cells = cells[1:]
+    if cells and not cells[-1].strip():
+        cells = cells[:-1]
+    return [cell.replace("\\|", "|").strip() for cell in cells]
+
+
+def _is_separator(cells) -> bool:
+    return bool(cells) and all(set(c) <= set("-: ") and "-" in c for c in cells)
+
+
+def parse_verification(body: str) -> dict:
+    """One ``## Verification`` body as ``{"state", "rows"}``.
+
+    Two shapes exist in the corpus and only one is machine-readable: the
+    five-column verdict table parses, a numbered prose list does not. The
+    unreadable shape is reported ``unparsed`` and shown verbatim, never as
+    zero rows -- "verified nothing" and "verdicts I cannot read" are
+    different facts, and a viewer must not hand a reader the wrong one. A
+    row disagreeing with the header's width makes the whole section
+    unparsed for the same reason: half a table is a wrong count of
+    verdicts, not a partial one.
+    """
+
+    lines = body.splitlines()
+    for index, line in enumerate(lines):
+        header = _row_cells(line)
+        if header is None or [c.lower() for c in header] != list(VERIFICATION_COLUMNS):
+            continue
+        rows = []
+        for following in lines[index + 1 :]:
+            cells = _row_cells(following)
+            if cells is None:
+                break
+            if _is_separator(cells):
+                continue
+            if len(cells) != len(VERIFICATION_COLUMNS):
+                return {"state": VERIFICATION_UNPARSED, "rows": []}
+            rows.append(dict(zip(VERIFICATION_COLUMNS, cells)))
+        if rows:
+            return {"state": VERIFICATION_ROWS, "rows": rows}
+        break
+    return {"state": VERIFICATION_UNPARSED, "rows": []}
+
+
+def read_ticket(path: Path) -> dict:
+    """One ticket's presentation fields. An unreadable or malformed file
+    yields the same shape with empty values -- never an exception."""
+
+    try:
+        text = path.read_text(encoding="utf-8", errors="replace")
+    except OSError:
+        text = ""
+    front = _parse_frontmatter(text)
+    sections = split_sections(text)
+    return {
+        "id": _scalar(front.get("id")) or path.stem,
+        # The other identity. Every link the page emits is built from `id`,
+        # but a lookup resolves `<file_id>.md`, so the two are carried
+        # separately and `identity_diagnostics` names them where they
+        # disagree instead of leaving the reader a dead link.
+        "file_id": path.stem,
+        "status": _scalar(front.get("status")),
+        "executor": _scalar(front.get("executor")),
+        "bound": _scalar(front.get("bound")),
+        "claimed_at": _scalar(front.get("claimed_at")),
+        "claimed_by": _scalar(front.get("claimed_by")),
+        "depends_on": _sequence(front.get("depends_on")),
+        "objective": sections.get("Objective", ""),
+        "sections": sections,
+        "path": str(path),
+    }
+
+
+def bound_minutes(bound):
+    """Minutes, or ``None`` when ``bound`` is not a duration.
+
+    Deliberately unlike ``scripts/tickets.py``'s ``_parse_bound_minutes``,
+    which substitutes ``DEFAULT_BOUND_MINUTES`` so a claim can still be
+    aged: a lease needs some number, but a viewer does not. The observed
+    real value is ``one session``, and a meter drawn against an invented
+    60-minute denominator would report progress no ticket ever stated.
+    """
+
+    match = DURATION_RE.match(bound.strip()) if isinstance(bound, str) else None
+    if match is None:
+        return None
+    return int(match.group(1)) * (60 if match.group(2) == "h" else 1)
+
+
+def _now() -> datetime:
+    """The wall clock, read in exactly one place.
+
+    Every value on the page that moves while no file moves comes through
+    here, so the digest that validates the page and the render that draws
+    it read one clock -- and a test can hold it still.
+    """
+
+    return datetime.now(timezone.utc)
+
+
+def claim_meter(front: dict, now=None):
+    """Elapsed against bound for a live claim, or ``None``.
+
+    ``None`` in every degraded case -- no live claim, no duration bound, no
+    parsable ``claimed_at`` -- because a meter is a measurement and there is
+    nothing here to measure. ``front`` is any mapping carrying ``status``,
+    ``bound`` and ``claimed_at``: a ticket record or raw frontmatter.
+    """
+
+    if _scalar(front.get("status")) not in LIVE_CLAIM_STATUSES:
+        return None
+    minutes = bound_minutes(_scalar(front.get("bound")))
+    if not minutes or minutes <= 0:
+        return None
+    started = _parse_iso(_scalar(front.get("claimed_at")))
+    if started is None:
+        return None
+    now = _now() if now is None else now
+    # A clock skewed behind the claim would otherwise render a negative bar.
+    elapsed = max(int((now - started).total_seconds() // 60), 0)
+    return {
+        "elapsed_minutes": elapsed,
+        "bound_minutes": minutes,
+        "percent": min(int(round(elapsed * 100.0 / minutes)), 100),
+        "over": elapsed > minutes,
+    }
+
+
+# One path component's byte ceiling. POSIX `NAME_MAX` is 255 on every
+# filesystem this runs on and Windows caps a component at 255 characters,
+# so a longer name is one no store can hold: the path layer answers
+# `ENAMETOOLONG` rather than "no such file", and an `OSError` out of a
+# lookup is not one of the two answers these functions promise.
+MAX_NAME_BYTES = 255
+# A control character is never part of a run name or a ticket id, and NUL
+# is the one the path layer refuses outright -- `Path.resolve` raises
+# `ValueError: embedded null byte`, which `BaseHTTPRequestHandler` does not
+# catch, so the client gets no HTTP response at all and `socketserver`
+# prints the absolute tickets path to stderr.
+UNSAFE_NAME_RE = re.compile(r"[\x00-\x1f\x7f/\\]")
+
+
+def _safe_name(value) -> str:
+    """One path component, or ``""``.
+
+    The query string is the only untrusted input that becomes a path, so
+    this is the whole boundary between it and the filesystem. A value that
+    could climb out of the tickets tree, or that the path layer would
+    refuse to look up at all, resolves to nothing here rather than raising
+    somewhere below.
+    """
+
+    if not isinstance(value, str) or not value or value in (".", ".."):
+        return ""
+    if UNSAFE_NAME_RE.search(value):
+        return ""
+    if len(value.encode("utf-8", "replace")) > MAX_NAME_BYTES:
+        return ""
+    return value
+
+
+def _in_tree(base: Path, *parts):
+    """``base`` joined with ``parts`` and resolved, or ``None`` when the
+    result escapes ``base`` or the host's path layer refuses the name.
+
+    ``_safe_name`` rejects every value known to reach here badly; this is
+    the same guarantee one layer down, for the shapes a single host cannot
+    enumerate -- a total path over the platform's own limit, say. The
+    callers promise a value or ``None``, never an exception, on any string
+    a client can put in a query.
+    """
+
+    try:
+        root = base.resolve()
+        candidate = root.joinpath(*parts).resolve()
+        return candidate if root in candidate.parents else None
+    except (OSError, ValueError):
+        return None
+
+
+def find_ticket(root: Path, run: str, ticket_id: str):
+    """One ticket by run and id, or ``None``. Never walks the whole tree,
+    and never resolves outside ``.orch/tickets/``."""
+
+    run, ticket_id = _safe_name(run), _safe_name(ticket_id)
+    # The name a lookup uses carries the suffix, so it is that name -- not
+    # the id it came from -- that has to clear the component ceiling.
+    if not run or not ticket_id or not _safe_name(ticket_id + TICKET_SUFFIX):
+        return None
+    path = _in_tree(Path(root).joinpath(*TICKETS_DIR), run, ticket_id + TICKET_SUFFIX)
+    try:
+        found = path is not None and path.is_file()
+    except OSError:
+        return None
+    return read_ticket(path) if found else None
+
+
+def run_tickets(root: Path, run: str):
+    """Every ticket in one run, or ``None`` when the run does not resolve.
+    Guarded like ``find_ticket``: the run name is client-supplied."""
+
+    run = _safe_name(run)
+    if not run:
+        return None
+    run_dir = _in_tree(Path(root).joinpath(*TICKETS_DIR), run)
+    try:
+        found = run_dir is not None and run_dir.is_dir()
+    except OSError:
+        return None
+    if not found:
+        return None
+    return [read_ticket(path) for path in sorted(run_dir.glob("*" + TICKET_SUFFIX))]
+
+
+def graph_input(tickets) -> tuple:
+    """``(node ids, edges)`` for one run. An edge runs from a dependency to
+    the ticket that declares it, so it points up the layers."""
+
+    ids = tuple(ticket["id"] for ticket in tickets)
+    edges = tuple(
+        (dependency, ticket["id"])
+        for ticket in tickets
+        for dependency in ticket["depends_on"]
+    )
+    return ids, edges
+
+
+# Named for the same reason the layout's DIAGNOSTIC_CYCLE and
+# DIAGNOSTIC_DANGLING are: this reader says what it cannot honour. A ticket
+# whose frontmatter `id:` is not its file name is reachable from nothing
+# the page draws -- the index row, the graph node and the active band all
+# link `id`, and every lookup resolves `<file name>.md` -- and two files
+# declaring one id collapse onto one node, hiding the other ticket
+# outright. Nothing on the write path prevents either: a ticket copied or
+# renamed between runs keeps the id it was written with.
+DIAGNOSTIC_ID_MISMATCH = "frontmatter id does not name its own file"
+DIAGNOSTIC_ID_COLLISION = "one id declared by two files"
+
+
+def identity_diagnostics(tickets) -> list:
+    """Every place a run's tickets disagree about their own identity."""
+
+    diagnostics = [
+        "{0}: {1} in {2}{3}".format(
+            DIAGNOSTIC_ID_MISMATCH, ticket["id"], ticket["file_id"], TICKET_SUFFIX
+        )
+        for ticket in tickets
+        if ticket["id"] != ticket["file_id"]
+    ]
+    files = {}
+    for ticket in tickets:
+        files.setdefault(ticket["id"], []).append(ticket["file_id"] + TICKET_SUFFIX)
+    for ticket_id in sorted(name for name, seen in files.items() if len(seen) > 1):
+        diagnostics.append(
+            "{0}: {1} declared by {2}".format(
+                DIAGNOSTIC_ID_COLLISION, ticket_id, ", ".join(sorted(files[ticket_id]))
+            )
+        )
+    return diagnostics
+
+
+FRICTION_KEYS = ("ts", "observed", "expected", "category", "host")
+_EPOCH = datetime(1970, 1, 1, tzinfo=timezone.utc)
+
+
+def _stamp_order(entry: dict) -> tuple:
+    """Newest first. An entry whose ``ts`` will not parse sorts last rather
+    than jumping the queue on a string comparison."""
+
+    stamp = _parse_iso(_scalar(entry.get("ts")))
+    return (stamp is not None, stamp or _EPOCH)
+
+
+def _read_jsonl(text: str, entries: list) -> int:
+    """Append every JSON object in ``text`` to ``entries``; return the count
+    of lines that were not one.
+
+    Both logs this reader shows are append-only JSONL written by a process
+    that may be killed mid-line, so a half-written tail is expected rather
+    than exceptional. One bad line costs that line and nothing else: the
+    friction law's whole point is that observations survive, and the events
+    seam is held to the same handling by sharing this code rather than by
+    resembling it.
+    """
+
+    skipped = 0
+    for line in text.splitlines():
+        if not line.strip():
+            continue
+        try:
+            entry = json.loads(line)
+        except ValueError:
+            entry = None
+        if isinstance(entry, dict):
+            entries.append(entry)
+        else:
+            skipped += 1
+    return skipped
+
+
+def read_friction(root) -> dict:
+    """Every friction entry under ``root``, newest first, with a count of
+    the lines that could not be read as one."""
+
+    directory = Path(root).joinpath(*FRICTION_DIR)
+    entries = []
+    skipped = 0
+    for path in sorted(directory.glob("*" + JSONL_SUFFIX)) if directory.is_dir() else ():
+        try:
+            text = path.read_text(encoding="utf-8", errors="replace")
+        except OSError:
+            # Unreadable this poll; the next one tries again.
+            continue
+        skipped += _read_jsonl(text, entries)
+    entries.sort(key=_stamp_order, reverse=True)
+    return {"entries": entries, "skipped": skipped}
+
+
+def read_events(root, run: str):
+    """One run's hook events, newest first, or ``None`` when it has no log.
+
+    The deferred hooks seam the spec's ``binding_constraints`` fix so v2 is
+    additive: ``.orch/events/<run>.jsonl``, one JSON object per line,
+    carrying ``ts``, ``run``, ``ticket``, ``agent``, ``event``, ``tool`` and
+    ``detail``. No hook writes it in this version, so ``None`` is the
+    ordinary answer and it has to stay silent -- a heading over an empty
+    feed would promise a stream nothing produces.
+    """
+
+    run = _safe_name(run)
+    if not run or not _safe_name(run + JSONL_SUFFIX):
+        return None
+    path = _in_tree(Path(root).joinpath(*EVENTS_DIR), run + JSONL_SUFFIX)
+    try:
+        found = path is not None and path.is_file()
+    except OSError:
+        return None
+    if not found:
+        return None
+    try:
+        text = path.read_text(encoding="utf-8", errors="replace")
+    except OSError:
+        # Unreadable this poll; the next one tries again. Silence is the
+        # documented answer for an absent log, and this is not that.
+        return {"entries": [], "skipped": 0}
+    entries = []
+    skipped = _read_jsonl(text, entries)
+    entries.sort(key=_stamp_order, reverse=True)
+    return {"entries": entries, "skipped": skipped}
+
+
+def active_claims(discovery: dict) -> list:
+    """Every ticket under way, paired with the run it belongs to.
+
+    Ticket ids are unique only within a run, so an id alone would not say
+    which claim it is.
+    """
+
+    return [
+        {"run": run["run"], "ticket": ticket}
+        for run in discovery["runs"]
+        for ticket in run["tickets"]
+        if ticket["status"] == ACTIVE_STATUS
+    ]
+
+
+def _resolve_root(start) -> Path:
+    """``start``'s main checkout root.
+
+    ``start`` may be a linked worktree, the main checkout, or any directory
+    inside either; when it is not inside a git repository at all it is used
+    as the root itself, so the viewer can be pointed at a bare copy of an
+    ``.orch/`` tree.
+    """
+
+    start_path = Path(start)
+    root = _find_repo_root(start_path)
+    return start_path.resolve() if root is None else root
+
+
+def discover(start) -> dict:
+    """Every run and ticket under ``start``'s main checkout."""
+
+    root = _resolve_root(start)
+    tickets_root = root / ".orch" / "tickets"
+    runs = []
+    if not (root / ".orch").is_dir():
+        empty = EMPTY_NO_ORCH
+    else:
+        if tickets_root.is_dir():
+            for run_dir in sorted(p for p in tickets_root.iterdir() if p.is_dir()):
+                runs.append(
+                    {
+                        "run": run_dir.name,
+                        "tickets": [read_ticket(p) for p in sorted(run_dir.glob("*.md"))],
+                    }
+                )
+        empty = "" if runs else EMPTY_NO_RUNS
+    return {"root": root, "empty": empty, "runs": runs}
+
+
+# --- dependency graph layout -------------------------------------------------
+
+# A layered layout with a Coffman-Graham sorter, computed here rather than
+# in the browser: Argo Workflows ships the same two phases hand-rolled in
+# 56 + 48 lines with zero dependencies for graphs far larger than this
+# project's 3-12 tickets (`lane-ui-patterns.md` §3), and in Python it falls
+# under `unittest discover`, so a layout bug is a failing test rather than
+# a visual regression nobody catches.
+
+# Coffman-Graham's width bound W. Four keeps a run inside a laptop viewport;
+# a wider fan spills onto further layers instead of off the right edge.
+LAYER_WIDTH = 4
+NODE_WIDTH = 132
+NODE_HEIGHT = 44
+GAP_X = 24
+GAP_Y = 52
+MARGIN = 16
+
+# Coordinates are integers, so "two calls return byte-equal coordinates" is
+# a fact about the layout rather than about float formatting.
+LayoutNode = namedtuple("LayoutNode", ("id", "layer", "order", "x", "y"))
+
+# What the layout cannot honour it names. Both shapes occur on real data:
+# nothing on the write path proves a `depends_on` set is acyclic, and a
+# ticket copied between runs keeps a `depends_on` its new run cannot
+# resolve.
+DIAGNOSTIC_CYCLE = "dependency cycle"
+DIAGNOSTIC_DANGLING = "depends_on names no ticket in this run"
+
+
+def layout_key(node_ids, edges) -> tuple:
+    """The node-and-edge set, normalized, and nothing else.
+
+    Nothing derived from a ticket's *state* may reach this key: re-laying
+    out a graph on a refresh that moved no node is the live defect
+    `lane-ui-patterns.md` §6(3) records in Argo, whose own fix sits in the
+    source commented out. Sorting here is also what makes the layout
+    independent of the order the tickets happened to be read in.
+    """
+
+    return (tuple(sorted(set(node_ids))), tuple(sorted(set(edges))))
+
+
+def _rotated(cycle) -> list:
+    """A reported cycle restated from its lexicographically smallest node,
+    so the diagnostic reads the same however the detector entered it."""
+
+    ring = list(cycle[:-1]) if len(cycle) > 1 and cycle[0] == cycle[-1] else list(cycle)
+    if not ring:
+        return []
+    start = ring.index(min(ring))
+    ring = ring[start:] + ring[:start]
+    return ring + [ring[0]]
+
+
+def _break_cycles(node_ids, edges) -> tuple:
+    """``(edges with every back arc withheld, one diagnostic per cycle)``.
+
+    ``graphlib.TopologicalSorter`` exists at the 3.9 floor and reports the
+    offending nodes rather than leaving them to be guessed. Only an arc the
+    detector itself named is withheld, so each pass makes progress; the
+    loop is bounded by the edge count, so the pathological set costs time
+    and never the process.
+    """
+
+    kept = list(edges)
+    diagnostics = []
+    for _ in range(len(edges) + 1):
+        sorter = graphlib.TopologicalSorter()
+        for node in node_ids:
+            sorter.add(node)
+        for source, target in kept:
+            sorter.add(target, source)
+        try:
+            sorter.prepare()
+            return kept, diagnostics
+        except graphlib.CycleError as error:
+            ring = _rotated(list(error.args[1]))
+            arcs = set()
+            for index in range(len(ring) - 1):
+                arcs.add((ring[index], ring[index + 1]))
+                arcs.add((ring[index + 1], ring[index]))
+            droppable = sorted(arc for arc in arcs if arc in kept)
+            if not droppable:
+                break
+            kept.remove(droppable[0])
+            diagnostics.append(
+                "{0}: {1}; edge {2} -> {3} not drawn".format(
+                    DIAGNOSTIC_CYCLE,
+                    " -> ".join(ring),
+                    droppable[0][0],
+                    droppable[0][1],
+                )
+            )
+    return kept, diagnostics
+
+
+def _predecessors(node_ids, edges) -> dict:
+    """``{node: sorted dependencies}``, every node present."""
+
+    preds = dict((node, set()) for node in node_ids)
+    for source, target in edges:
+        preds[target].add(source)
+    return dict((node, sorted(values)) for node, values in preds.items())
+
+
+def _coffman_graham_order(node_ids, preds) -> list:
+    """Coffman-Graham phase 1: label each node only once every predecessor
+    carries a label, taking the candidate whose predecessor labels are
+    lexicographically smallest. The tie-break on the id is load-bearing --
+    without it the whole layout depends on iteration order."""
+
+    labels = {}
+    order = []
+    remaining = list(node_ids)
+    while remaining:
+        best = None
+        for node in remaining:
+            if any(p not in labels for p in preds[node]):
+                continue
+            key = (sorted((labels[p] for p in preds[node]), reverse=True), node)
+            if best is None or key < best:
+                best = key
+        if best is None:
+            # No candidate means a cycle reached this far. Unreachable once
+            # `_break_cycles` has run; kept so a caller that skipped it
+            # degrades to input order rather than looping forever.
+            order.extend(remaining)
+            break
+        labels[best[1]] = len(labels)
+        order.append(best[1])
+        remaining.remove(best[1])
+    return order
+
+
+def _layer_assignment(order, preds, width) -> dict:
+    """Coffman-Graham phase 2: each node lands on the lowest layer that is
+    strictly above every predecessor's and is not already full. Every edge
+    is therefore upward by construction, not by a later repair pass."""
+
+    layers = {}
+    occupancy = {}
+    for node in order:
+        layer = max((layers[p] + 1 for p in preds[node] if p in layers), default=0)
+        while occupancy.get(layer, 0) >= width:
+            layer += 1
+        layers[node] = layer
+        occupancy[layer] = occupancy.get(layer, 0) + 1
+    return layers
+
+
+def _barycenter(node, preds, placed) -> Fraction:
+    """The mean position of a node's already-placed predecessors, exactly.
+    A float mean sorts the same today and is one rounding change away from
+    not doing so. A node with no placed predecessor floats left."""
+
+    positions = [placed[p] for p in preds[node] if p in placed]
+    if not positions:
+        return Fraction(-1)
+    return Fraction(sum(positions), len(positions))
+
+
+def _within_layer_order(node_ids, layers, preds) -> dict:
+    """One barycenter sweep down the layers. Crossing reduction is one of
+    the two things dagre buys over Argo's hand-rolled layout, and one sweep
+    is most of it at this size; ties break on the id."""
+
+    members = {}
+    for node in node_ids:
+        members.setdefault(layers[node], []).append(node)
+    placed = {}
+    for layer in sorted(members):
+        ordered = sorted(
+            members[layer], key=lambda node: (_barycenter(node, preds, placed), node)
+        )
+        for index, node in enumerate(ordered):
+            placed[node] = index
+    return placed
+
+
+def graph_layout(node_ids, edges) -> dict:
+    """Coordinates for one run's dependency graph.
+
+    ``edges`` run from a dependency to the ticket that declares it, so an
+    edge always points up the layers. Returns ``nodes``, the ``edges``
+    actually drawn, any ``diagnostics``, and the canvas size.
+
+    O(V^2 log V + E) -- the Coffman-Graham labelling is the quadratic term,
+    which at 3-12 tickets is a few hundred comparisons.
+    """
+
+    ids, given = layout_key(node_ids, edges)
+    known = set(ids)
+    diagnostics = []
+    missing = sorted({end for edge in given for end in edge} - known)
+    if missing:
+        diagnostics.append("{0}: {1}".format(DIAGNOSTIC_DANGLING, ", ".join(missing)))
+    kept, cycles = _break_cycles(
+        ids, [edge for edge in given if edge[0] in known and edge[1] in known]
+    )
+    diagnostics.extend(cycles)
+    preds = _predecessors(ids, kept)
+    order = _coffman_graham_order(ids, preds)
+    layers = _layer_assignment(order, preds, LAYER_WIDTH)
+    placed = _within_layer_order(ids, layers, preds)
+    nodes = [
+        LayoutNode(
+            node,
+            layers[node],
+            placed[node],
+            MARGIN + placed[node] * (NODE_WIDTH + GAP_X),
+            MARGIN + layers[node] * (NODE_HEIGHT + GAP_Y),
+        )
+        for node in ids
+    ]
+    columns = max((node.order for node in nodes), default=-1) + 1
+    rows = max((node.layer for node in nodes), default=-1) + 1
+    return {
+        "nodes": nodes,
+        "edges": list(kept),
+        "diagnostics": diagnostics,
+        "width": MARGIN * 2 + columns * NODE_WIDTH + max(columns - 1, 0) * GAP_X,
+        "height": MARGIN * 2 + rows * NODE_HEIGHT + max(rows - 1, 0) * GAP_Y,
+    }
+
+
+LAYOUT_CACHE = {}
+LAYOUT_CACHE_LIMIT = 32
+
+
+def cached_layout(node_ids, edges) -> dict:
+    """``graph_layout`` memoized on the node-and-edge set alone.
+
+    Status is deliberately absent from the key: a poll that repaints a
+    ticket from claimed to complete moved no node, so it must not pay for
+    a layout. Bounded and insertion-ordered, because the process outlives
+    every run it is asked about.
+    """
+
+    key = layout_key(node_ids, edges)
+    layout = LAYOUT_CACHE.get(key)
+    if layout is None:
+        layout = graph_layout(node_ids, edges)
+        if len(LAYOUT_CACHE) >= LAYOUT_CACHE_LIMIT:
+            excess = len(LAYOUT_CACHE) - LAYOUT_CACHE_LIMIT + 1
+            for stale in list(LAYOUT_CACHE)[:excess]:
+                LAYOUT_CACHE.pop(stale, None)
+        LAYOUT_CACHE[key] = layout
+    return layout
+
+
+# --- rendering ---------------------------------------------------------------
+
+
+def _plural(count: int, singular: str, plural: str) -> str:
+    return "{0} {1}".format(count, singular if count == 1 else plural)
+
+
+def _cell(value: str, fallback: str) -> str:
+    """One table cell. Every branch escapes: ``.orch/`` is untrusted data."""
+
+    if value:
+        return html.escape(value)
+    return '<span class="empty">{0}</span>'.format(html.escape(fallback))
+
+
+def render_status(status: str) -> str:
+    """The status pill: glyph, word, and a class binding the hue token and
+    the border style. A value outside the contract's set keeps its own
+    text, escaped, beside the named fallback -- hiding an unrecognized
+    status would hide exactly the state a reader came to see. An absent
+    status is an empty state rather than a state."""
+
+    if not status:
+        return _cell("", EMPTY_UNSET)
+    seen = status_presentation(status)
+    text = html.escape(seen.word)
+    if status not in STATUS_PRESENTATION:
+        text = "{0} {1}".format(text, html.escape(status))
+    # The glyph is aria-hidden because the word beside it says the same
+    # thing; a screen reader announcing the code point would only add noise.
+    return (
+        '<span class="st st-{word}">'
+        '<span class="glyph" aria-hidden="true">{glyph}</span> {text}</span>'
+    ).format(word=seen.word, glyph=seen.glyph, text=text)
+
+
+def is_live(tickets) -> bool:
+    """Whether anything on this page can move without a human first moving
+    something else. It sets the poll interval, so it is a property of what
+    the page shows rather than of the root."""
+
+    return any(ticket["status"] in POLL_FAST_STATUSES for ticket in tickets)
+
+
+def _page(title: str, body: str, tickets=()) -> str:
+    return (
+        "<!DOCTYPE html>\n"
+        '<html lang="en">\n<head>\n<meta charset="utf-8">\n'
+        '<meta name="viewport" content="width=device-width, initial-scale=1">\n'
+        "<title>{title}</title>\n<style>{css}</style>\n</head>\n"
+        '<body>\n<main data-live="{live}">\n{body}</main>\n'
+        "<script>{js}</script>\n</body>\n</html>\n"
+    ).format(
+        title=html.escape(title),
+        css=PAGE_CSS,
+        live="yes" if is_live(tickets) else "no",
+        body=body,
+        js=PAGE_JS,
+    )
+
+
+def ticket_href(run: str, ticket_id: str) -> str:
+    """A same-origin relative link. Run and id are directory and file names
+    from untrusted data, so both are percent-encoded whole -- nothing in
+    them survives as URL structure -- and then escaped as markup."""
+
+    return html.escape(
+        "{route}?run={run}&id={id}".format(
+            route=TICKET_ROUTE, run=quote(run, safe=""), id=quote(ticket_id, safe="")
+        )
+    )
+
+
+def graph_href(run: str) -> str:
+    return html.escape(
+        "{route}?run={run}".format(route=GRAPH_ROUTE, run=quote(run, safe=""))
+    )
+
+
+def _meter(ticket: dict) -> str:
+    """The elapsed bar, or the named reason there is none.
+
+    Where a live claim has no meter the absence is named, because that is
+    the common case on real data and a reader should not have to wonder
+    whether the bar failed to draw.
+    """
+
+    meter = claim_meter(ticket)
+    if meter is not None:
+        return (
+            ' · <progress max="100" value="{percent}">{percent}%</progress>'
+            " {elapsed}m of {bound}m{over}".format(
+                percent=meter["percent"],
+                elapsed=meter["elapsed_minutes"],
+                bound=meter["bound_minutes"],
+                over=", over bound" if meter["over"] else "",
+            )
+        )
+    if ticket["status"] in LIVE_CLAIM_STATUSES:
+        reason = (
+            "bound is not a duration"
+            if bound_minutes(ticket["bound"]) is None
+            else "no claim time to measure from"
+        )
+        return ' · <span class="empty">{0}: {1}</span>'.format(
+            html.escape(EMPTY_NO_METER), html.escape(reason)
+        )
+    return ""
+
+
+def render_active_band(claims) -> str:
+    """Who is at work right now, across every run.
+
+    Absent when nobody is: an empty band is furniture that says nothing,
+    and the reader would still have to scan the tables to be sure.
+    """
+
+    if not claims:
+        return ""
+    parts = ['<ul class="band">\n']
+    for claim in claims:
+        ticket = claim["ticket"]
+        parts.append(
+            '<li class="claim"><a href="{href}">{id}</a> · {run} · {executor}'
+            " · {claimed_by}{meter}</li>\n".format(
+                href=ticket_href(claim["run"], ticket["id"]),
+                id=html.escape(ticket["id"]),
+                run=html.escape(claim["run"]),
+                executor=_cell(ticket["executor"], EMPTY_UNSET),
+                claimed_by=_cell(ticket["claimed_by"], EMPTY_UNSET),
+                meter=_meter(ticket),
+            )
+        )
+    parts.append("</ul>\n")
+    return "".join(parts)
+
+
+def render_index(discovery: dict) -> str:
+    parts = [
+        "<h1>orchflows runs</h1>\n",
+        '<p class="root">{0}</p>\n'.format(html.escape(str(discovery["root"]))),
+        '<p class="back"><a href="{0}">friction log</a></p>\n'.format(FRICTION_ROUTE),
+        render_active_band(active_claims(discovery)),
+    ]
+    if discovery["empty"]:
+        parts.append('<p class="empty">{0}</p>\n'.format(html.escape(discovery["empty"])))
+    for run in discovery["runs"]:
+        parts.append(
+            '<section class="run">\n<h2>{name}</h2>\n'
+            '<p class="back"><a href="{href}">dependency graph</a></p>\n'.format(
+                name=html.escape(run["run"]), href=graph_href(run["run"])
+            )
+        )
+        # Named here as well as on the graph, because every row below is a
+        # link built from an id the lookup may not resolve.
+        parts.append(render_diagnostics(identity_diagnostics(run["tickets"])))
+        if not run["tickets"]:
+            parts.append('<p class="empty">{0}</p>\n'.format(html.escape(EMPTY_NO_TICKETS)))
+        else:
+            parts.append(
+                "<table>\n<thead>\n<tr><th>id</th><th>status</th>"
+                "<th>executor</th><th>objective</th></tr>\n</thead>\n<tbody>\n"
+            )
+            for ticket in run["tickets"]:
+                parts.append(
+                    '<tr><td><a href="{href}">{id}</a></td><td>{status}</td>'
+                    "<td>{executor}</td><td>{objective}</td></tr>\n".format(
+                        href=ticket_href(run["run"], ticket["id"]),
+                        id=html.escape(ticket["id"]),
+                        status=render_status(ticket["status"]),
+                        executor=_cell(ticket["executor"], EMPTY_UNSET),
+                        objective=_cell(ticket["objective"], EMPTY_NO_OBJECTIVE),
+                    )
+                )
+            parts.append("</tbody>\n</table>\n")
+        parts.append("</section>\n")
+    return _page(
+        "orchflows runs",
+        "".join(parts),
+        [ticket for run in discovery["runs"] for ticket in run["tickets"]],
+    )
+
+
+def render_diagnostics(diagnostics) -> str:
+    """What the layout could not honour, named on the page. Silent when
+    there is nothing to say -- an empty list rendered as an empty box would
+    read as a warning nobody can act on."""
+
+    if not diagnostics:
+        return ""
+    return '<ul class="diagnostics">\n{0}</ul>\n'.format(
+        "".join("<li>{0}</li>\n".format(html.escape(line)) for line in diagnostics)
+    )
+
+
+def render_graph_svg(run: str, tickets, layout: dict) -> str:
+    """The dependency graph as inline SVG at natural size inside a
+    scrollable box. No canvas and no pan/zoom: at 3-12 nodes both are
+    machinery with no keyboard path (`lane-ui-patterns.md` §3.2)."""
+
+    at = dict((node.id, node) for node in layout["nodes"])
+    state = dict((ticket["id"], ticket["status"]) for ticket in tickets)
+    parts = [
+        '<div class="canvas">\n<svg class="graph" viewBox="0 0 {width} {height}" '
+        'width="{width}" height="{height}" role="img" '
+        'aria-label="dependency graph for {run}">\n'.format(
+            width=layout["width"], height=layout["height"], run=html.escape(run)
+        ),
+        '<defs><marker id="dep-arrow" viewBox="0 0 8 8" refX="8" refY="4" '
+        'markerWidth="6" markerHeight="6" orient="auto">'
+        '<path class="arrow" d="M0 0 L8 4 L0 8 z" /></marker></defs>\n',
+    ]
+    for source, target in layout["edges"]:
+        tail, head = at[source], at[target]
+        parts.append(
+            '<line class="edge" x1="{x1}" y1="{y1}" x2="{x2}" y2="{y2}" '
+            'marker-end="url(#dep-arrow)" />\n'.format(
+                x1=tail.x + NODE_WIDTH // 2,
+                y1=tail.y + NODE_HEIGHT,
+                x2=head.x + NODE_WIDTH // 2,
+                y2=head.y,
+            )
+        )
+    for node in layout["nodes"]:
+        seen = status_presentation(state.get(node.id, ""))
+        parts.append(
+            '<a href="{href}"><g class="nd nd-{word}" transform="translate({x},{y})">'
+            '<rect width="{w}" height="{h}" rx="5" />'
+            '<text class="nd-id" x="10" y="19">{id}</text>'
+            '<text class="nd-state" x="10" y="35">{glyph} {word}</text>'
+            "</g></a>\n".format(
+                href=ticket_href(run, node.id),
+                word=seen.word,
+                glyph=seen.glyph,
+                x=node.x,
+                y=node.y,
+                w=NODE_WIDTH,
+                h=NODE_HEIGHT,
+                id=html.escape(node.id),
+            )
+        )
+    parts.append("</svg>\n</div>\n")
+    return "".join(parts)
+
+
+def render_events(log) -> str:
+    """One run's hook events, newest first, or nothing at all.
+
+    ``None`` is the seam's "the file does not exist" half, and it renders
+    as silence: no heading, no count, no empty state. A malformed line is
+    skipped and counted, exactly as the friction feed reports one.
+    """
+
+    if log is None:
+        return ""
+    entries = log["entries"]
+    counted = _plural(len(entries), "event", "events")
+    if log["skipped"]:
+        counted = "{0} · {1}".format(
+            counted, _plural(log["skipped"], "unreadable line", "unreadable lines")
+        )
+    parts = [
+        '<section class="events">\n<h2>events</h2>\n',
+        '<p class="count">{0}</p>\n'.format(html.escape(counted)),
+    ]
+    if entries:
+        parts.append('<ul class="feed">\n')
+        for entry in entries:
+            parts.append(
+                '<li class="event">\n<p class="meta">'
+                '<span class="ts">{ts}</span> · {run} · {event}</p>\n'
+                '<p class="who">{agent} · {ticket}</p>\n'
+                '<p class="did">{tool} · {detail}</p>\n</li>\n'.format(
+                    ts=html.escape(_scalar(entry.get("ts"))),
+                    run=_cell(_scalar(entry.get("run")), EMPTY_UNSET),
+                    event=_cell(_scalar(entry.get("event")), EMPTY_UNSET),
+                    agent=_cell(_scalar(entry.get("agent")), EMPTY_UNSET),
+                    ticket=_cell(_scalar(entry.get("ticket")), EMPTY_UNSET),
+                    tool=_cell(_scalar(entry.get("tool")), EMPTY_UNSET),
+                    detail=_cell(_scalar(entry.get("detail")), EMPTY_UNSET),
+                )
+            )
+        parts.append("</ul>\n")
+    parts.append("</section>\n")
+    return "".join(parts)
+
+
+def render_graph(run: str, tickets, events=None) -> str:
+    """One run's dependency graph, its coordinates computed here rather
+    than in the browser."""
+
+    layout = cached_layout(*graph_input(tickets))
+    body = [
+        "<h1>{0}</h1>\n".format(html.escape(run)),
+        '<p class="count">{0} · {1}</p>\n'.format(
+            _plural(len(tickets), "ticket", "tickets"),
+            _plural(len(layout["edges"]), "dependency", "dependencies"),
+        ),
+        render_diagnostics(identity_diagnostics(tickets) + layout["diagnostics"]),
+    ]
+    if not tickets:
+        body.append('<p class="empty">{0}</p>\n'.format(html.escape(EMPTY_NO_TICKETS)))
+    else:
+        body.append(render_graph_svg(run, tickets, layout))
+    body.append(render_events(events))
+    body.append('<p class="back"><a href="/">all runs</a></p>\n')
+    return _page("{0} · graph".format(run), "".join(body), tickets)
+
+
+def render_missing_run(run: str) -> str:
+    """The run name comes from the query string, so it is escaped before it
+    is echoed back."""
+
+    return _page(
+        "not found",
+        "<h1>not found</h1>\n<p>{empty}: {run}</p>\n"
+        '<p class="back"><a href="/">all runs</a></p>\n'.format(
+            empty=html.escape(EMPTY_NO_RUN), run=_cell(run, EMPTY_UNSET)
+        ),
+    )
+
+
+def render_friction(log: dict) -> str:
+    """The friction log, newest first, over every month it spans."""
+
+    entries = log["entries"]
+    counted = _plural(len(entries), "entry", "entries")
+    if log["skipped"]:
+        counted = "{0} · {1} skipped".format(
+            counted, _plural(log["skipped"], "unreadable line", "unreadable lines")
+        )
+    body = [
+        "<h1>friction</h1>\n",
+        '<p class="count">{0}</p>\n'.format(html.escape(counted)),
+    ]
+    if entries:
+        body.append('<ul class="feed">\n')
+        for entry in entries:
+            body.append(
+                '<li class="entry">\n<p class="meta">'
+                '<span class="ts">{ts}</span> · {category} · {host}</p>\n'
+                '<p class="observed">observed: {observed}</p>\n'
+                '<p class="expected">expected: {expected}</p>\n</li>\n'.format(
+                    ts=html.escape(_scalar(entry.get("ts"))),
+                    category=_cell(_scalar(entry.get("category")), EMPTY_UNSET),
+                    host=_cell(_scalar(entry.get("host")), EMPTY_UNSET),
+                    observed=_cell(_scalar(entry.get("observed")), EMPTY_UNSET),
+                    expected=_cell(_scalar(entry.get("expected")), EMPTY_UNSET),
+                )
+            )
+        body.append("</ul>\n")
+    elif not log["skipped"]:
+        # With skipped lines the count line already says a log was found and
+        # what became of it; claiming there is none would be the wrong story.
+        body.append('<p class="empty">{0}</p>\n'.format(html.escape(EMPTY_NO_FRICTION)))
+    body.append('<p class="back"><a href="/">all runs</a></p>\n')
+    return _page("friction", "".join(body))
+
+
+def _prose(body: str) -> str:
+    """Ticket bodies are markdown, and rendering untrusted markdown as
+    markup is what ``rules/visibility.md`` §6 forbids. The text goes out
+    escaped inside a ``pre``, so its own structure survives without any of
+    it becoming an element."""
+
+    if not body.strip():
+        return '<p class="empty">{0}</p>\n'.format(html.escape(EMPTY_SECTION))
+    return "<pre>{0}</pre>\n".format(html.escape(body))
+
+
+def render_verification(body: str) -> str:
+    """The verdict table, or the section verbatim under the explicit state
+    ``unparsed``. The count is emitted only where rows were actually read,
+    so no reader is ever shown a verdict count the ticket does not have."""
+
+    parsed = parse_verification(body)
+    parts = ['<section class="verification">\n<h2>{0}</h2>\n'.format(VERIFICATION_SECTION)]
+    if parsed["state"] == VERIFICATION_ROWS:
+        rows = parsed["rows"]
+        parts.append('<p class="count">{0} entries</p>\n'.format(len(rows)))
+        parts.append(
+            "<table>\n<thead>\n<tr>{0}</tr>\n</thead>\n<tbody>\n".format(
+                "".join("<th>{0}</th>".format(html.escape(c)) for c in VERIFICATION_COLUMNS)
+            )
+        )
+        for row in rows:
+            parts.append(
+                "<tr>{0}</tr>\n".format(
+                    "".join(
+                        "<td>{0}</td>".format(html.escape(row[c]))
+                        for c in VERIFICATION_COLUMNS
+                    )
+                )
+            )
+        parts.append("</tbody>\n</table>\n")
+    else:
+        parts.append('<p class="empty">{0}</p>\n'.format(html.escape(VERIFICATION_UNPARSED_NOTE)))
+        parts.append(_prose(body))
+    parts.append("</section>\n")
+    return "".join(parts)
+
+
+def render_sections(sections: dict) -> str:
+    """Every section the ticket carries, in the order it carries them.
+
+    A section the ticket omits is absent here too: a heading with nothing
+    under it would claim the ticket says something it does not. A name the
+    contract does not fix still renders -- ``contracts/work-item.md`` lets a
+    domain extend the section set, so dropping an unrecognized heading would
+    hide real state.
+    """
+
+    parts = []
+    for name, body in sections.items():
+        if name == VERIFICATION_SECTION:
+            parts.append(render_verification(body))
+        else:
+            parts.append(
+                '<section class="body">\n<h2>{0}</h2>\n{1}</section>\n'.format(
+                    html.escape(name), _prose(body)
+                )
+            )
+    return "".join(parts)
+
+
+def render_claim(ticket: dict) -> str:
+    """The claim: its bound, its start, and an elapsed meter only where both
+    operands exist."""
+
+    return '<p class="claim">bound {bound} · claimed {claimed}{meter}</p>\n'.format(
+        bound=_cell(ticket["bound"], EMPTY_UNSET),
+        claimed=_cell(ticket["claimed_at"], EMPTY_UNSET),
+        meter=_meter(ticket),
+    )
+
+
+def render_ticket(run: str, ticket: dict) -> str:
+    body = "".join(
+        [
+            "<h1>{0}</h1>\n".format(html.escape(ticket["id"])),
+            '<p class="meta">{run} · {status} · {executor}</p>\n'.format(
+                run=html.escape(run),
+                status=render_status(ticket["status"]),
+                executor=_cell(ticket["executor"], EMPTY_UNSET),
+            ),
+            '<p class="root">{0}</p>\n'.format(html.escape(ticket["path"])),
+            render_claim(ticket),
+            render_sections(ticket["sections"]),
+            '<p class="back"><a href="/">all runs</a></p>\n',
+        ]
+    )
+    return _page("{0} · {1}".format(ticket["id"], run), body, [ticket])
+
+
+def render_missing_ticket(run: str, ticket_id: str) -> str:
+    """Both values come from the query string, so both are escaped before
+    they are echoed back."""
+
+    return _page(
+        "not found",
+        "<h1>not found</h1>\n<p>no ticket {id} in run {run} under this root</p>\n"
+        '<p class="back"><a href="/">all runs</a></p>\n'.format(
+            id=_cell(ticket_id, EMPTY_UNSET), run=_cell(run, EMPTY_UNSET)
+        ),
+    )
+
+
+def render_not_found(route: str) -> str:
+    """The requested path is client-supplied, so it is escaped like any
+    other untrusted value before it is echoed back."""
+
+    return _page(
+        "not found",
+        "<h1>not found</h1>\n<p>no route serves {0}</p>\n".format(html.escape(route)),
+    )
+
+
+def render_route(start, path: str) -> tuple:
+    """``(status, html)`` for one request path. Pure: reads, never writes."""
+
+    parsed = urlsplit(path)
+    if parsed.path == INDEX_ROUTE:
+        return 200, render_index(discover(start))
+    if parsed.path == TICKET_ROUTE:
+        query = parse_qs(parsed.query)
+        run = query.get("run", [""])[0]
+        ticket_id = query.get("id", [""])[0]
+        ticket = find_ticket(_resolve_root(start), run, ticket_id)
+        if ticket is None:
+            return 404, render_missing_ticket(run, ticket_id)
+        return 200, render_ticket(run, ticket)
+    if parsed.path == GRAPH_ROUTE:
+        run = parse_qs(parsed.query).get("run", [""])[0]
+        root = _resolve_root(start)
+        tickets = run_tickets(root, run)
+        if tickets is None:
+            return 404, render_missing_run(run)
+        return 200, render_graph(run, tickets, read_events(root, run))
+    if parsed.path == FRICTION_ROUTE:
+        return 200, render_friction(read_friction(_resolve_root(start)))
+    return 404, render_not_found(parsed.path)
+
+
+# --- conditional requests ----------------------------------------------------
+
+# Walked for their contents. `.orch` itself is observed for its presence
+# alone: `discover` renders a different named empty state for "no `.orch/`
+# at all" than for "`.orch/` carrying neither tickets nor friction", so a
+# digest that could not tell the two apart would answer 304 across the very
+# transition a viewer left open on a fresh checkout is waiting for.
+STATE_DIRS = (TICKETS_DIR, FRICTION_DIR, EVENTS_DIR)
+OBSERVED_DIRS = (ORCH_DIR,) + STATE_DIRS
+
+
+def live_meter_state(root, now=None) -> tuple:
+    """``(ticket file, elapsed minutes)`` for every meter now on screen.
+
+    The elapsed meter is the one thing the page draws that moves while no
+    file moves: ``claim_meter`` measures against the wall clock. A digest
+    built from file state alone therefore answers 304 to a bar that is
+    visibly wrong, and it does so worst in exactly the state the
+    one-second poll exists for -- a claim running past its bound never
+    reaches ", over bound" because the page never repaints.
+
+    A ticket with no live measurable claim contributes nothing, so a run
+    whose every ticket is terminal digests to one value forever and keeps
+    its 304. What is contributed is the rendered minute count rather than
+    the clock, so the validator changes when the reader would see a
+    different number and not once a second.
+    """
+
+    tickets_root = Path(root).joinpath(*TICKETS_DIR)
+    if not tickets_root.is_dir():
+        return ()
+    measured = []
+    for path in sorted(tickets_root.rglob("*" + TICKET_SUFFIX)):
+        try:
+            text = path.read_text(encoding="utf-8", errors="replace")
+        except OSError:
+            continue
+        meter = claim_meter(_parse_frontmatter(text), now)
+        if meter is not None:
+            measured.append(
+                (path.relative_to(tickets_root).as_posix(), meter["elapsed_minutes"])
+            )
+    return tuple(measured)
+
+
+def state_digest(root, now=None) -> str:
+    """A fingerprint of everything the served page depends on under ``root``.
+
+    Each file contributes its name, its size and its ``st_mtime_ns``. Size
+    is in the digest because a filesystem that records mtime to the second
+    -- every FAT volume, and HFS+ before APFS -- would otherwise call two
+    writes in the same second one state, and the view would sit stale until
+    some unrelated edit moved the clock on.
+
+    Each observed directory contributes whether it exists at all, because
+    an absence and an empty presence are two different pages. Each live
+    elapsed meter contributes the minute it currently renders, because the
+    clock is an input the filesystem does not record.
+    """
+
+    base = Path(root)
+    digest = hashlib.sha256()
+    for parts in OBSERVED_DIRS:
+        digest.update(
+            "{0}\0{1}\n".format(
+                "/".join(parts), int(base.joinpath(*parts).is_dir())
+            ).encode("utf-8")
+        )
+    for parts in STATE_DIRS:
+        directory = base.joinpath(*parts)
+        if not directory.is_dir():
+            continue
+        for path in sorted(directory.rglob("*")):
+            try:
+                stat = path.stat()
+            except OSError:
+                # Gone between the walk and the stat. Its absence is itself
+                # a change, which the next poll digests.
+                continue
+            digest.update(
+                "{0}\0{1}\0{2}\n".format(
+                    path.relative_to(base).as_posix(), stat.st_size, stat.st_mtime_ns
+                ).encode("utf-8")
+            )
+    for name, elapsed in live_meter_state(base, now):
+        digest.update("{0}\0{1}\n".format(name, elapsed).encode("utf-8"))
+    return digest.hexdigest()
+
+
+def entity_tag(root, path: str, now=None) -> str:
+    """One page's validator: the state of everything read, bound to the
+    resource it was read for, quoted as RFC 7232 requires."""
+
+    digest = hashlib.sha256(path.encode("utf-8"))
+    digest.update(state_digest(root, now).encode("ascii"))
+    return '"{0}"'.format(digest.hexdigest()[:32])
+
+
+def _unweighted(tag: str) -> str:
+    return tag[2:] if tag.startswith("W/") else tag
+
+
+def _etag_matches(header, etag: str) -> bool:
+    """RFC 7232 §3.2: ``If-None-Match`` is ``*`` or a list of tags, and the
+    comparison is weak, so a ``W/`` prefix on either side is not a mismatch.
+
+    Splitting the list on commas is safe because the only tags that can
+    match are the ones minted here, and those are hex.
+    """
+
+    if not header:
+        return False
+    sent = [item.strip() for item in header.split(",") if item.strip()]
+    if "*" in sent:
+        return True
+    return any(_unweighted(item) == _unweighted(etag) for item in sent)
+
+
+def respond(start, path: str, if_none_match=None) -> tuple:
+    """``(status, etag, html)`` for one request.
+
+    A page whose validator the client already holds costs no ticket read
+    and no layout -- which is what makes a one-second poll affordable.
+    Only a 200 carries a tag: a 404 offers nothing to revalidate, and a
+    client holding no tag for a path can never be answered 304 for it.
+    """
+
+    root = _resolve_root(start)
+    etag = entity_tag(root, path)
+    if _etag_matches(if_none_match, etag):
+        return 304, etag, ""
+    status, page = render_route(root, path)
+    return (status, etag, page) if status == 200 else (status, "", page)
+
+
+# --- serving -----------------------------------------------------------------
+
+
+class ReaderServer(ThreadingHTTPServer):
+    """Carries the root, so the handler needs neither a global nor a closure."""
+
+    daemon_threads = True
+
+    def __init__(self, address, handler_class, root: Path):
+        self.root = root
+        ThreadingHTTPServer.__init__(self, address, handler_class)
+
+
+class ReaderHandler(BaseHTTPRequestHandler):
+    server_version = "orchflows-ui"
+    sys_version = ""
+
+    def do_GET(self):
+        status, etag, page = respond(
+            self.server.root, self.path, self.headers.get("If-None-Match")
+        )
+        self.send_response(status)
+        if etag:
+            self.send_header("ETag", etag)
+        # A live view of a directory that changes underneath it: hold the
+        # page but revalidate every time. `no-store` would forbid holding
+        # it at all, so no client would ever send `If-None-Match` and the
+        # 304 would be unreachable.
+        self.send_header("Cache-Control", "no-cache")
+        if status == 304:
+            self.end_headers()
+            return
+        body = page.encode("utf-8")
+        self.send_header("Content-Type", "text/html; charset=utf-8")
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+    def log_message(self, format, *args):
+        """Silent. The one line worth reading is the URL printed at start."""
+
+
+def create_server(root, port: int) -> ReaderServer:
+    """Bind loopback only. Nothing here authenticates a request and
+    ``.orch/`` is not public data, so the socket never leaves this host.
+    Port 0 asks the OS for a free port; the caller reads back
+    ``server_address``.
+    """
+
+    return ReaderServer((LOOPBACK_HOST, port), ReaderHandler, Path(root))
+
+
+def main(argv=None):
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument(
+        "--root",
+        default=".",
+        help="any path inside the repository; resolved to the main checkout",
+    )
+    parser.add_argument(
+        "--port", type=int, default=DEFAULT_PORT, help="loopback port; 0 picks a free one"
+    )
+    args = parser.parse_args(sys.argv[1:] if argv is None else argv)
+    try:
+        server = create_server(Path(args.root), args.port)
+    except OSError as error:
+        # DEFAULT_PORT is fixed, so a second viewer on one host lands here.
+        print(
+            "cannot bind port {0}: {1}".format(args.port, error),
+            file=sys.stderr,
+        )
+        return 2
+    host, port = server.server_address[0], server.server_address[1]
+    print("orchflows ui on http://{0}:{1}/ -- ctrl-c to stop".format(host, port))
+    try:
+        server.serve_forever()
+    except KeyboardInterrupt:
+        pass
+    finally:
+        server.server_close()
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/tests/fixtures/transcripts/-Users-dmcinerney-tools-alpha/11111111-1111-4111-8111-111111111111.jsonl
+++ b/tests/fixtures/transcripts/-Users-dmcinerney-tools-alpha/11111111-1111-4111-8111-111111111111.jsonl
@@ -1,0 +1,19 @@
+{"type":"worktree-state","sessionId":"11111111-1111-4111-8111-111111111111","worktreeSession":{"sessionId":"11111111-1111-4111-8111-111111111111","originalCwd":"/Users/dmcinerney/tools/alpha","originalBranch":"main","originalHeadCommit":"0f9641d5c1a2b3c4d5e6f708192a3b4c5d6e7f80"}}
+{"type":"mode","sessionId":"11111111-1111-4111-8111-111111111111","mode":"default"}
+{"type":"ai-title","sessionId":"11111111-1111-4111-8111-111111111111","aiTitle":"Alpha, the title that was superseded"}
+{"type":"user","sessionId":"11111111-1111-4111-8111-111111111111","message":{"role":"user","content":"ZQXJVWNTRPKB-transcript-content-must-not-render"}}
+{"type":"assistant","sessionId":"11111111-1111-4111-8111-111111111111","message":{"role":"assistant","content":[{"type":"text","text":"ZQXJVWNTRPKB-transcript-content-must-not-render"}]}}
+{"type":"attachment","sessionId":"11111111-1111-4111-8111-111111111111","attachment":{"type":"file","content":"ZQXJVWNTRPKB-transcript-content-must-not-render"}}
+{"type":"last-prompt","sessionId":"11111111-1111-4111-8111-111111111111","prompt":"ZQXJVWNTRPKB-transcript-content-must-not-render"}
+{"type":"user","sessionId":"11111111-1111-4111-8111-111111111111","toolUseResult":{"stdout":"ZQXJVWNTRPKB-transcript-content-must-not-render","stderr":"ZQXJVWNTRPKB-transcript-content-must-not-render"}}
+{"type":"assistant","sessionId":"11111111-1111-4111-8111-111111111111","message":{"role":"assistant","content":[{"type":"tool_use","id":"toolu_alpha_03","name":"Bash","input":{"command":"ZQXJVWNTRPKB-transcript-content-must-not-render"}}]}}
+{"type":"user","sessionId":"11111111-1111-4111-8111-111111111111","message":{"role":"user","content":[{"type":"tool_result","tool_use_id":"toolu_alpha_03","content":"ZQXJVWNTRPKB-transcript-content-must-not-render"}]}}
+{"type":"assistant","sessionId":"11111111-1111-4111-8111-111111111111","message":{"role":"assistant","content":[{"type":"tool_use","id":"toolu_alpha_01","name":"Agent","input":{"prompt":"ZQXJVWNTRPKB-transcript-content-must-not-render"}}]}}
+{"type":"user","sessionId":"11111111-1111-4111-8111-111111111111","message":{"role":"user","content":[{"type":"tool_result","tool_use_id":"toolu_alpha_01","content":"ZQXJVWNTRPKB-transcript-content-must-not-render"}]}}
+{"type":"assistant","sessionId":"11111111-1111-4111-8111-111111111111","message":{"role":"assistant","content":[{"type":"tool_use","id":"toolu_alpha_02","name":"Agent","input":{"prompt":"ZQXJVWNTRPKB-transcript-content-must-not-render"}}]}}
+{"type":"file-history-snapshot","sessionId":"11111111-1111-4111-8111-111111111111","snapshot":{"/Users/dmcinerney/tools/alpha/x.py":"ZQXJVWNTRPKB-transcript-content-must-not-render"}}
+{"type":"file-history-delta","sessionId":"11111111-1111-4111-8111-111111111111","delta":"ZQXJVWNTRPKB-transcript-content-must-not-render"}
+{"type":"queue-operation","sessionId":"11111111-1111-4111-8111-111111111111","operation":"enqueue","prompt":"ZQXJVWNTRPKB-transcript-content-must-not-render"}
+{"type":"system","sessionId":"11111111-1111-4111-8111-111111111111","content":"ZQXJVWNTRPKB-transcript-content-must-not-render"}
+{"type":"ai-title","sessionId":"11111111-1111-4111-8111-111111111111","aiTitle":"Alpha, the last title recorded"}
+{"type":"pr-link","sessionId":"11111111-1111-4111-8111-111111111111","url":"ZQXJVWNTRPKB-transcript-content-must-not-render"}

--- a/tests/fixtures/transcripts/-Users-dmcinerney-tools-alpha/11111111-1111-4111-8111-111111111111/subagents/agent-aa11.jsonl
+++ b/tests/fixtures/transcripts/-Users-dmcinerney-tools-alpha/11111111-1111-4111-8111-111111111111/subagents/agent-aa11.jsonl
@@ -1,0 +1,3 @@
+{"type":"user","message":{"role":"user","content":"ZQXJVWNTRPKB-transcript-content-must-not-render"}}
+{"type":"assistant","message":{"role":"assistant","content":[{"type":"text","text":"ZQXJVWNTRPKB-transcript-content-must-not-render"}]}}
+{"type":"ai-title","aiTitle":"ZQXJVWNTRPKB-transcript-content-must-not-render"}

--- a/tests/fixtures/transcripts/-Users-dmcinerney-tools-alpha/11111111-1111-4111-8111-111111111111/subagents/agent-aa11.meta.json
+++ b/tests/fixtures/transcripts/-Users-dmcinerney-tools-alpha/11111111-1111-4111-8111-111111111111/subagents/agent-aa11.meta.json
@@ -1,0 +1,1 @@
+{"agentType":"orch-worker","description":"Implement the session index","toolUseId":"toolu_alpha_01","spawnDepth":1}

--- a/tests/fixtures/transcripts/-Users-dmcinerney-tools-alpha/11111111-1111-4111-8111-111111111111/subagents/agent-aa12.meta.json
+++ b/tests/fixtures/transcripts/-Users-dmcinerney-tools-alpha/11111111-1111-4111-8111-111111111111/subagents/agent-aa12.meta.json
@@ -1,0 +1,1 @@
+{"agentType":"orch-planner","description":"Review the <b>layout</b> choices","toolUseId":"toolu_alpha_02","spawnDepth":1,"model":"opus"}

--- a/tests/fixtures/transcripts/-Users-dmcinerney-tools-alpha/11111111-1111-4111-8111-111111111111/subagents/agent-aa13.meta.json
+++ b/tests/fixtures/transcripts/-Users-dmcinerney-tools-alpha/11111111-1111-4111-8111-111111111111/subagents/agent-aa13.meta.json
@@ -1,0 +1,1 @@
+{"agentType":"Explore","description":"Sweep the fixtures directory","toolUseId":"toolu_alpha_03","spawnDepth":2}

--- a/tests/fixtures/transcripts/-Users-dmcinerney-tools-alpha/11111111-1111-4111-8111-111111111111/tool-results/toolu_alpha_01.json
+++ b/tests/fixtures/transcripts/-Users-dmcinerney-tools-alpha/11111111-1111-4111-8111-111111111111/tool-results/toolu_alpha_01.json
@@ -1,0 +1,1 @@
+{"stdout":"ZQXJVWNTRPKB-transcript-content-must-not-render","stderr":"","interrupted":false}

--- a/tests/fixtures/transcripts/-Users-dmcinerney-tools-alpha/22222222-2222-4222-8222-222222222222.jsonl
+++ b/tests/fixtures/transcripts/-Users-dmcinerney-tools-alpha/22222222-2222-4222-8222-222222222222.jsonl
@@ -1,0 +1,4 @@
+{"type":"mode","sessionId":"22222222-2222-4222-8222-222222222222","mode":"default"}
+{"type":"user","sessionId":"22222222-2222-4222-8222-222222222222","message":{"role":"user","content":"ZQXJVWNTRPKB-transcript-content-must-not-render"}}
+{"type":"assistant","sessionId":"22222222-2222-4222-8222-222222222222","message":{"role":"assistant","content":[{"type":"text","text":"ZQXJVWNTRPKB-transcript-content-must-not-render"}]}}
+{"type":"last-prompt","sessionId":"22222222-2222-4222-8222-222222222222","prompt":"ZQXJVWNTRPKB-transcript-content-must-not-render"}

--- a/tests/fixtures/transcripts/-Users-dmcinerney-tools-beta-repo--claude-worktrees-wt-one/55555555-5555-4555-8555-555555555555.jsonl
+++ b/tests/fixtures/transcripts/-Users-dmcinerney-tools-beta-repo--claude-worktrees-wt-one/55555555-5555-4555-8555-555555555555.jsonl
@@ -1,0 +1,4 @@
+{"type":"worktree-state","sessionId":"55555555-5555-4555-8555-555555555555","worktreeSession":{"sessionId":"55555555-5555-4555-8555-555555555555","originalCwd":"/Users/dmcinerney/tools/beta-repo","worktreePath":"/Users/dmcinerney/tools/beta-repo/.claude/worktrees/wt-one","worktreeName":"wt-one","worktreeBranch":"worktree-wt-one","originalBranch":"main","originalHeadCommit":"0f9641d5c1a2b3c4d5e6f708192a3b4c5d6e7f80"}}
+{"type":"ai-title","sessionId":"55555555-5555-4555-8555-555555555555","aiTitle":"Worktree session, cut short"}
+{"type":"user","sessionId":"55555555-5555-4555-8555-555555555555","message":{"role":"user","content":"ZQXJVWNTRPKB-transcript-content-must-not-render"}}
+{"type":"assistant","sessionId":"55555555-5555-4555-8555-5555555

--- a/tests/fixtures/transcripts/-Users-dmcinerney-tools-beta-repo--claude-worktrees-wt-one/55555555-5555-4555-8555-555555555555/subagents/agent-cc31.meta.json
+++ b/tests/fixtures/transcripts/-Users-dmcinerney-tools-beta-repo--claude-worktrees-wt-one/55555555-5555-4555-8555-555555555555/subagents/agent-cc31.meta.json
@@ -1,0 +1,1 @@
+{"agentType":"orch-worker","description":"Port the required checks","toolUseId":"toolu_wt_01","spawnDepth":1}

--- a/tests/fixtures/transcripts/-Users-dmcinerney-tools-beta-repo--claude-worktrees-wt-one/55555555-5555-4555-8555-555555555555/subagents/agent-cc32.meta.json
+++ b/tests/fixtures/transcripts/-Users-dmcinerney-tools-beta-repo--claude-worktrees-wt-one/55555555-5555-4555-8555-555555555555/subagents/agent-cc32.meta.json
@@ -1,0 +1,1 @@
+{"agentType":"Explore","description":"Sweep for callers","toolUseId":"toolu_wt_02","spawnDepth":2,"parentAgentId":"cc31"}

--- a/tests/fixtures/transcripts/-Users-dmcinerney-tools-beta-repo/33333333-3333-4333-8333-333333333333.jsonl
+++ b/tests/fixtures/transcripts/-Users-dmcinerney-tools-beta-repo/33333333-3333-4333-8333-333333333333.jsonl
@@ -1,0 +1,6 @@
+{"type":"worktree-state","sessionId":"33333333-3333-4333-8333-333333333333","worktreeSession":{"sessionId":"33333333-3333-4333-8333-333333333333","originalCwd":"/Users/dmcinerney/tools/beta-repo","originalBranch":"main","originalHeadCommit":"0f9641d5c1a2b3c4d5e6f708192a3b4c5d6e7f80"}}
+{"type":"ai-title","sessionId":"33333333-3333-4333-8333-333333333333","aiTitle":"Beta <script>alert(1)</script> title"}
+{"type":"user","sessionId":"33333333-3333-4333-8333-333333333333","message":{"role":"user","content":"ZQXJVWNTRPKB-transcript-content-must-not-render"}}
+{"type":"assistant","sessionId":"33333333-3333-4333-8333-333333333333","message":{"role":"assistant","content":[{"type":"text","text":"ZQXJVWNTRPKB-transcript-content-must-not-render"}]}}
+{"type":"last-prompt","sessionId":"33333333-3333-4333-8333-333333333333","prompt":"ZQXJVWNTRPKB-transcript-content-must-not-render"}
+{"type":"user","sessionId":"33333333-3333-4333-8333-333333333333","toolUseResult":{"stdout":"ZQXJVWNTRPKB-transcript-content-must-not-render"}}

--- a/tests/fixtures/transcripts/-Users-dmcinerney-tools-beta-repo/33333333-3333-4333-8333-333333333333/subagents/agent-bb21.meta.json
+++ b/tests/fixtures/transcripts/-Users-dmcinerney-tools-beta-repo/33333333-3333-4333-8333-333333333333/subagents/agent-bb21.meta.json
@@ -1,0 +1,1 @@
+{"agentType":"<script>alert(1)</script>","description":"<img src=\"x\" onerror=\"alert(1)\">","toolUseId":"toolu_beta_01","spawnDepth":1}

--- a/tests/fixtures/transcripts/-Users-dmcinerney-tools-beta-repo/33333333-3333-4333-8333-333333333333/subagents/agent-bb22.meta.json
+++ b/tests/fixtures/transcripts/-Users-dmcinerney-tools-beta-repo/33333333-3333-4333-8333-333333333333/subagents/agent-bb22.meta.json
@@ -1,0 +1,1 @@
+{"agentType":42,"description":["not","a","string"],"toolUseId":null,"spawnDepth":"two"}

--- a/tests/fixtures/transcripts/-Users-dmcinerney-tools-beta-repo/33333333-3333-4333-8333-333333333333/subagents/agent-bb23.meta.json
+++ b/tests/fixtures/transcripts/-Users-dmcinerney-tools-beta-repo/33333333-3333-4333-8333-333333333333/subagents/agent-bb23.meta.json
@@ -1,0 +1,1 @@
+not json at all

--- a/tests/fixtures/transcripts/-Users-dmcinerney-tools-beta-repo/44444444-4444-4444-8444-444444444444.jsonl
+++ b/tests/fixtures/transcripts/-Users-dmcinerney-tools-beta-repo/44444444-4444-4444-8444-444444444444.jsonl
@@ -1,0 +1,5 @@
+this line is not JSON at all: ZQXJVWNTRPKB-transcript-content-must-not-render
+{"type":"ai-title","sessionId":"44444444-4444-4444-8444-444444444444","aiTitle":"Malformed but still labelled"}
+["json","but","not","an","object","ZQXJVWNTRPKB-transcript-content-must-not-render"]
+
+{"type":"user","sessionId":"44444444-4444-4444-8444-444444444444","message":{"role":"user","content":"ZQXJVWNTRPKB-transcript-content-must-not-render"}}

--- a/tests/fixtures/transcripts/README.md
+++ b/tests/fixtures/transcripts/README.md
@@ -1,0 +1,58 @@
+# Claude Code transcript fixture corpus
+
+A synthetic `~/.claude/projects` tree. `tests/test_ui.py` copies it into a
+temporary directory and stamps a deterministic mtime on each session file,
+because the index orders on last activity and a copy takes whatever the
+clock says. No test reads the operator's real transcripts: the reader
+resolves the `~/.claude/projects` default in `main` alone, so a test that
+supplies no root gets a named empty state rather than the real tree.
+
+Layout, as observed on a live host on 2026-08-10: sessions at
+`<slug>/<uuid>.jsonl`; a per-session directory `<slug>/<uuid>/` holding
+`subagents/agent-<id>.meta.json` and `agent-<id>.jsonl` alongside a
+`tool-results/`. The slug is the working directory with every separator
+replaced by `-`. `worktree-state` carries its fields one level down under
+`worktreeSession`, not flat.
+
+Two further facts, observed the same day over 305 subagents on that host,
+neither of them anybody's contract. A subagent is spawned by an
+`assistant` record carrying a `tool_use` block named `Agent` whose `id` is
+the subagent's `toolUseId`, and it has returned once a `user` record
+carries a `tool_result` block whose `tool_use_id` is that same id — both
+blocks one level down, under `message.content`. That pair is the only
+evidence of activity there is, and `tool-results/`
+carries none of it — no subagent's `toolUseId` named a file there. The
+tool *name* is what makes the pair evidence: a `toolUseId` is an ordinary
+tool-use id and any tool's call and result can be recorded under one. And
+`parentAgentId` is present on every depth-2 record and on no depth-1
+record, resolving in every case to the sibling whose stem is
+`agent-<parentAgentId>`.
+
+| fixture | shape it carries |
+|---|---|
+| `-Users-dmcinerney-tools-alpha/1111….jsonl` | healthy: two `ai-title` records, so the *last* one is the label; a `worktree-state` whose `originalCwd` agrees with the slug; one record of every other observed type; and the three activity shapes — an `Agent` call that returned (`toolu_alpha_01`), one that has not (`toolu_alpha_02`), and a `Bash` call and result under a *subagent's* `toolUseId` (`toolu_alpha_03`), which is evidence of nothing about that subagent |
+| `…/1111…/subagents/agent-aa1{1,2,3}.meta.json` | three subagents, two at `spawnDepth` 1 and one at 2; one carries a `model` key the spec's evidence does not list, one a `description` carrying markup. The depth-2 record carries no `parentAgentId`, so its attachment is not provable |
+| `…/1111…/subagents/agent-aa11.jsonl` | a subagent's own transcript: megabytes on a real host, never opened here. Its every line carries the sentinel |
+| `…/1111…/tool-results/toolu_alpha_01.json` | a tool result beside the transcript, never opened. Carries the sentinel |
+| `-Users-dmcinerney-tools-alpha/2222….jsonl` | no `ai-title`, no `worktree-state`, no session directory: the named-fallback label, the slug-decoded working directory, and zero subagents |
+| `-Users-dmcinerney-tools-beta-repo/3333….jsonl` | an `aiTitle` carrying `<script>alert(1)</script>`; `originalCwd` is `…/beta-repo`, which the slug decode cannot recover — the hyphen in `beta-repo` is indistinguishable from an encoded separator |
+| `…/3333…/subagents/agent-bb2{1,2,3}.meta.json` | `bb21` carries markup in both `agentType` and `description`, the second with the quote characters an attribute context has to survive; `bb22` is an object whose every field is the wrong type; `bb23` is not JSON at all |
+| `-Users-dmcinerney-tools-beta-repo/4444….jsonl` | malformed: a line that is not JSON, a line that is JSON and not an object, a blank line that is neither. Still labelled, and in the same project directory as `3333…`, where its working directory can only come from the slug |
+| `-Users-dmcinerney-tools-beta-repo--claude-worktrees-wt-one/5555….jsonl` | truncated: a partial final line with no newline. `worktreePath` and `originalCwd` both present, so the worktree path wins |
+| `…/5555…/subagents/agent-cc3{1,2}.meta.json` | the provable attachment: `cc32` is at depth 2 and its `parentAgentId` resolves to `cc31`. Neither appears in the transcript, so both states are `unknown` |
+| `not-an-encoded-path/6666….jsonl` | empty, under a directory name that does not decode to a path at all |
+
+Every `user` and `assistant` body, every `last-prompt`, attachment, tool
+input, tool result and file-history record in this corpus carries the
+string `ZQXJVWNTRPKB-transcript-content-must-not-render`. The spec's
+renderable set — `sessionId`, `aiTitle`, the `worktree-state` fields,
+timestamps, sizes, counts and the subagent metadata — carries it nowhere,
+so a sentinel on any rendered route is a content leak and nothing else.
+
+Six sessions across four project directories. Their assigned mtimes
+interleave the directories, so an index that grouped by directory would
+still pass an ordering assertion made over one of them.
+
+`git` tracks no empty directory, so the "session with no `subagents/`"
+case is a session with no session directory at all — which is also what a
+real host shows for a session that spawned nothing.

--- a/tests/fixtures/ui/README.md
+++ b/tests/fixtures/ui/README.md
@@ -1,0 +1,39 @@
+# Reader UI fixture corpus
+
+Flat by run: `<run>/<id>.md`. `tests/test_ui.py` copies these into a
+temporary `<tmp>/.orch/tickets/<run>/` at run time, so no `.orch/`
+directory is tracked here and no test can mutate repository state. The
+real ticket corpus is gitignored and uncommittable, so these are authored
+to the shapes it exhibits rather than redacted from it.
+
+| fixture | shape it carries |
+|---|---|
+| `run-alpha/A1.md` | conforming: every `contracts/work-item.md` floor key, plain body |
+| `run-alpha/A2.md` | `## Objective` carrying `<script>alert(1)</script>` — untrusted data per `rules/visibility.md` §6 |
+| `run-beta/B1.md` | degenerate: no `status`, no `executor`, no body section at all |
+| `run-gamma/G1.md` | `## Verification` as a five-column verdict table, one row escaping a `\|` inside its evidence, one `FAIL` |
+| `run-gamma/G2.md` | `## Verification` as numbered prose — the shape that must read `unparsed`, never zero rows |
+| `run-gamma/G3.md` | `bound: one session` — a bound that is not a duration |
+| `run-gamma/G4.md` | `bound: 90m` with a `claimed_at` — the only shape an elapsed meter may be drawn from |
+| `run-gamma/G5.md` | `status: claimed` with no `claimed_at`, and only one body section |
+| `run-gamma/G6.md` | `status: side<b>ways` — outside the contract's closed set, carrying markup |
+| `run-gamma/G7.md` | a section name the contract does not fix, a present-but-empty section, and `## Handoff` inside a fence |
+| `run-delta/D1.md`–`D5.md` | a cycle-free diamond: one root, two middle tickets, a join, a sink — four layers, and one edge that must cross a layer |
+| `run-delta/D2.md`, `D3.md` | `depends_on` as a block list and inline, the two spellings `_parse_frontmatter` accepts |
+| `run-delta/*` | every status terminal, so the run is the settled case the poll interval must read as idle |
+| `run-epsilon/E1.md`–`E3.md` | a three-ticket `depends_on` cycle; `E1` is `ready`, so the run is also the live case for the poll interval |
+| `run-epsilon/E4.md` | `depends_on` naming a ticket that is not in this run |
+| `friction/2026-07.jsonl` | two well-formed entries, one carrying `<b>markup</b>` |
+| `friction/2026-08.jsonl` | a line that is not JSON, an array that is JSON and not an entry, a blank line, and an entry with neither `category` nor `host` |
+| `events/run-gamma.jsonl` | the deferred hooks seam: one line per `event` value, one carrying `<b>markup</b>`, one with every nullable key null, plus the same two unreadable shapes and a blank line. No other run has one, so the seam's silent half is a fixture too |
+
+Across both friction logs: five entries, two unreadable lines, and blank
+lines that are not unreadable. Every log here is oldest-first on disk, the
+order an append-only log is written in, so a feed that merely concatenated
+them would be exactly backwards.
+
+`claimed_at` values sit on 2026-01-01 so a test can pin `now` and assert an
+exact elapsed figure.
+
+A run directory with zero tickets is materialized by the test, since git
+tracks no empty directory.

--- a/tests/fixtures/ui/events/run-gamma.jsonl
+++ b/tests/fixtures/ui/events/run-gamma.jsonl
@@ -1,0 +1,6 @@
+{"ts": "2026-01-01T00:20:00Z", "run": "run-gamma", "ticket": "G4", "agent": "fixture-agent", "event": "tool_pre", "tool": "Read", "detail": "scripts/ui.py"}
+{"ts": "2026-01-01T00:20:03Z", "run": "run-gamma", "ticket": "G4", "agent": "fixture-agent", "event": "tool_post", "tool": "Read", "detail": "a detail carrying <b>markup</b>"}
+a half-written line is what a killed writer leaves behind
+{"ts": "2026-01-01T00:21:00Z", "run": "run-gamma", "ticket": null, "agent": "fixture-agent", "event": "subagent_stop", "tool": null, "detail": null}
+["ts", "an array is valid JSON and still not an event"]
+

--- a/tests/fixtures/ui/friction/2026-07.jsonl
+++ b/tests/fixtures/ui/friction/2026-07.jsonl
@@ -1,0 +1,2 @@
+{"ts": "2026-07-30T09:15:00Z", "observed": "tools/validate.py discovered no file under scripts/", "expected": "a new script to be admitted by the validator like any other artifact", "category": "missing-doc", "host": "claude-code"}
+{"ts": "2026-07-31T18:02:11Z", "observed": "the logger refused a path under a shared .orch/ and the entry carried <b>markup</b>", "expected": "an untrusted value to reach the feed escaped, never as live markup", "category": "workaround", "host": "claude-code"}

--- a/tests/fixtures/ui/friction/2026-08.jsonl
+++ b/tests/fixtures/ui/friction/2026-08.jsonl
@@ -1,0 +1,6 @@
+{"ts": "2026-08-01T07:40:00Z", "observed": "install.py --dry-run named three scripts", "expected": "four, once SCRIPT_NAMES carried the new module", "category": "surprising-output", "host": "claude-code"}
+this line is not JSON at all and a half-written log ends exactly like it
+{"ts": "2026-08-02T22:34:54Z", "observed": "a route added by branching inside the dispatcher was invisible to the whole-page guards", "expected": "every served route to be reached by a concrete example", "category": "contract-gap", "host": "claude-code"}
+["ts", "an array is valid JSON and still not a friction entry"]
+
+{"ts": "2026-08-03T11:00:00Z", "observed": "an entry written by an older logger carried neither a category nor a host", "expected": "the feed to render the keys it has rather than drop the entry"}

--- a/tests/fixtures/ui/run-alpha/A1.md
+++ b/tests/fixtures/ui/run-alpha/A1.md
@@ -1,0 +1,29 @@
+---
+id: A1
+run: run-alpha
+status: complete
+executor: orch-tdd
+depends_on: []
+write_scope:
+  - scratch/a1.txt
+bound: 30m
+claimed_by: fixture-agent
+claimed_at: 2026-01-01T00:00:00Z
+---
+
+## Objective
+
+A conforming ticket carrying every frontmatter key in the
+`contracts/work-item.md` floor and a plain body.
+
+## Result
+
+Nothing was done; this file exists to be read.
+
+## Feedback
+
+[]
+
+## Risks
+
+[]

--- a/tests/fixtures/ui/run-alpha/A2.md
+++ b/tests/fixtures/ui/run-alpha/A2.md
@@ -1,0 +1,30 @@
+---
+id: A2
+run: run-alpha
+status: claimed
+executor: orch-verify
+depends_on:
+  - A1
+write_scope:
+  - scratch/a2.txt
+bound: 45m
+claimed_by: fixture-agent
+claimed_at: 2026-01-01T00:05:00Z
+---
+
+## Objective
+
+Untrusted ticket text: <script>alert(1)</script> must reach the page as
+escaped characters, never as live markup.
+
+## Result
+
+Nothing was done; this file exists to be read.
+
+## Feedback
+
+[]
+
+## Risks
+
+[]

--- a/tests/fixtures/ui/run-beta/B1.md
+++ b/tests/fixtures/ui/run-beta/B1.md
@@ -1,0 +1,8 @@
+---
+id: B1
+run: run-beta
+depends_on: []
+write_scope:
+  - scratch/b1.txt
+bound: 30m
+---

--- a/tests/fixtures/ui/run-delta/D1.md
+++ b/tests/fixtures/ui/run-delta/D1.md
@@ -1,0 +1,17 @@
+---
+id: D1
+run: run-delta
+status: complete
+executor: orch-tdd
+depends_on: []
+write_scope:
+  - scratch/d1.txt
+bound: 90m
+claimed_by: fixture-agent
+claimed_at: 2026-01-01T00:00:00Z
+---
+
+## Objective
+
+The single root of a cycle-free dependency graph: nothing precedes it, so
+every layered layout puts it alone on the lowest layer.

--- a/tests/fixtures/ui/run-delta/D2.md
+++ b/tests/fixtures/ui/run-delta/D2.md
@@ -1,0 +1,19 @@
+---
+id: D2
+run: run-delta
+status: complete
+executor: orch-tdd
+depends_on:
+  - D1
+write_scope:
+  - scratch/d2.txt
+bound: 90m
+claimed_by: fixture-agent
+claimed_at: 2026-01-01T00:10:00Z
+---
+
+## Objective
+
+One half of the diamond's middle layer. Written as a block list so the
+graph is proved to read both `depends_on` spellings the frontmatter parser
+accepts.

--- a/tests/fixtures/ui/run-delta/D3.md
+++ b/tests/fixtures/ui/run-delta/D3.md
@@ -1,0 +1,18 @@
+---
+id: D3
+run: run-delta
+status: failed
+executor: orch-tdd
+depends_on: [D1]
+write_scope:
+  - scratch/d3.txt
+bound: 90m
+claimed_by: fixture-agent
+claimed_at: 2026-01-01T00:10:00Z
+---
+
+## Objective
+
+The other half of the diamond's middle layer, its `depends_on` written
+inline. Terminal and failed, so the run carries a state the poll interval
+must read as settled.

--- a/tests/fixtures/ui/run-delta/D4.md
+++ b/tests/fixtures/ui/run-delta/D4.md
@@ -1,0 +1,17 @@
+---
+id: D4
+run: run-delta
+status: blocked
+executor: orch-verify
+depends_on: [D2, D3]
+write_scope:
+  - scratch/d4.txt
+bound: 90m
+claimed_by: fixture-agent
+claimed_at: 2026-01-01T00:30:00Z
+---
+
+## Objective
+
+The diamond's join: two predecessors on the same layer, so a layout that
+merely stacked nodes in file order would put an edge inside one layer.

--- a/tests/fixtures/ui/run-delta/D5.md
+++ b/tests/fixtures/ui/run-delta/D5.md
@@ -1,0 +1,18 @@
+---
+id: D5
+run: run-delta
+status: limited
+executor: orch-verify
+depends_on: [D4]
+write_scope:
+  - scratch/d5.txt
+bound: one session
+claimed_by: fixture-agent
+claimed_at: 2026-01-01T00:45:00Z
+---
+
+## Objective
+
+The graph's sink, four layers above its root. Terminal like every other
+ticket in this run, which is what makes the run usable as the settled case
+for the poll interval.

--- a/tests/fixtures/ui/run-epsilon/E1.md
+++ b/tests/fixtures/ui/run-epsilon/E1.md
@@ -1,0 +1,18 @@
+---
+id: E1
+run: run-epsilon
+status: ready
+executor: orch-tdd
+depends_on: [E3]
+write_scope:
+  - scratch/e1.txt
+bound: 90m
+claimed_by: ""
+claimed_at: ""
+---
+
+## Objective
+
+One third of a three-ticket `depends_on` cycle. Real data can carry one:
+nothing on the write path proves acyclicity, so the layout must terminate
+and name the cycle rather than hang or raise.

--- a/tests/fixtures/ui/run-epsilon/E2.md
+++ b/tests/fixtures/ui/run-epsilon/E2.md
@@ -1,0 +1,17 @@
+---
+id: E2
+run: run-epsilon
+status: pending
+executor: orch-tdd
+depends_on: [E1]
+write_scope:
+  - scratch/e2.txt
+bound: 90m
+claimed_by: ""
+claimed_at: ""
+---
+
+## Objective
+
+The second arc of the cycle: E1 waits on E3, E2 waits on E1, E3 waits on
+E2.

--- a/tests/fixtures/ui/run-epsilon/E3.md
+++ b/tests/fixtures/ui/run-epsilon/E3.md
@@ -1,0 +1,16 @@
+---
+id: E3
+run: run-epsilon
+status: pending
+executor: orch-verify
+depends_on: [E2]
+write_scope:
+  - scratch/e3.txt
+bound: 90m
+claimed_by: ""
+claimed_at: ""
+---
+
+## Objective
+
+The arc that closes the cycle.

--- a/tests/fixtures/ui/run-epsilon/E4.md
+++ b/tests/fixtures/ui/run-epsilon/E4.md
@@ -1,0 +1,18 @@
+---
+id: E4
+run: run-epsilon
+status: pending
+executor: orch-tdd
+depends_on: [ZZ9, E1]
+write_scope:
+  - scratch/e4.txt
+bound: 90m
+claimed_by: ""
+claimed_at: ""
+---
+
+## Objective
+
+A `depends_on` naming a ticket that is not in this run. Copying a ticket
+between runs leaves this shape behind; the graph must drop the edge with a
+named diagnostic rather than invent a node or raise a lookup error.

--- a/tests/fixtures/ui/run-gamma/G1.md
+++ b/tests/fixtures/ui/run-gamma/G1.md
@@ -1,0 +1,33 @@
+---
+id: G1
+run: run-gamma
+status: complete
+executor: orch-tdd
+depends_on: []
+write_scope:
+  - scratch/g1.txt
+bound: 90m
+claimed_by: fixture-agent
+claimed_at: 2026-01-01T00:00:00Z
+---
+
+## Objective
+
+A ticket whose `## Verification` carries the five-column table shape, one
+row of which escapes a pipe inside its evidence cell.
+
+## Verification
+
+| # | verdict | oracle | class | evidence |
+| --- | --- | --- | --- | --- |
+| 1 | PASS | `tools/validate.py` | deterministic | exit 0, zero output |
+| 2 | PASS | the named test | deterministic | `(?:src\|href)` matched nothing on either route |
+| 3 | FAIL | `install.py --dry-run` | deterministic | plan named 3 scripts, 4 expected |
+
+## Feedback
+
+[]
+
+## Risks
+
+[]

--- a/tests/fixtures/ui/run-gamma/G2.md
+++ b/tests/fixtures/ui/run-gamma/G2.md
@@ -1,0 +1,37 @@
+---
+id: G2
+run: run-gamma
+status: blocked
+executor: orch-verify
+depends_on:
+  - G1
+write_scope:
+  - scratch/g2.txt
+bound: 45m
+claimed_by: fixture-agent
+claimed_at: 2026-01-01T00:05:00Z
+---
+
+## Objective
+
+A ticket whose `## Verification` is a numbered prose list, the second shape
+the real corpus carries. Nothing here is a table.
+
+## Verification
+
+Baseline recorded on three interpreters before the first edit; every oracle
+was specified before any work, so `pre-existing` provenance holds
+throughout.
+
+1. Green on the product's own floor — PASS. deterministic. `unittest
+   discover -s tests` on 3.9.6: rc=0, OK, 341 tests, 4 skipped.
+2. No test lost — PASS. deterministic. Baseline identities collected from a
+   pristine detached worktree; `comm -23` empty, so nothing was dropped.
+
+## Feedback
+
+[]
+
+## Risks
+
+[]

--- a/tests/fixtures/ui/run-gamma/G3.md
+++ b/tests/fixtures/ui/run-gamma/G3.md
@@ -1,0 +1,18 @@
+---
+id: G3
+run: run-gamma
+status: claimed
+executor: orch-tdd
+depends_on: []
+write_scope:
+  - scratch/g3.txt
+bound: one session
+claimed_by: fixture-agent
+claimed_at: 2026-01-01T00:15:00Z
+---
+
+## Objective
+
+A live claim whose `bound` is prose, the value the real corpus actually
+carries. `scripts/tickets.py:48` DURATION_RE does not match it, so there is
+no denominator and there must be no meter.

--- a/tests/fixtures/ui/run-gamma/G4.md
+++ b/tests/fixtures/ui/run-gamma/G4.md
@@ -1,0 +1,17 @@
+---
+id: G4
+run: run-gamma
+status: claimed
+executor: orch-tdd
+depends_on: []
+write_scope:
+  - scratch/g4.txt
+bound: 90m
+claimed_by: fixture-agent
+claimed_at: 2026-01-01T00:20:00Z
+---
+
+## Objective
+
+A live claim with a duration bound and a claim timestamp: both operands
+exist, so the elapsed meter is computable.

--- a/tests/fixtures/ui/run-gamma/G5.md
+++ b/tests/fixtures/ui/run-gamma/G5.md
@@ -1,0 +1,16 @@
+---
+id: G5
+run: run-gamma
+status: claimed
+executor: orch-tdd
+depends_on: []
+write_scope:
+  - scratch/g5.txt
+bound: 90m
+claimed_by: fixture-agent
+---
+
+## Objective
+
+Claimed with no `claimed_at`: the bound parses but the start does not
+exist, so elapsed is unknowable and no meter may be drawn.

--- a/tests/fixtures/ui/run-gamma/G6.md
+++ b/tests/fixtures/ui/run-gamma/G6.md
@@ -1,0 +1,18 @@
+---
+id: G6
+run: run-gamma
+status: side<b>ways
+executor: orch-tdd
+depends_on: []
+write_scope:
+  - scratch/g6.txt
+bound: 30m
+claimed_by: fixture-agent
+claimed_at: 2026-01-01T00:25:00Z
+---
+
+## Objective
+
+A status outside the contract's closed set, carrying markup: `.orch/` is
+untrusted data, so the reader must name the value unknown and still show it
+escaped rather than dropping it.

--- a/tests/fixtures/ui/run-gamma/G7.md
+++ b/tests/fixtures/ui/run-gamma/G7.md
@@ -1,0 +1,34 @@
+---
+id: G7
+run: run-gamma
+status: suspended
+executor: orch-tdd
+depends_on: []
+write_scope:
+  - scratch/g7.txt
+bound: 30m
+claimed_by: fixture-agent
+claimed_at: 2026-01-01T00:30:00Z
+---
+
+## Objective
+
+Body shape: most sections absent, one section name the contract does not
+fix, one section present but empty, and a fenced block whose content looks
+like a heading.
+
+## Notes on the wire
+
+`contracts/work-item.md` fixes eight section names and lets a domain extend
+them, so a reader that dropped an unrecognized one would hide real state.
+
+```text
+## Handoff
+This line sits inside a fence. It is content, not a section heading.
+```
+
+## Result
+
+## Risks
+
+[]

--- a/tests/test_ui.py
+++ b/tests/test_ui.py
@@ -1,0 +1,2545 @@
+"""Reader UI: main-checkout resolution, discovery, escaping, empty states,
+status presentation, verification degradation, the elapsed meter, and the
+read-only, no-network and loopback-only guarantees."""
+
+import ast
+import contextlib
+import http.client
+import io
+import ipaddress
+import os
+import re
+import shutil
+import sys
+import tempfile
+import threading
+import unittest
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from unittest.mock import patch
+from urllib.parse import quote
+
+PAYLOAD = "<script>alert(1)</script>"
+# Spec criterion 12: an asset reference is remote when its value starts
+# with a scheme or with a protocol-relative `//`.
+REMOTE_ASSET_RE = re.compile(r"""(?:src|href)\s*=\s*["']?\s*(?:https?:)?//""", re.IGNORECASE)
+
+ROOT = Path(__file__).resolve().parent.parent
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+import scripts.tickets as tickets_mod  # noqa: E402
+import scripts.ui as ui  # noqa: E402
+
+UI_PY = ROOT / "scripts" / "ui.py"
+WORK_ITEM_CONTRACT = ROOT / "contracts" / "work-item.md"
+FIXTURES = Path(__file__).resolve().parent / "fixtures" / "ui"
+FIXTURE_RUNS = ("run-alpha", "run-beta", "run-gamma", "run-delta", "run-epsilon")
+EMPTY_RUN = "run-empty"
+# Every ticket in `run-delta` is terminal and none is claimed, so it is the
+# corpus's settled run: the case where the band is absent and the poll
+# interval must not be the live one.
+SETTLED_RUN = "run-delta"
+CYCLIC_RUN = "run-epsilon"
+
+
+def contract_statuses() -> tuple:
+    """The closed status set exactly as `contracts/work-item.md` states it.
+
+    Read from the contract rather than restated here, so the presentation
+    map is held to its owner: a status added there and missed here fails
+    this suite instead of rendering as the unknown fallback."""
+
+    text = WORK_ITEM_CONTRACT.read_text(encoding="utf-8")
+    declaration = re.search(r"^- `status`:(.+?)—", text, re.MULTILINE | re.DOTALL)
+    if declaration is None:
+        return ()
+    return tuple(re.findall(r"`([a-z]+)`", declaration.group(1)))
+
+
+def contract_sections() -> tuple:
+    """The body section names `contracts/work-item.md` fixes, read from the
+    contract for the same reason as the status set."""
+
+    text = WORK_ITEM_CONTRACT.read_text(encoding="utf-8")
+    return tuple(re.findall(r"^- `## (.+?)` —", text, re.MULTILINE))
+
+
+def copy_logs(source: Path, dest: Path):
+    """One fixture log directory materialized under a temporary ``.orch/``."""
+
+    dest.mkdir(parents=True)
+    for src in sorted(source.glob("*.jsonl")):
+        shutil.copyfile(str(src), str(dest / src.name))
+
+
+def make_checkout(tmp: Path, runs=FIXTURE_RUNS, friction=True, events=True) -> Path:
+    """A main checkout: a ``.git`` directory plus ``.orch/tickets/<run>/``
+    materialized from the flat tracked fixtures, one run with no tickets
+    (git tracks no empty directory, so it is built here), the friction log
+    and the deferred hooks seam's event log. ``runs`` narrows the corpus for
+    a test that needs a run set the whole corpus does not exhibit."""
+
+    root = tmp / "main"
+    (root / ".git").mkdir(parents=True)
+    tickets = root / ".orch" / "tickets"
+    for run in runs:
+        dest = tickets / run
+        dest.mkdir(parents=True)
+        for src in sorted((FIXTURES / run).glob("*.md")):
+            shutil.copyfile(str(src), str(dest / src.name))
+    (tickets / EMPTY_RUN).mkdir(parents=True)
+    if friction:
+        copy_logs(FIXTURES / "friction", root / ".orch" / "friction")
+    if events:
+        copy_logs(FIXTURES / "events", root / ".orch" / "events")
+    return root
+
+
+def make_worktree(tmp: Path, main_root: Path) -> Path:
+    """A linked worktree: a ``.git`` *file* pointing at
+    ``<main>/.git/worktrees/<name>``, the shape ``git worktree add`` writes."""
+
+    worktree = tmp / "wt"
+    worktree.mkdir()
+    gitdir = main_root / ".git" / "worktrees" / "wt"
+    gitdir.mkdir(parents=True)
+    (worktree / ".git").write_text("gitdir: {0}\n".format(gitdir), encoding="utf-8")
+    return worktree
+
+
+def ticket_paths(discovery: dict) -> list:
+    return [ticket["path"] for run in discovery["runs"] for ticket in run["tickets"]]
+
+
+def fixture_ticket_count() -> int:
+    """Derived from the corpus on disk, so adding a fixture never silently
+    weakens a count that exists to keep a test non-vacuous."""
+
+    return sum(len(list((FIXTURES / run).glob("*.md"))) for run in FIXTURE_RUNS)
+
+
+def row_for(page: str, ticket_id: str) -> str:
+    """The table row carrying ``ticket_id``, so a field is proved to sit
+    with its own ticket rather than merely somewhere on the page."""
+
+    for fragment in page.split("<tr")[1:]:
+        row = fragment.split("</tr>")[0]
+        if ">{0}<".format(ticket_id) in row:
+            return row
+    return ""
+
+
+def block_for(page: str, class_name: str, close: str = "</section>") -> str:
+    """The element carrying ``class_name``, so an assertion about one part
+    of the page cannot be satisfied by another part of it."""
+
+    fragments = page.split('class="{0}"'.format(class_name))[1:]
+    return fragments[0].split(close)[0] if fragments else ""
+
+
+def detail_url(run: str, ticket_id: str) -> str:
+    return "/ticket?run={0}&id={1}".format(run, ticket_id)
+
+
+def graph_url(run: str) -> str:
+    return "/graph?run={0}".format(run)
+
+
+NODE_RE = re.compile(
+    r'<g class="nd (nd-[a-z]+)"[^>]*>.*?<text class="nd-id"[^>]*>([^<]+)</text>'
+)
+
+
+def node_for(page: str, ticket_id: str) -> str:
+    """The status class the graph drew on ``ticket_id``'s own node. Every
+    status name also appears in the stylesheet, so a bare substring search
+    over the page proves nothing about what was drawn."""
+
+    for status_class, drawn in NODE_RE.findall(page):
+        if drawn == ticket_id:
+            return status_class
+    return ""
+
+
+def section_for(page: str, run: str) -> str:
+    for fragment in page.split('<section class="run">')[1:]:
+        body = fragment.split("</section>")[0]
+        if ">{0}<".format(run) in body:
+            return body
+    return ""
+
+
+# A bare route name exercises almost none of a route's behaviour: `/ticket`
+# with no query is the one branch that never reads a file. Each served route
+# is paired with the concrete URLs that reach its real work, so the whole-page
+# guarantees -- writes nothing, fetches nothing -- are proved where the page
+# is actually built.
+ROUTE_EXAMPLES = {
+    ui.INDEX_ROUTE: ("/",),
+    ui.TICKET_ROUTE: (
+        "/ticket",
+        detail_url("run-gamma", "G1"),
+        detail_url("run-gamma", "G6"),
+        detail_url("run-gamma", "G7"),
+        detail_url("run-gamma", "no-such-ticket"),
+        detail_url("run-empty", "G1"),
+    ),
+    ui.GRAPH_ROUTE: (
+        "/graph",
+        graph_url(SETTLED_RUN),
+        graph_url(CYCLIC_RUN),
+        graph_url("run-gamma"),
+        graph_url(EMPTY_RUN),
+        graph_url("no-such-run"),
+    ),
+    ui.FRICTION_ROUTE: ("/friction",),
+}
+
+
+def every_route() -> tuple:
+    """Every served route by concrete example, plus one that is not served,
+    so the 404 page is held to the same guarantees as the index."""
+
+    urls = tuple(url for route in ui.ROUTES for url in ROUTE_EXAMPLES.get(route, ()))
+    return urls + ("/no-such-route",)
+
+
+# `run-gamma/G4.md` is claimed at this instant with a 90m bound: the only
+# fixture from which an elapsed meter may be drawn.
+CLAIMED_AT = datetime(2026, 1, 1, 0, 20, 0, tzinfo=timezone.utc)
+FROZEN_NOW = datetime(2026, 1, 1, 1, 0, 0, tzinfo=timezone.utc)
+
+
+@contextlib.contextmanager
+def frozen_clock(now=FROZEN_NOW):
+    """Hold the reader's clock still.
+
+    A live elapsed meter is an input to the page and therefore to the
+    validator the page is served under, so two requests straddling a minute
+    boundary honestly disagree. A test about an unchanged *directory* must
+    not also be a test about the second it happened to run in.
+    """
+
+    with patch.object(ui, "_now", return_value=now):
+        yield
+
+
+def freeze(case, now=FROZEN_NOW):
+    """`frozen_clock` for a whole case, for the cases whose every assertion
+    spans two requests."""
+
+    stack = contextlib.ExitStack()
+    case.addCleanup(stack.close)
+    stack.enter_context(frozen_clock(now))
+
+
+@contextlib.contextmanager
+def serving(root: Path):
+    """The real server on an ephemeral loopback port."""
+
+    server = ui.create_server(root, 0)
+    thread = threading.Thread(target=server.serve_forever)
+    thread.daemon = True
+    thread.start()
+    try:
+        yield server
+    finally:
+        server.shutdown()
+        server.server_close()
+        thread.join(timeout=5)
+
+
+def write_ticket(run_dir: Path, ticket_id: str, **fields) -> Path:
+    """One ticket with exactly the frontmatter a test names, for cases the
+    shared fixtures deliberately do not carry."""
+
+    run_dir.mkdir(parents=True, exist_ok=True)
+    lines = ["---", "id: {0}".format(ticket_id)]
+    lines.extend("{0}: {1}".format(key, value) for key, value in fields.items())
+    lines.extend(["---", ""])
+    path = run_dir / "{0}.md".format(ticket_id)
+    path.write_text("\n".join(lines), encoding="utf-8")
+    return path
+
+
+def fetch(server, route: str, headers=None) -> tuple:
+    """``(status, headers, body)`` over the real socket."""
+
+    host, port = server.server_address[0], server.server_address[1]
+    connection = http.client.HTTPConnection(host, port, timeout=5)
+    try:
+        connection.request("GET", route, headers=headers or {})
+        response = connection.getresponse()
+        return response.status, response.headers, response.read().decode("utf-8")
+    finally:
+        connection.close()
+
+
+def get(server, route: str) -> tuple:
+    status, _headers, body = fetch(server, route)
+    return status, body
+
+
+def snapshot(tree: Path) -> dict:
+    """Name, size and mtime of every entry under ``tree``, recursively."""
+
+    entries = {}
+    for path in sorted(tree.rglob("*")):
+        stat = path.stat()
+        key = path.relative_to(tree).as_posix()
+        entries[key] = (path.is_dir(), stat.st_size, stat.st_mtime_ns)
+    return entries
+
+
+class TestRootResolution(unittest.TestCase):
+    """Spec criterion 5."""
+
+    def test_worktree_and_main_checkout_yield_identical_ticket_paths(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp = Path(tmp)
+            main = make_checkout(tmp)
+            worktree = make_worktree(tmp, main)
+
+            from_main = ui.discover(main)
+            from_worktree = ui.discover(worktree)
+
+            self.assertEqual(main.resolve(), from_worktree["root"])
+            paths = ticket_paths(from_main)
+            self.assertEqual(fixture_ticket_count(), len(paths), paths)
+            self.assertTrue(paths)
+            self.assertEqual(paths, ticket_paths(from_worktree))
+            for path in ticket_paths(from_worktree):
+                self.assertNotIn(str(worktree.resolve()), path)
+
+    def test_every_run_directory_is_discovered_including_the_empty_one(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            discovery = ui.discover(make_checkout(Path(tmp)))
+            self.assertEqual(
+                sorted(FIXTURE_RUNS + (EMPTY_RUN,)),
+                [run["run"] for run in discovery["runs"]],
+            )
+            by_run = {run["run"]: run for run in discovery["runs"]}
+            self.assertEqual([], by_run[EMPTY_RUN]["tickets"])
+            self.assertEqual(
+                ["A1", "A2"], [t["id"] for t in by_run["run-alpha"]["tickets"]]
+            )
+
+
+class TestIndexPage(unittest.TestCase):
+    """The objective: one page listing every run and its tickets."""
+
+    def test_index_lists_every_run_with_each_ticket_id_status_and_executor(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            main = make_checkout(Path(tmp))
+            status, page = ui.render_route(main, "/")
+
+            self.assertEqual(200, status)
+            for run in FIXTURE_RUNS + (EMPTY_RUN,):
+                self.assertNotEqual("", section_for(page, run), run)
+            alpha_one = row_for(page, "A1")
+            self.assertIn("complete", alpha_one)
+            self.assertIn("orch-tdd", alpha_one)
+            alpha_two = row_for(page, "A2")
+            self.assertIn("claimed", alpha_two)
+            self.assertIn("orch-verify", alpha_two)
+            self.assertNotIn("orch-tdd", alpha_two)
+
+    def test_unknown_route_is_404_with_the_requested_path_escaped(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            main = make_checkout(Path(tmp))
+            status, page = ui.render_route(main, "/<script>x</script>")
+
+            self.assertEqual(404, status)
+            self.assertNotIn("<script>x</script>", page)
+            self.assertIn("&lt;script&gt;x&lt;/script&gt;", page)
+
+
+class TestEscaping(unittest.TestCase):
+    """Spec criterion 9 and the `rules/visibility.md` §6 untrusted-data law."""
+
+    def test_untrusted_objective_reaches_the_page_escaped_never_as_markup(self):
+        source = (FIXTURES / "run-alpha" / "A2.md").read_text(encoding="utf-8")
+        self.assertIn(PAYLOAD, source)
+
+        with tempfile.TemporaryDirectory() as tmp:
+            main = make_checkout(Path(tmp))
+            _, page = ui.render_route(main, "/")
+
+            self.assertIn("&lt;script&gt;alert(1)&lt;/script&gt;", row_for(page, "A2"))
+            self.assertNotIn(PAYLOAD, page)
+
+    def test_the_detail_page_escapes_the_same_payload(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            main = make_checkout(Path(tmp))
+            status, page = ui.render_route(main, detail_url("run-alpha", "A2"))
+
+            self.assertEqual(200, status)
+            self.assertIn("&lt;script&gt;alert(1)&lt;/script&gt;", page)
+            self.assertNotIn(PAYLOAD, page)
+
+
+class TestEmptyStates(unittest.TestCase):
+    """Spec criterion 13."""
+
+    def test_root_with_no_orch_directory_renders_a_named_empty_state(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            bare = Path(tmp) / "bare"
+            (bare / ".git").mkdir(parents=True)
+
+            status, page = ui.render_route(bare, "/")
+
+            self.assertEqual(200, status)
+            self.assertIn("no .orch directory under this root", page)
+
+    def test_orch_directory_with_no_tickets_tree_renders_a_named_empty_state(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp) / "friction-only"
+            (root / ".git").mkdir(parents=True)
+            (root / ".orch" / "friction").mkdir(parents=True)
+
+            status, page = ui.render_route(root, "/")
+
+            self.assertEqual(200, status)
+            self.assertIn("no runs under .orch/tickets", page)
+
+    def test_run_directory_with_zero_tickets_renders_a_named_empty_state(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            main = make_checkout(Path(tmp))
+            _, page = ui.render_route(main, "/")
+
+            self.assertIn("no tickets in this run", section_for(page, EMPTY_RUN))
+            self.assertNotIn("no tickets in this run", section_for(page, "run-alpha"))
+
+    def test_ticket_omitting_optional_data_renders_named_empty_states(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            main = make_checkout(Path(tmp))
+            _, page = ui.render_route(main, "/")
+
+            degenerate = row_for(page, "B1")
+            self.assertIn("no objective recorded", degenerate)
+            self.assertIn("unset", degenerate)
+            self.assertNotIn("unset", row_for(page, "A1"))
+            self.assertNotIn("no objective recorded", row_for(page, "A1"))
+
+
+class TestStatusPresentation(unittest.TestCase):
+    """Spec criterion 14 and the colour law of `lane-ui-patterns.md` §2,
+    sourced to Airflow 2.10.5 `airflow/utils/state.py`."""
+
+    def test_the_map_covers_exactly_the_contract_status_set(self):
+        statuses = contract_statuses()
+
+        self.assertEqual(8, len(statuses), statuses)
+        self.assertEqual(set(statuses), set(ui.STATUS_PRESENTATION))
+        self.assertEqual(set(statuses), set(tickets_mod.VALID_STATUSES))
+
+    def test_every_status_resolves_to_a_populated_distinct_triple(self):
+        statuses = contract_statuses()
+        seen = [ui.status_presentation(status) for status in statuses]
+
+        for status, presentation in zip(statuses, seen):
+            self.assertTrue(presentation.glyph, status)
+            self.assertTrue(presentation.word, status)
+            self.assertTrue(presentation.hue.startswith("--st-"), status)
+            self.assertTrue(presentation.border, status)
+        triples = [(p.glyph, p.word, p.hue) for p in seen]
+        self.assertEqual(len(triples), len(set(triples)))
+        # The word alone would make every triple unique, so the channel that
+        # has to carry the state on its own is also checked on its own.
+        self.assertEqual(8, len({p.glyph for p in seen}))
+        self.assertEqual(8, len({p.word for p in seen}))
+
+    def test_an_unknown_status_maps_to_the_named_fallback_and_never_raises(self):
+        for value in ("", "fabulous", "COMPLETE", "<script>", "3", "complete "):
+            self.assertEqual(ui.STATUS_FALLBACK, ui.status_presentation(value), value)
+        self.assertEqual("unknown", ui.STATUS_FALLBACK.word)
+        # The fallback keeps its own hue: an unrecognized status that
+        # borrowed a real state's colour would read as that state.
+        self.assertNotIn(
+            ui.STATUS_FALLBACK.hue,
+            [ui.status_presentation(status).hue for status in contract_statuses()],
+        )
+
+    def test_eight_statuses_collapse_onto_exactly_six_hues_two_of_them_shared(self):
+        statuses = contract_statuses()
+        hues = [ui.status_presentation(status).hue for status in statuses]
+
+        self.assertEqual(6, len(set(hues)))
+        shared = sorted(hue for hue in set(hues) if hues.count(hue) > 1)
+        self.assertEqual(2, len(shared), shared)
+        for hue in shared:
+            pair = [s for s in statuses if ui.status_presentation(s).hue == hue]
+            self.assertEqual(2, len(pair), pair)
+            # A shared hue is legible only because the other channels differ.
+            self.assertEqual(2, len({ui.status_presentation(s).glyph for s in pair}), pair)
+            self.assertEqual(2, len({ui.status_presentation(s).border for s in pair}), pair)
+
+    def test_blocked_is_amber_and_failed_owns_red_alone(self):
+        blocked = ui.status_presentation("blocked")
+        failed = ui.status_presentation("failed")
+
+        self.assertNotEqual(blocked.hue, failed.hue)
+        self.assertEqual("amber", ui.HUE_TOKENS[blocked.hue])
+        self.assertEqual("red", ui.HUE_TOKENS[failed.hue])
+        self.assertEqual(
+            [failed.hue], [t for t, family in ui.HUE_TOKENS.items() if family == "red"]
+        )
+
+    def test_in_flight_never_shares_the_hue_of_done_well(self):
+        hues = [ui.status_presentation(s).hue for s in ("claimed", "ready", "complete")]
+
+        self.assertEqual(3, len(set(hues)), hues)
+        self.assertEqual("green", ui.HUE_TOKENS[ui.status_presentation("complete").hue])
+
+    def test_every_hue_token_names_a_declared_colour_family(self):
+        used = {ui.status_presentation(s).hue for s in contract_statuses()}
+        used.add(ui.STATUS_FALLBACK.hue)
+
+        self.assertEqual(used, set(ui.HUE_TOKENS))
+        for token, family in ui.HUE_TOKENS.items():
+            self.assertTrue(token.startswith("--st-"), token)
+            self.assertTrue(family, token)
+
+    def test_no_glyph_is_an_emoji_presentation_character(self):
+        # Windows is a first-class CI leg and the page ships no icon font,
+        # so each glyph must be a single text-presentation code point the
+        # system font stack already carries. The rejected set is the
+        # obvious-but-wrong choice for four of these states.
+        rejected = ("⛔", "⏸", "✅", "❌", "⚠", "\U0001f534")
+        glyphs = [p.glyph for p in ui.STATUS_PRESENTATION.values()]
+        glyphs.append(ui.STATUS_FALLBACK.glyph)
+
+        for glyph in glyphs:
+            # One code point: a trailing variation selector is what turns a
+            # text mark into an emoji, and it would fail this length check.
+            self.assertEqual(1, len(glyph), ascii(glyph))
+            self.assertLess(ord(glyph), 0x1F000, ascii(glyph))
+            self.assertNotIn(glyph, rejected, ascii(glyph))
+            self.assertFalse(0x2600 <= ord(glyph) <= 0x26FF, ascii(glyph))
+
+
+class TestStatusRendering(unittest.TestCase):
+    """The ticket objective: every rendered ticket carries its status as a
+    glyph, a word and a hue token."""
+
+    def index(self) -> str:
+        with tempfile.TemporaryDirectory() as tmp:
+            main = make_checkout(Path(tmp))
+            status, page = ui.render_route(main, "/")
+            self.assertEqual(200, status)
+            return page
+
+    def test_each_row_carries_the_glyph_the_word_and_the_status_class(self):
+        page = self.index()
+
+        for ticket_id, status in (("A1", "complete"), ("G2", "blocked"), ("G7", "suspended")):
+            row = row_for(page, ticket_id)
+            presentation = ui.status_presentation(status)
+            self.assertIn(presentation.glyph, row, ticket_id)
+            self.assertIn(presentation.word, row, ticket_id)
+            self.assertIn("st-{0}".format(status), row, ticket_id)
+
+    def test_every_status_class_in_the_markup_has_a_stylesheet_rule(self):
+        page = self.index()
+
+        used = set(re.findall(r'class="st (st-[a-z]+)"', page))
+        styled = set(re.findall(r"\.(st-[a-z]+) \{", page))
+        self.assertTrue(used)
+        self.assertEqual(set(), used - styled)
+
+    def test_every_hue_token_the_page_references_is_declared_on_the_page(self):
+        # A `var()` with no declaration and no fallback resolves to nothing,
+        # so a dangling token silently drops the whole border.
+        page = self.index()
+
+        referenced = set(re.findall(r"var\((--st-[a-z-]+)\)", page))
+        declared = set(re.findall(r"(--st-[a-z-]+):\s*[^;]+;", page))
+        self.assertTrue(referenced)
+        self.assertEqual(set(), referenced - declared)
+
+    def test_an_unknown_status_is_named_unknown_and_still_shown_escaped(self):
+        source = (FIXTURES / "run-gamma" / "G6.md").read_text(encoding="utf-8")
+        self.assertIn("status: side<b>ways", source)
+
+        page = self.index()
+
+        row = row_for(page, "G6")
+        self.assertIn(ui.STATUS_FALLBACK.word, row)
+        self.assertIn("st-unknown", row)
+        self.assertIn("side&lt;b&gt;ways", row)
+        self.assertNotIn("side<b>ways", page)
+
+
+class TestVerificationParsing(unittest.TestCase):
+    """Spec criterion 8 at the parser seam. Two shapes exist in the corpus;
+    only one is machine-readable, and saying so is the whole feature."""
+
+    def parsed(self, fixture: str) -> dict:
+        text = (FIXTURES / "run-gamma" / fixture).read_text(encoding="utf-8")
+        return ui.parse_verification(ui.split_sections(text)["Verification"])
+
+    def test_the_five_column_table_yields_populated_rows(self):
+        parsed = self.parsed("G1.md")
+
+        self.assertEqual(ui.VERIFICATION_ROWS, parsed["state"])
+        self.assertEqual(3, len(parsed["rows"]))
+        for row in parsed["rows"]:
+            self.assertEqual(set(ui.VERIFICATION_COLUMNS), set(row))
+            for column, value in row.items():
+                self.assertTrue(value, column)
+        self.assertEqual("PASS", parsed["rows"][0]["verdict"])
+        self.assertEqual("FAIL", parsed["rows"][2]["verdict"])
+        # A `\|` inside a cell is escaped content, not a column boundary:
+        # the real corpus carries regexes in its evidence column.
+        self.assertIn("(?:src|href)", parsed["rows"][1]["evidence"])
+
+    def test_the_numbered_prose_list_is_unparsed_and_never_zero_rows(self):
+        parsed = self.parsed("G2.md")
+
+        self.assertEqual(ui.VERIFICATION_UNPARSED, parsed["state"])
+        self.assertEqual([], parsed["rows"])
+
+    def test_a_header_with_no_data_rows_is_unparsed_rather_than_zero_rows(self):
+        parsed = ui.parse_verification(
+            "| # | verdict | oracle | class | evidence |\n| --- | --- | --- | --- | --- |\n"
+        )
+
+        self.assertEqual(ui.VERIFICATION_UNPARSED, parsed["state"])
+
+    def test_a_row_narrower_than_the_header_leaves_the_whole_section_unparsed(self):
+        # Half a table read as rows would report a verdict count that is not
+        # the ticket's. Showing the text verbatim loses nothing.
+        parsed = ui.parse_verification(
+            "| # | verdict | oracle | class | evidence |\n"
+            "| --- | --- | --- | --- | --- |\n"
+            "| 1 | PASS | the command | deterministic | exit 0 |\n"
+            "| 2 | PASS | the command |\n"
+        )
+
+        self.assertEqual(ui.VERIFICATION_UNPARSED, parsed["state"])
+
+    def test_an_absent_section_is_reported_as_absent_not_as_unparsed(self):
+        text = (FIXTURES / "run-gamma" / "G7.md").read_text(encoding="utf-8")
+
+        self.assertNotIn("Verification", ui.split_sections(text))
+
+
+class TestTicketDetail(unittest.TestCase):
+    """The reading axis: one ticket, its state, its verdicts and its body."""
+
+    def detail(self, main: Path, run: str, ticket_id: str) -> str:
+        status, page = ui.render_route(main, detail_url(run, ticket_id))
+        self.assertEqual(200, status, ticket_id)
+        return page
+
+    def test_the_index_links_every_ticket_to_a_detail_page_that_serves(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            main = make_checkout(Path(tmp))
+            _, index = ui.render_route(main, "/")
+
+            self.assertIn('href="/ticket?run=run-gamma&amp;id=G1"', row_for(index, "G1"))
+            page = self.detail(main, "run-gamma", "G1")
+            self.assertIn("G1", page)
+            self.assertIn("orch-tdd", page)
+            self.assertIn(ui.status_presentation("complete").glyph, page)
+
+    def test_the_table_shape_renders_every_verdict_row_with_a_count(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            main = make_checkout(Path(tmp))
+
+            block = block_for(self.detail(main, "run-gamma", "G1"), "verification")
+
+            for value in ("PASS", "FAIL", "deterministic", "tools/validate.py"):
+                self.assertIn(value, block, value)
+            self.assertIn("3 entries", block)
+            self.assertNotIn(ui.VERIFICATION_UNPARSED, block)
+
+    def test_the_prose_shape_renders_unparsed_verbatim_and_carries_no_count(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            main = make_checkout(Path(tmp))
+
+            page = self.detail(main, "run-gamma", "G2")
+            block = block_for(page, "verification")
+
+            self.assertIn(ui.VERIFICATION_UNPARSED, block)
+            self.assertNotIn('class="count"', block)
+            self.assertNotIn("0 entries", page)
+            # Unparsed is not unshown: the prose itself still reaches the page.
+            self.assertIn("comm -23", block)
+
+    def test_an_unresolvable_ticket_is_404_with_both_values_escaped(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            main = make_checkout(Path(tmp))
+
+            status, page = ui.render_route(main, detail_url("run-gamma", "<script>x"))
+
+            self.assertEqual(404, status)
+            self.assertIn("&lt;script&gt;x", page)
+            self.assertNotIn("<script>x", page)
+
+    def test_a_query_that_climbs_out_of_the_tickets_tree_resolves_to_nothing(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            main = make_checkout(Path(tmp))
+            outside = main / ".orch" / "secret.md"
+            outside.write_text(
+                "---\nid: secret\n---\n\n## Objective\n\nOUTSIDE-THE-TICKETS-TREE\n",
+                encoding="utf-8",
+            )
+
+            for url in (
+                "/ticket",
+                "/ticket?run=..&id=secret",
+                "/ticket?run=run-gamma%2F..%2F..&id=secret",
+                "/ticket?run=.&id=secret",
+                detail_url("run-gamma", "..%2F..%2Fsecret"),
+            ):
+                status, page = ui.render_route(main, url)
+
+                self.assertEqual(404, status, url)
+                self.assertNotIn("OUTSIDE-THE-TICKETS-TREE", page, url)
+
+
+# Names a client can send that the path layer refuses outright rather than
+# answering "no such file": NUL raises `ValueError: embedded null byte` out
+# of `Path.resolve`, and a component over `NAME_MAX` raises `OSError`
+# ENAMETOOLONG out of the stat. Neither is caught by
+# `BaseHTTPRequestHandler`, so before the guard the client got no HTTP
+# response at all and `socketserver` printed the absolute tickets path.
+REFUSED_NAMES = (
+    "\x00",
+    "lead\x00ing",
+    "\x00trailing",
+    "\x1f",
+    "b" * 300,
+    # 253 clears the ceiling on its own and fails it once `.md` is appended,
+    # which is the name the lookup actually uses.
+    "c" * 253,
+)
+
+
+class TestRefusedNames(unittest.TestCase):
+    """The query-to-path boundary. `find_ticket` answers a ticket or
+    ``None``, `run_tickets` tickets or ``None`` and `render_route` a
+    ``(status, html)`` pair -- for every string a client can send, not only
+    for the ones this filesystem happens to tolerate."""
+
+    def urls(self) -> tuple:
+        return tuple(
+            url
+            for name in REFUSED_NAMES
+            for url in (
+                graph_url(quote(name, safe="")),
+                detail_url(quote(name, safe=""), "G1"),
+                detail_url("run-gamma", quote(name, safe="")),
+            )
+        )
+
+    def test_a_refused_name_is_a_named_empty_answer_never_an_exception(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            main = make_checkout(Path(tmp))
+
+            for name in REFUSED_NAMES:
+                self.assertIsNone(ui.find_ticket(main, name, "G1"), ascii(name))
+                self.assertIsNone(ui.find_ticket(main, "run-gamma", name), ascii(name))
+                self.assertIsNone(ui.run_tickets(main, name), ascii(name))
+                self.assertIsNone(ui.read_events(main, name), ascii(name))
+            # Non-vacuity: the same three calls still resolve a real name,
+            # so `None` above is a rejection rather than a lookup that
+            # stopped working.
+            self.assertIsNotNone(ui.find_ticket(main, "run-gamma", "G1"))
+            self.assertTrue(ui.run_tickets(main, "run-gamma"))
+
+    def test_every_refused_name_renders_a_404_page(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            main = make_checkout(Path(tmp))
+
+            for url in self.urls():
+                status, page = ui.render_route(main, url)
+
+                self.assertEqual(404, status, url)
+                self.assertIn("not found", page, url)
+
+    def test_a_refused_name_answers_over_the_socket_rather_than_dropping_it(self):
+        # The inline poll loop catches a network error and retries, so a
+        # parked browser re-triggers this every second; and a traceback out
+        # of `socketserver` discloses the absolute tickets path the
+        # silenced `log_message` exists to withhold.
+        with tempfile.TemporaryDirectory() as tmp:
+            main = make_checkout(Path(tmp))
+            with serving(main) as server:
+                for url in self.urls():
+                    status, _headers, page = fetch(server, url)
+
+                    self.assertEqual(404, status, url)
+                    self.assertTrue(page, url)
+
+    def test_the_guard_admits_every_name_the_corpus_actually_uses(self):
+        # A ceiling set too low, or a character class drawn too wide, would
+        # make this suite's own fixtures unreachable.
+        for name in FIXTURE_RUNS + (EMPTY_RUN, "G1", "run-gamma", "a-z_0.9"):
+            self.assertEqual(name, ui._safe_name(name), name)
+
+
+class TestSectionRendering(unittest.TestCase):
+    """A ticket body is whatever its author wrote: `contracts/work-item.md`
+    fixes eight section names, requires only some of them, and lets a domain
+    add its own. The reader shows what is there and invents nothing."""
+
+    def detail(self, main: Path, run: str, ticket_id: str) -> str:
+        status, page = ui.render_route(main, detail_url(run, ticket_id))
+        self.assertEqual(200, status, ticket_id)
+        return page
+
+    def test_a_heading_inside_a_fenced_block_is_content_not_a_section(self):
+        text = (FIXTURES / "run-gamma" / "G7.md").read_text(encoding="utf-8")
+
+        sections = ui.split_sections(text)
+
+        # The fenced line names a section the contract does fix, so nothing
+        # about the name itself can rescue this: only the fence can.
+        self.assertIn("Handoff", contract_sections())
+        self.assertNotIn("Handoff", sections)
+        # The line is not lost -- it belongs to the section it sits in.
+        self.assertIn("## Handoff", sections["Notes on the wire"])
+
+    def test_only_the_sections_the_ticket_carries_are_rendered(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            main = make_checkout(Path(tmp))
+
+            page = self.detail(main, "run-gamma", "G5")
+
+            self.assertIn("<h2>Objective</h2>", page)
+            for absent in ("Verification", "Result", "Risks", "Feedback"):
+                self.assertNotIn("<h2>{0}</h2>".format(absent), page, absent)
+
+    def test_a_section_name_outside_the_contract_set_is_still_rendered(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            main = make_checkout(Path(tmp))
+
+            page = self.detail(main, "run-gamma", "G7")
+
+            self.assertNotIn("Notes on the wire", contract_sections())
+            self.assertIn("<h2>Notes on the wire</h2>", page)
+            self.assertIn("fixes eight section names", page)
+
+    def test_a_present_but_empty_section_is_named_rather_than_blank(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            main = make_checkout(Path(tmp))
+
+            page = self.detail(main, "run-gamma", "G7")
+            after = page.split("<h2>Result</h2>")[1].split("</section>")[0]
+
+            self.assertIn(ui.EMPTY_SECTION, after)
+
+    def test_sections_render_in_the_order_the_ticket_carries_them(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            main = make_checkout(Path(tmp))
+
+            page = self.detail(main, "run-gamma", "G7")
+
+            self.assertEqual(
+                ["Objective", "Notes on the wire", "Result", "Risks"],
+                re.findall(r"<h2>(.*?)</h2>", page),
+            )
+
+
+class TestElapsedMeter(unittest.TestCase):
+    """Spec criterion 9: `bound` is prose on real data, and a meter drawn
+    from a substituted default would be a fiction."""
+
+    NOW = datetime(2026, 1, 1, 1, 0, 0, tzinfo=timezone.utc)
+
+    def test_only_the_ticket_duration_grammar_yields_minutes(self):
+        self.assertEqual(90, ui.bound_minutes("90m"))
+        self.assertEqual(120, ui.bound_minutes("2h"))
+        for value in ("one session", "", "90", "90 m", "1d", "m90", "-5m", None):
+            self.assertIsNone(ui.bound_minutes(value), value)
+
+    def test_this_module_refuses_the_default_bound_its_sibling_substitutes(self):
+        # Non-vacuity: the sibling really does default, so `None` here is a
+        # decision rather than an accident of the same code path.
+        self.assertEqual(
+            tickets_mod.DEFAULT_BOUND_MINUTES,
+            tickets_mod._parse_bound_minutes("one session"),
+        )
+        self.assertIsNone(ui.bound_minutes("one session"))
+
+    def test_a_live_claim_with_both_operands_measures_elapsed_against_bound(self):
+        meter = ui.claim_meter(
+            {"status": "claimed", "bound": "90m", "claimed_at": "2026-01-01T00:00:00Z"},
+            self.NOW,
+        )
+
+        self.assertEqual(60, meter["elapsed_minutes"])
+        self.assertEqual(90, meter["bound_minutes"])
+        self.assertEqual(67, meter["percent"])
+        self.assertFalse(meter["over"])
+
+    def test_a_claim_past_its_bound_caps_at_full_and_says_so(self):
+        meter = ui.claim_meter(
+            {"status": "suspended", "bound": "30m", "claimed_at": "2026-01-01T00:00:00Z"},
+            self.NOW,
+        )
+
+        self.assertEqual(100, meter["percent"])
+        self.assertTrue(meter["over"])
+
+    def test_nothing_is_measured_without_two_operands_and_a_live_claim(self):
+        for front in (
+            {"status": "claimed", "bound": "one session", "claimed_at": "2026-01-01T00:00:00Z"},
+            {"status": "claimed", "bound": "90m"},
+            {"status": "claimed", "bound": "90m", "claimed_at": "yesterday"},
+            {"status": "complete", "bound": "90m", "claimed_at": "2026-01-01T00:00:00Z"},
+            {"status": "pending", "bound": "90m", "claimed_at": "2026-01-01T00:00:00Z"},
+            {},
+        ):
+            self.assertIsNone(ui.claim_meter(front, self.NOW), front)
+
+    def claim_line(self, ticket_id: str) -> tuple:
+        with tempfile.TemporaryDirectory() as tmp:
+            main = make_checkout(Path(tmp))
+            status, page = ui.render_route(main, detail_url("run-gamma", ticket_id))
+            self.assertEqual(200, status, ticket_id)
+            return block_for(page, "claim", "</p>"), page
+
+    def test_a_non_duration_bound_renders_no_meter_and_no_default(self):
+        claim, page = self.claim_line("G3")
+
+        self.assertIn("one session", claim)
+        self.assertIn(ui.EMPTY_NO_METER, claim)
+        self.assertNotIn("<progress", page)
+        self.assertNotIn("%", claim)
+        # The sibling's 60-minute lease default must not appear as a bound.
+        self.assertNotIn("60", claim)
+
+    def test_a_duration_bound_with_a_claim_time_renders_a_meter(self):
+        claim, _ = self.claim_line("G4")
+
+        self.assertIn("<progress", claim)
+        self.assertIn("%", claim)
+        self.assertIn("90m", claim)
+        self.assertNotIn(ui.EMPTY_NO_METER, claim)
+
+    def test_claimed_with_no_claim_time_renders_no_meter_and_does_not_raise(self):
+        claim, page = self.claim_line("G5")
+
+        self.assertIn(ui.EMPTY_UNSET, claim)
+        self.assertIn(ui.EMPTY_NO_METER, claim)
+        self.assertNotIn("<progress", page)
+        self.assertNotIn("%", claim)
+
+
+def coordinates(layout: dict) -> bytes:
+    """The layout's coordinates as bytes, so "identical" is byte identity
+    rather than a comparison that a float's repr could paper over."""
+
+    return "\n".join(
+        "{0} {1} {2} {3} {4}".format(node.id, node.layer, node.order, node.x, node.y)
+        for node in layout["nodes"]
+    ).encode("utf-8")
+
+
+def fan_graph(width: int) -> tuple:
+    """One root, ``width`` middles, one sink: the shape whose within-layer
+    ordering has the most ties, and so the most room to come out unstable."""
+
+    ids = ("R",) + tuple("M{0}".format(i) for i in range(width)) + ("S",)
+    edges = tuple(("R", "M{0}".format(i)) for i in range(width))
+    edges += tuple(("M{0}".format(i), "S") for i in range(width))
+    return ids, edges
+
+
+class TestGraphLayout(unittest.TestCase):
+    """Spec criterion 6. A layered layout with a Coffman-Graham sorter, the
+    shape Argo Workflows ships hand-rolled in 56 + 48 lines with zero
+    dependencies (`lane-ui-patterns.md` §3), computed in Python so a layout
+    bug is a failing unit test rather than a visual regression."""
+
+    IDS = ("D1", "D2", "D3", "D4", "D5")
+    EDGES = (("D1", "D2"), ("D1", "D3"), ("D2", "D4"), ("D3", "D4"), ("D4", "D5"))
+
+    def test_two_calls_on_equal_input_return_byte_equal_coordinates(self):
+        first = ui.graph_layout(self.IDS, self.EDGES)
+        second = ui.graph_layout(self.IDS, self.EDGES)
+
+        self.assertTrue(coordinates(first))
+        self.assertEqual(coordinates(first), coordinates(second))
+        # Byte equality is only meaningful because every coordinate is an
+        # integer: a float would make it a fact about repr, not about layout.
+        for node in first["nodes"]:
+            for value in (node.layer, node.order, node.x, node.y):
+                self.assertIsInstance(value, int, node)
+
+    def test_input_order_does_not_move_a_single_node(self):
+        # Set and dict iteration is where a layout loses determinism, and it
+        # loses it silently: the same call in one process keeps agreeing.
+        forward = ui.graph_layout(self.IDS, self.EDGES)
+        reversed_input = ui.graph_layout(
+            tuple(reversed(self.IDS)), tuple(reversed(self.EDGES))
+        )
+
+        self.assertEqual(coordinates(forward), coordinates(reversed_input))
+
+    def test_a_wide_graph_with_every_tie_still_lays_out_identically_twice(self):
+        ids, edges = fan_graph(9)
+
+        first = ui.graph_layout(ids, edges)
+        second = ui.graph_layout(tuple(reversed(ids)), tuple(reversed(edges)))
+
+        self.assertEqual(coordinates(first), coordinates(second))
+        self.assertEqual(len(ids), len(first["nodes"]))
+
+    def test_every_edge_runs_from_a_strictly_lower_layer_to_a_strictly_higher_one(self):
+        layout = ui.graph_layout(self.IDS, self.EDGES)
+        layer = {node.id: node.layer for node in layout["nodes"]}
+
+        self.assertEqual([], layout["diagnostics"])
+        for source, target in layout["edges"]:
+            self.assertLess(layer[source], layer[target], (source, target))
+        # Non-vacuity: a layout that dropped every edge, or collapsed the
+        # graph onto one layer, would satisfy the loop above and nothing else.
+        self.assertEqual(len(self.EDGES), len(layout["edges"]))
+        self.assertEqual(4, len(set(layer.values())))
+        self.assertEqual(0, layer["D1"])
+
+    def test_the_layer_law_survives_a_graph_wider_than_the_layer_bound(self):
+        ids, edges = fan_graph(9)
+
+        layout = ui.graph_layout(ids, edges)
+        layer = {node.id: node.layer for node in layout["nodes"]}
+
+        self.assertGreater(9, ui.LAYER_WIDTH)
+        for source, target in layout["edges"]:
+            self.assertLess(layer[source], layer[target], (source, target))
+        counts = {}
+        for value in layer.values():
+            counts[value] = counts.get(value, 0) + 1
+        self.assertTrue(counts)
+        for value, count in counts.items():
+            self.assertLessEqual(count, ui.LAYER_WIDTH, (value, count))
+
+    def test_no_two_nodes_share_a_coordinate(self):
+        ids, edges = fan_graph(9)
+
+        for layout in (ui.graph_layout(*fan_graph(9)), ui.graph_layout(self.IDS, self.EDGES)):
+            points = [(node.x, node.y) for node in layout["nodes"]]
+            self.assertEqual(len(points), len(set(points)), points)
+
+    def test_an_empty_graph_lays_out_to_nothing_rather_than_raising(self):
+        layout = ui.graph_layout((), ())
+
+        self.assertEqual([], layout["nodes"])
+        self.assertEqual([], layout["edges"])
+        self.assertEqual([], layout["diagnostics"])
+
+
+class TestGraphDiagnostics(unittest.TestCase):
+    """Spec criterion 7. Nothing on the write path proves a `depends_on` set
+    is a DAG, and `.orch/` is untrusted data, so the layout is total over
+    every edge set: it terminates, it never raises, and what it cannot
+    honour it names."""
+
+    CYCLE = (("E3", "E1"), ("E1", "E2"), ("E2", "E3"))
+    IDS = ("E1", "E2", "E3")
+
+    def layer_law_holds(self, layout: dict):
+        layer = {node.id: node.layer for node in layout["nodes"]}
+        for source, target in layout["edges"]:
+            self.assertLess(layer[source], layer[target], (source, target))
+
+    def test_a_cycle_is_reported_as_a_named_diagnostic_and_never_raised(self):
+        layout = ui.graph_layout(self.IDS, self.CYCLE)
+
+        self.assertEqual(3, len(layout["nodes"]))
+        self.assertEqual(1, len(layout["diagnostics"]), layout["diagnostics"])
+        diagnostic = layout["diagnostics"][0]
+        self.assertTrue(diagnostic.startswith(ui.DIAGNOSTIC_CYCLE), diagnostic)
+        for node_id in self.IDS:
+            self.assertIn(node_id, diagnostic, diagnostic)
+
+    def test_breaking_the_cycle_leaves_every_remaining_edge_obeying_the_layer_law(self):
+        layout = ui.graph_layout(self.IDS, self.CYCLE)
+
+        self.layer_law_holds(layout)
+        # Exactly one arc is withheld: dropping the whole cycle would lose
+        # two true dependencies to report one false one.
+        self.assertEqual(len(self.CYCLE) - 1, len(layout["edges"]))
+
+    def test_the_diagnostic_does_not_depend_on_the_order_the_edges_arrive_in(self):
+        first = ui.graph_layout(self.IDS, self.CYCLE)
+        shuffled = ui.graph_layout(
+            tuple(reversed(self.IDS)), (self.CYCLE[1], self.CYCLE[2], self.CYCLE[0])
+        )
+
+        self.assertEqual(first["diagnostics"], shuffled["diagnostics"])
+        self.assertEqual(coordinates(first), coordinates(shuffled))
+
+    def test_a_ticket_depending_on_itself_is_named_rather_than_drawn(self):
+        layout = ui.graph_layout(("X", "Y"), (("X", "X"), ("X", "Y")))
+
+        self.assertEqual([("X", "Y")], layout["edges"])
+        self.assertEqual(1, len(layout["diagnostics"]))
+        self.assertIn(ui.DIAGNOSTIC_CYCLE, layout["diagnostics"][0])
+
+    def test_a_dependency_on_a_ticket_outside_the_run_is_named_and_dropped(self):
+        layout = ui.graph_layout(("E1", "E4"), (("ZZ9", "E4"), ("E1", "E4")))
+
+        self.assertEqual(["E1", "E4"], [node.id for node in layout["nodes"]])
+        self.assertEqual([("E1", "E4")], layout["edges"])
+        self.assertEqual(1, len(layout["diagnostics"]), layout["diagnostics"])
+        self.assertTrue(layout["diagnostics"][0].startswith(ui.DIAGNOSTIC_DANGLING))
+        self.assertIn("ZZ9", layout["diagnostics"][0])
+
+    def test_a_graph_that_is_nothing_but_cycles_still_terminates(self):
+        # Every ordered pair of eight nodes, so every edge sits on a cycle
+        # and a naive "drop one edge and retry" that picked a chord would
+        # never converge. The suite's own runtime is the timeout.
+        ids = tuple("N{0}".format(i) for i in range(8))
+        edges = tuple((a, b) for a in ids for b in ids if a != b)
+
+        layout = ui.graph_layout(ids, edges)
+
+        self.assertEqual(8, len(layout["nodes"]))
+        self.assertTrue(layout["diagnostics"])
+        self.layer_law_holds(layout)
+
+    def test_both_diagnostics_can_be_reported_at_once(self):
+        layout = ui.graph_layout(("A", "B"), (("A", "B"), ("B", "A"), ("GONE", "A")))
+
+        named = " ".join(layout["diagnostics"])
+        self.assertIn(ui.DIAGNOSTIC_CYCLE, named)
+        self.assertIn(ui.DIAGNOSTIC_DANGLING, named)
+
+
+class TestGraphView(unittest.TestCase):
+    """The graph route: coordinates from the server, rendered as inline SVG.
+    No canvas and no external asset -- `install.py`'s `SCRIPT_NAMES` ships
+    flat filenames, so a sidecar asset would never reach `~/.orchflows/bin`
+    even if the no-network law allowed one."""
+
+    def graph(self, main: Path, run: str) -> str:
+        status, page = ui.render_route(main, graph_url(run))
+        self.assertEqual(200, status, run)
+        return page
+
+    def test_a_ticket_carries_its_dependencies_and_its_claimant(self):
+        ticket = ui.read_ticket(FIXTURES / SETTLED_RUN / "D4.md")
+
+        self.assertEqual(("D2", "D3"), ticket["depends_on"])
+        self.assertEqual("fixture-agent", ticket["claimed_by"])
+        # Both `depends_on` spellings the frontmatter parser accepts reach
+        # the graph identically; only the fixtures know which is which.
+        self.assertEqual(
+            ("D1",), ui.read_ticket(FIXTURES / SETTLED_RUN / "D2.md")["depends_on"]
+        )
+        self.assertEqual((), ui.read_ticket(FIXTURES / SETTLED_RUN / "D1.md")["depends_on"])
+
+    def test_the_graph_draws_one_node_per_ticket_and_one_edge_per_dependency(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            main = make_checkout(Path(tmp))
+
+            page = self.graph(main, SETTLED_RUN)
+
+            self.assertIn("<svg", page)
+            self.assertNotIn("<canvas", page)
+            self.assertEqual(5, len(re.findall(r'<g class="nd', page)), page)
+            self.assertEqual(5, len(re.findall(r'<line class="edge"', page)))
+            for ticket_id in ("D1", "D2", "D3", "D4", "D5"):
+                self.assertIn(">{0}<".format(ticket_id), page, ticket_id)
+
+    def test_every_drawn_edge_points_downward_on_the_canvas(self):
+        # The layer law is a fact about integers; this is the fact about the
+        # picture, and one sign error separates them.
+        with tempfile.TemporaryDirectory() as tmp:
+            main = make_checkout(Path(tmp))
+
+            page = self.graph(main, SETTLED_RUN)
+
+            drawn = re.findall(r'<line class="edge" x1="\d+" y1="(\d+)" x2="\d+" y2="(\d+)"', page)
+            self.assertEqual(5, len(drawn))
+            for y1, y2 in drawn:
+                self.assertLess(int(y1), int(y2), (y1, y2))
+
+    def test_each_node_carries_its_status_and_links_to_its_ticket(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            main = make_checkout(Path(tmp))
+
+            page = self.graph(main, SETTLED_RUN)
+
+            self.assertIn('href="/ticket?run=run-delta&amp;id=D3"', page)
+            self.assertIn("nd-failed", page)
+            self.assertIn(ui.status_presentation("failed").glyph, page)
+
+    def test_a_cyclic_run_displays_the_named_diagnostic_and_still_draws(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            main = make_checkout(Path(tmp))
+
+            page = self.graph(main, CYCLIC_RUN)
+
+            diagnostics = block_for(page, "diagnostics", "</ul>")
+            self.assertIn(ui.DIAGNOSTIC_CYCLE, diagnostics)
+            self.assertIn(ui.DIAGNOSTIC_DANGLING, diagnostics)
+            self.assertIn("ZZ9", diagnostics)
+            # Named, not fatal: the four nodes are still on the page.
+            self.assertEqual(4, len(re.findall(r'<g class="nd', page)))
+
+    def test_a_run_with_no_dependencies_draws_nodes_and_no_edges(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            main = make_checkout(Path(tmp))
+
+            page = self.graph(main, "run-beta")
+
+            self.assertIn("<svg", page)
+            self.assertIn('<g class="nd', page)
+            self.assertNotIn('<line class="edge"', page)
+            self.assertEqual("", block_for(page, "diagnostics", "</ul>"))
+
+    def test_a_run_with_no_tickets_names_the_empty_state_instead_of_drawing(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            main = make_checkout(Path(tmp))
+
+            page = self.graph(main, EMPTY_RUN)
+
+            self.assertIn(ui.EMPTY_NO_TICKETS, page)
+            self.assertNotIn("<svg", page)
+
+    def test_an_unresolvable_run_is_404_with_the_value_escaped(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            main = make_checkout(Path(tmp))
+
+            for url in ("/graph", graph_url("no-such-run"), graph_url("..")):
+                status, page = ui.render_route(main, url)
+                self.assertEqual(404, status, url)
+
+            status, page = ui.render_route(main, graph_url("%3Cscript%3Ex"))
+            self.assertEqual(404, status)
+            self.assertIn("&lt;script&gt;x", page)
+            self.assertNotIn("<script>x", page)
+
+    def test_an_out_of_contract_status_is_drawn_from_the_closed_set(self):
+        # G6's `status` carries markup. The graph never interpolates a raw
+        # status at all -- it draws the presentation the closed set maps to
+        # -- so the fact worth holding is that the fallback was drawn, on
+        # G6's own node, rather than that markup is missing from the page.
+        with tempfile.TemporaryDirectory() as tmp:
+            page = self.graph(make_checkout(Path(tmp)), "run-gamma")
+
+            self.assertEqual(
+                "nd-{0}".format(ui.STATUS_FALLBACK.word), node_for(page, "G6")
+            )
+            self.assertIn(ui.STATUS_FALLBACK.glyph, page)
+            self.assertNotIn("side<b>ways", page)
+
+    def test_every_untrusted_value_the_graph_interpolates_reaches_it_escaped(self):
+        # A run name and a ticket id are directory and file names, so the
+        # payload has to be one a filesystem will accept: `&` is legal on
+        # every platform this runs on, and is exactly the character that
+        # ends an href's query parameter early if it is not escaped.
+        run = "run&sub"
+        with tempfile.TemporaryDirectory() as tmp:
+            root = make_checkout(Path(tmp), runs=())
+            run_dir = root / ".orch" / "tickets" / run
+            write_ticket(run_dir, "T&1", status="done")
+            write_ticket(run_dir, "T&2", status="ready", depends_on="T&1")
+
+            status, page = ui.render_route(
+                root, "/graph?run={0}".format(quote(run, safe=""))
+            )
+            self.assertEqual(200, status)
+
+            self.assertIn('aria-label="dependency graph for run&amp;sub"', page)
+            self.assertIn('href="/ticket?run=run%26sub&amp;id=T%261"', page)
+            self.assertIn('<text class="nd-id" x="10" y="19">T&amp;1</text>', page)
+            self.assertNotIn("run&sub", page)
+            self.assertNotIn(">T&1<", page)
+
+    def test_a_dependency_naming_markup_reaches_the_diagnostic_escaped(self):
+        # `depends_on` is the one untrusted value that reaches the page as
+        # free text rather than as a name the corpus vouches for: a dangling
+        # target is reported verbatim and need never have been a filename.
+        with tempfile.TemporaryDirectory() as tmp:
+            root = make_checkout(Path(tmp), runs=())
+            write_ticket(
+                root / ".orch" / "tickets" / "run-ghost",
+                "H1",
+                status="ready",
+                depends_on="<b>ghost</b>",
+            )
+
+            page = self.graph(root, "run-ghost")
+
+            diagnostics = block_for(page, "diagnostics", "</ul>")
+            self.assertIn(ui.DIAGNOSTIC_DANGLING, diagnostics)
+            self.assertIn("&lt;b&gt;ghost&lt;/b&gt;", diagnostics)
+            self.assertNotIn("<b>ghost</b>", page)
+
+    def test_the_index_offers_a_graph_for_every_run(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            main = make_checkout(Path(tmp))
+
+            _, index = ui.render_route(main, "/")
+
+            for run in FIXTURE_RUNS + (EMPTY_RUN,):
+                self.assertIn('href="/graph?run={0}"'.format(run), index, run)
+
+
+def write_raw_ticket(run_dir: Path, file_name: str, declared_id: str, **fields) -> Path:
+    """A ticket whose file name and declared ``id:`` are set separately, for
+    the case ``write_ticket`` cannot express: the two disagreeing."""
+
+    run_dir.mkdir(parents=True, exist_ok=True)
+    lines = ["---", "id: {0}".format(declared_id)]
+    lines.extend("{0}: {1}".format(key, value) for key, value in fields.items())
+    lines.extend(["---", ""])
+    path = run_dir / file_name
+    path.write_text("\n".join(lines), encoding="utf-8")
+    return path
+
+
+class TestTicketIdentity(unittest.TestCase):
+    """A ticket carries two identities: the frontmatter `id:` the page
+    displays and links, and the file name every lookup resolves. Nothing on
+    the write path keeps them equal -- a ticket copied or renamed between
+    runs keeps the id it was written with -- and where they differ every
+    link the page emits for that ticket is dead. The reader names what it
+    cannot honour everywhere else; this is the last place it went silent."""
+
+    RUN = "run-identity"
+
+    def checkout(self, tmp: str, tickets) -> Path:
+        root = make_checkout(Path(tmp), runs=(), friction=False, events=False)
+        for file_name, declared_id in tickets:
+            write_raw_ticket(
+                root / ".orch" / "tickets" / self.RUN,
+                file_name,
+                declared_id,
+                status="ready",
+            )
+        return root
+
+    def diagnostics(self, page: str) -> str:
+        return block_for(page, "diagnostics", "</ul>")
+
+    def test_a_declared_id_that_is_not_its_file_name_is_named_on_the_index(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = self.checkout(tmp, (("C1.md", "renamed"),))
+
+            page = ui.render_route(root, "/")[1]
+
+            named = self.diagnostics(section_for(page, self.RUN))
+            self.assertNotEqual("", named)
+            self.assertIn(ui.DIAGNOSTIC_ID_MISMATCH, named)
+            self.assertIn("renamed", named)
+            self.assertIn("C1.md", named)
+
+    def test_the_same_mismatch_is_named_on_the_graph(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = self.checkout(tmp, (("C1.md", "renamed"),))
+
+            page = ui.render_route(root, graph_url(self.RUN))[1]
+
+            self.assertIn(ui.DIAGNOSTIC_ID_MISMATCH, self.diagnostics(page))
+            # Named, not fatal: the node is still drawn.
+            self.assertIn(">renamed<", page)
+
+    def test_the_diagnostic_names_a_link_that_really_is_dead(self):
+        # Without this the diagnostic could be true of nothing: the row,
+        # the node and the band all link the declared id, and that is the
+        # id no lookup resolves.
+        with tempfile.TemporaryDirectory() as tmp:
+            root = self.checkout(tmp, (("C1.md", "renamed"),))
+
+            page = ui.render_route(root, "/")[1]
+
+            self.assertIn('href="/ticket?run=run-identity&amp;id=renamed"', page)
+            self.assertEqual(404, ui.render_route(root, detail_url(self.RUN, "renamed"))[0])
+            self.assertEqual(200, ui.render_route(root, detail_url(self.RUN, "C1"))[0])
+
+    def test_two_files_declaring_one_id_are_named_and_one_node_is_drawn(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = self.checkout(tmp, (("C1.md", "dup"), ("C2.md", "dup")))
+
+            page = ui.render_route(root, graph_url(self.RUN))[1]
+
+            named = self.diagnostics(page)
+            self.assertIn(ui.DIAGNOSTIC_ID_COLLISION, named)
+            self.assertIn("C1.md", named)
+            self.assertIn("C2.md", named)
+            # The collapse the diagnostic exists for: two tickets, one node.
+            self.assertEqual(2, len(ui.run_tickets(root, self.RUN)))
+            self.assertEqual(1, len(re.findall(r'<g class="nd', page)))
+
+    def test_a_declared_id_carrying_markup_reaches_the_diagnostic_escaped(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = self.checkout(tmp, (("C1.md", "<b>x</b>"),))
+
+            page = ui.render_route(root, graph_url(self.RUN))[1]
+
+            self.assertIn("&lt;b&gt;x&lt;/b&gt;", self.diagnostics(page))
+            self.assertNotIn("<b>x</b>", page)
+
+    def test_a_run_whose_ids_all_match_their_files_says_nothing(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            main = make_checkout(Path(tmp))
+
+            self.assertEqual([], ui.identity_diagnostics(ui.run_tickets(main, "run-gamma")))
+            index = ui.render_route(main, "/")[1]
+            for run in FIXTURE_RUNS:
+                self.assertNotIn(
+                    ui.DIAGNOSTIC_ID_MISMATCH, self.diagnostics(section_for(index, run)), run
+                )
+
+    def test_an_unreadable_frontmatter_falls_back_to_the_file_name_silently(self):
+        # A ticket with no `id:` at all already resolves both ways, so it
+        # must not be reported as a disagreement.
+        with tempfile.TemporaryDirectory() as tmp:
+            root = make_checkout(Path(tmp), runs=(), friction=False, events=False)
+            run_dir = root / ".orch" / "tickets" / self.RUN
+            run_dir.mkdir(parents=True)
+            (run_dir / "C9.md").write_text("no frontmatter at all\n", encoding="utf-8")
+
+            tickets = ui.run_tickets(root, self.RUN)
+
+            self.assertEqual(["C9"], [ticket["id"] for ticket in tickets])
+            self.assertEqual([], ui.identity_diagnostics(tickets))
+
+
+class TestLayoutCache(unittest.TestCase):
+    """`lane-ui-patterns.md` §6(3): re-laying out a graph on a refresh that
+    moved no node is a live defect in a shipped orchestrator, whose own fix
+    sits in the source commented out. At a one-second poll the cost is paid
+    once per second forever, so the guard is the feature."""
+
+    def setUp(self):
+        ui.LAYOUT_CACHE.clear()
+        self.addCleanup(ui.LAYOUT_CACHE.clear)
+
+    @contextlib.contextmanager
+    def counting(self):
+        with patch.object(ui, "graph_layout", side_effect=ui.graph_layout) as computed:
+            yield computed
+
+    def test_two_requests_over_an_unchanged_ticket_set_lay_out_exactly_once(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            main = make_checkout(Path(tmp))
+
+            with self.counting() as computed:
+                first = ui.render_route(main, graph_url(SETTLED_RUN))[1]
+                second = ui.render_route(main, graph_url(SETTLED_RUN))[1]
+
+            self.assertEqual(1, computed.call_count)
+            self.assertEqual(first, second)
+            # The counter can reach two, so one is a measurement rather than
+            # a mock that was never wired to anything.
+            with self.counting() as recomputed:
+                ui.LAYOUT_CACHE.clear()
+                ui.render_route(main, graph_url(SETTLED_RUN))
+                ui.LAYOUT_CACHE.clear()
+                ui.render_route(main, graph_url(SETTLED_RUN))
+            self.assertEqual(2, recomputed.call_count)
+
+    def test_a_status_change_repaints_without_laying_the_graph_out_again(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            main = make_checkout(Path(tmp))
+            ticket = main / ".orch" / "tickets" / SETTLED_RUN / "D3.md"
+
+            with self.counting() as computed:
+                before = ui.render_route(main, graph_url(SETTLED_RUN))[1]
+                ticket.write_text(
+                    ticket.read_text(encoding="utf-8").replace(
+                        "status: failed", "status: complete"
+                    ),
+                    encoding="utf-8",
+                )
+                after = ui.render_route(main, graph_url(SETTLED_RUN))[1]
+
+            self.assertEqual(1, computed.call_count)
+            self.assertEqual("nd-failed", node_for(before, "D3"))
+            self.assertEqual("nd-complete", node_for(after, "D3"))
+
+    def test_a_node_or_an_edge_appearing_does_lay_the_graph_out_again(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            main = make_checkout(Path(tmp))
+            run_dir = main / ".orch" / "tickets" / SETTLED_RUN
+
+            with self.counting() as computed:
+                ui.render_route(main, graph_url(SETTLED_RUN))
+                (run_dir / "D6.md").write_text(
+                    "---\nid: D6\nstatus: ready\ndepends_on: [D5]\n---\n", encoding="utf-8"
+                )
+                ui.render_route(main, graph_url(SETTLED_RUN))
+                edged = run_dir / "D2.md"
+                edged.write_text(
+                    edged.read_text(encoding="utf-8").replace("  - D1", "  - D3"),
+                    encoding="utf-8",
+                )
+                page = ui.render_route(main, graph_url(SETTLED_RUN))[1]
+
+            self.assertEqual(3, computed.call_count)
+            self.assertIn(">D6<", page)
+
+    def test_two_runs_never_serve_each_other_a_cached_layout(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            main = make_checkout(Path(tmp))
+
+            delta = ui.render_route(main, graph_url(SETTLED_RUN))[1]
+            epsilon = ui.render_route(main, graph_url(CYCLIC_RUN))[1]
+
+            self.assertIn(">D5<", delta)
+            self.assertNotIn(">D5<", epsilon)
+            self.assertIn(">E4<", epsilon)
+            self.assertEqual(2, len(ui.LAYOUT_CACHE))
+
+    def test_the_cache_is_bounded_so_a_long_lived_viewer_cannot_grow_forever(self):
+        for index in range(ui.LAYOUT_CACHE_LIMIT * 2):
+            ui.cached_layout(("N{0}".format(index),), ())
+
+        self.assertEqual(ui.LAYOUT_CACHE_LIMIT, len(ui.LAYOUT_CACHE))
+
+    def test_a_cache_hit_returns_the_layout_that_was_computed_for_that_key(self):
+        ids, edges = fan_graph(5)
+
+        computed = ui.graph_layout(ids, edges)
+        first = ui.cached_layout(ids, edges)
+        second = ui.cached_layout(tuple(reversed(ids)), tuple(reversed(edges)))
+
+        self.assertEqual(coordinates(computed), coordinates(first))
+        self.assertIs(first, second)
+
+
+BAND_ID_RE = re.compile(r'<li class="claim">.*?<a [^>]*>([^<]+)</a>')
+
+
+def band_ids(page: str) -> list:
+    return BAND_ID_RE.findall(block_for(page, "band", "</ul>"))
+
+
+def band_entry(page: str, ticket_id: str) -> str:
+    """The band entry for ``ticket_id``, so a field is proved to sit with
+    its own claim rather than with some other executor's."""
+
+    for fragment in block_for(page, "band", "</ul>").split('<li class="claim">')[1:]:
+        entry = fragment.split("</li>")[0]
+        if ">{0}</a>".format(ticket_id) in entry:
+            return entry
+    return ""
+
+
+class TestActiveBand(unittest.TestCase):
+    """`U3` completion test 6, for the band the spec's view scope names.
+    Which executors are at work right now is the question an orchestrator
+    asks between polls, and reading it off the run tables costs a scan of
+    every ticket in every run."""
+
+    def index(self, tmp: str, runs=FIXTURE_RUNS) -> str:
+        return ui.render_route(make_checkout(Path(tmp), runs=runs), "/")[1]
+
+    def test_the_band_lists_exactly_the_tickets_whose_status_is_claimed(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            page = self.index(tmp)
+
+            self.assertEqual(["A2", "G3", "G4", "G5"], band_ids(page))
+            # G7 is suspended and G2 blocked: both hold a claim, neither is
+            # an executor at work, and the meter's wider notion of live is
+            # not this band's.
+            self.assertNotIn("G7", band_ids(page))
+            self.assertNotIn("G2", band_ids(page))
+
+    def test_the_band_is_absent_when_nothing_is_claimed(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            page = self.index(tmp, runs=(SETTLED_RUN,))
+
+            self.assertEqual("", block_for(page, "band", "</ul>"))
+            self.assertNotIn('<ul class="band"', page)
+            # The page itself still rendered, so the band's absence is not
+            # the absence of the index.
+            self.assertIn(">D1<", page)
+
+    def test_each_entry_names_its_run_ticket_executor_and_claimant(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = make_checkout(Path(tmp), runs=())
+            write_ticket(
+                root / ".orch" / "tickets" / "run-one",
+                "K1",
+                status="claimed",
+                executor="orch-tdd",
+                claimed_by="agent-one",
+            )
+            write_ticket(
+                root / ".orch" / "tickets" / "run-two",
+                "K2",
+                status="claimed",
+                executor="orch-verify",
+                claimed_by="agent-two",
+            )
+            page = ui.render_route(root, "/")[1]
+
+            self.assertEqual(["K1", "K2"], band_ids(page))
+            for wanted in ("run-one", "K1", "orch-tdd", "agent-one"):
+                self.assertIn(wanted, band_entry(page, "K1"), wanted)
+            for wanted in ("run-two", "K2", "orch-verify", "agent-two"):
+                self.assertIn(wanted, band_entry(page, "K2"), wanted)
+            # Each claimant sits with its own claim rather than anywhere.
+            self.assertNotIn("agent-two", band_entry(page, "K1"))
+
+    def test_an_entry_links_to_the_ticket_it_names(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            entry = band_entry(self.index(tmp), "G3")
+
+            self.assertIn('href="/ticket?run=run-gamma&amp;id=G3"', entry)
+
+    def test_a_claim_that_can_be_measured_carries_its_meter(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            self.assertIn("<progress", band_entry(self.index(tmp), "G4"))
+
+    def test_a_claim_with_nothing_to_measure_is_listed_without_a_meter(self):
+        # G5 is claimed and carries no `claimed_at`; G3's bound is not a
+        # duration. Both are real shapes, and a band that dropped either
+        # would hide a working executor.
+        with tempfile.TemporaryDirectory() as tmp:
+            page = self.index(tmp)
+
+            for ticket_id in ("G3", "G5"):
+                entry = band_entry(page, ticket_id)
+                self.assertNotIn("<progress", entry, ticket_id)
+                self.assertIn(ui.EMPTY_NO_METER, entry, ticket_id)
+
+    def test_an_unset_executor_or_claimant_is_named_rather_than_left_blank(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = make_checkout(Path(tmp), runs=())
+            write_ticket(root / ".orch" / "tickets" / "run-one", "K1", status="claimed")
+            entry = band_entry(ui.render_route(root, "/")[1], "K1")
+
+            self.assertEqual(2, entry.count(ui.EMPTY_UNSET), entry)
+
+    def test_an_untrusted_claimant_reaches_the_band_escaped(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = make_checkout(Path(tmp), runs=())
+            write_ticket(
+                root / ".orch" / "tickets" / "run-one",
+                "K1",
+                status="claimed",
+                claimed_by="<b>agent</b>",
+            )
+            page = ui.render_route(root, "/")[1]
+
+            self.assertIn("&lt;b&gt;agent&lt;/b&gt;", page)
+            self.assertNotIn("<b>agent</b>", page)
+
+    def test_the_band_sits_above_the_runs_it_summarises(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            page = self.index(tmp)
+
+            self.assertLess(page.index('class="band"'), page.index('class="run"'))
+
+
+SCRIPT_RE = re.compile(r"<script>(.*?)</script>", re.S)
+LIVE_RE = re.compile(r'<main data-live="([a-z]+)">')
+
+
+class TestPolling(unittest.TestCase):
+    """`U3` completion test 8. `lane-ui-patterns.md` §4: stdlib
+    `http.server` never speaks HTTP/2, so the browser's six-connection cap
+    applies in full and one held stream would deadlock a serial server.
+    Interval polling is the transport, and the interval is the whole
+    design."""
+
+    def script(self, page: str) -> str:
+        found = SCRIPT_RE.findall(page)
+        self.assertEqual(1, len(found), "expected exactly one inline script")
+        return found[0]
+
+    def live(self, root: Path, route: str) -> str:
+        return LIVE_RE.search(ui.render_route(root, route)[1]).group(1)
+
+    def test_every_polling_constant_the_spec_names_is_bound_in_the_emitted_js(self):
+        # Each interval is bound to its own name. A bare substring search
+        # cannot tell these three apart -- "1000" is inside "15000" and
+        # "5000" is inside "15000" too -- so a page that emitted only the
+        # hidden interval would satisfy all three.
+        with tempfile.TemporaryDirectory() as tmp:
+            source = self.script(ui.render_route(make_checkout(Path(tmp)), "/")[1])
+
+            for name, milliseconds in (
+                ("LIVE_MS", ui.POLL_LIVE_MS),
+                ("IDLE_MS", ui.POLL_IDLE_MS),
+                ("HIDDEN_MS", ui.POLL_HIDDEN_MS),
+            ):
+                bound = re.compile(
+                    r"\b{0}\s*=\s*{1}\b".format(name, milliseconds)
+                )
+                self.assertRegex(source, bound, name)
+            self.assertIn("document.hidden", source)
+
+    def test_the_binding_test_can_tell_the_three_intervals_apart(self):
+        # The discrimination the assertion above rests on, made explicit:
+        # against a page emitting one interval under all three names, two of
+        # the three patterns must fail.
+        source = "  var LIVE_MS = 15000, IDLE_MS = 15000, HIDDEN_MS = 15000;\n"
+
+        matched = [
+            re.search(r"\b{0}\s*=\s*{1}\b".format(name, milliseconds), source)
+            for name, milliseconds in (
+                ("LIVE_MS", ui.POLL_LIVE_MS),
+                ("IDLE_MS", ui.POLL_IDLE_MS),
+                ("HIDDEN_MS", ui.POLL_HIDDEN_MS),
+            )
+        ]
+
+        self.assertEqual([None, None], matched[:2])
+        self.assertIsNotNone(matched[2])
+
+    def test_those_constants_are_the_module_s_own(self):
+        self.assertEqual(
+            (1000, 5000, 15000),
+            (ui.POLL_LIVE_MS, ui.POLL_IDLE_MS, ui.POLL_HIDDEN_MS),
+        )
+
+    def test_no_route_emits_setinterval(self):
+        # `setInterval` queues a second request behind a slow first one; on a
+        # serial stdlib server that is how a poll becomes a pile-up.
+        with tempfile.TemporaryDirectory() as tmp:
+            main = make_checkout(Path(tmp))
+            for route in every_route():
+                page = ui.render_route(main, route)[1]
+                self.assertNotIn("setInterval", page, route)
+                self.assertIn("setTimeout", page, route)
+
+    def test_the_poll_revalidates_with_the_tag_it_was_given(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            source = self.script(ui.render_route(make_checkout(Path(tmp)), "/")[1])
+
+            self.assertIn("If-None-Match", source)
+            self.assertIn("304", source)
+
+    def test_the_script_is_inline_and_names_no_remote_source(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            main = make_checkout(Path(tmp))
+            for route in every_route():
+                page = ui.render_route(main, route)[1]
+                self.assertNotIn("<script src", page, route)
+                self.assertNotIn("<script ", page, route)
+
+    def test_a_run_with_work_under_way_polls_at_the_live_interval(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            main = make_checkout(Path(tmp))
+
+            # run-gamma holds claimed tickets; run-epsilon holds a ready one.
+            self.assertEqual("yes", self.live(main, graph_url("run-gamma")))
+            self.assertEqual("yes", self.live(main, graph_url(CYCLIC_RUN)))
+
+    def test_a_run_whose_every_ticket_is_terminal_polls_at_the_idle_interval(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            main = make_checkout(Path(tmp))
+
+            self.assertEqual("no", self.live(main, graph_url(SETTLED_RUN)))
+            self.assertEqual("no", self.live(main, graph_url(EMPTY_RUN)))
+
+    def test_the_index_is_live_while_any_run_is(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            self.assertEqual("yes", self.live(make_checkout(Path(tmp)), "/"))
+        with tempfile.TemporaryDirectory() as tmp:
+            settled = make_checkout(Path(tmp), runs=(SETTLED_RUN,))
+            self.assertEqual("no", self.live(settled, "/"))
+
+    def test_a_ticket_page_is_live_only_while_its_own_ticket_is(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            main = make_checkout(Path(tmp))
+
+            self.assertEqual("yes", self.live(main, detail_url("run-gamma", "G3")))
+            self.assertEqual("no", self.live(main, detail_url("run-gamma", "G1")))
+            # `suspended` holds the lease with nobody at the keyboard: the
+            # meter keeps running, the page has nothing to wait for.
+            self.assertEqual("no", self.live(main, detail_url("run-gamma", "G7")))
+
+    def test_a_page_with_no_ticket_in_view_polls_at_the_idle_interval(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            main = make_checkout(Path(tmp))
+
+            self.assertEqual("no", self.live(main, ui.FRICTION_ROUTE))
+            self.assertEqual("no", self.live(main, "/no-such-route"))
+
+
+TS_RE = re.compile(r'<span class="ts">([^<]*)</span>')
+
+
+class TestFrictionFeed(unittest.TestCase):
+    """`U3` completion test 7. The friction law says a session that hit
+    friction and logged nothing failed silently; a feed that dies on one
+    half-written line is the same failure one layer up."""
+
+    def feed(self, tmp: str, friction=True) -> str:
+        root = make_checkout(Path(tmp), friction=friction)
+        status, page = ui.render_route(root, ui.FRICTION_ROUTE)
+        self.assertEqual(200, status)
+        return page
+
+    def test_every_well_formed_entry_from_every_log_is_rendered(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            page = self.feed(tmp)
+
+            self.assertEqual(5, len(TS_RE.findall(page)))
+            self.assertIn("tools/validate.py discovered no file under scripts/", page)
+            self.assertIn("a route added by branching inside the dispatcher", page)
+
+    def test_entries_are_newest_first_across_the_log_files(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            stamps = TS_RE.findall(self.feed(tmp))
+
+            self.assertEqual(sorted(stamps, reverse=True), stamps)
+            self.assertEqual("2026-08-03T11:00:00Z", stamps[0])
+            self.assertEqual("2026-07-30T09:15:00Z", stamps[-1])
+
+    def test_a_malformed_line_is_skipped_and_counted_rather_than_failing(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            page = self.feed(tmp)
+
+            # Two: a line that is not JSON, and an array that is JSON and
+            # still not an entry.
+            self.assertIn("2 unreadable", page)
+            self.assertNotIn("an array is valid JSON", page)
+
+    def test_a_blank_line_is_not_a_malformed_one(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = make_checkout(Path(tmp), friction=False)
+            log = root / ".orch" / "friction" / "2026-09.jsonl"
+            log.parent.mkdir(parents=True)
+            log.write_text(
+                '\n{"ts": "2026-09-01T00:00:00Z", "observed": "a", "expected": "b"}\n\n\n',
+                encoding="utf-8",
+            )
+            read = ui.read_friction(root)
+
+            self.assertEqual(0, read["skipped"])
+            self.assertEqual(1, len(read["entries"]))
+
+    def test_a_clean_log_carries_no_skip_note_at_all(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = make_checkout(Path(tmp), friction=False)
+            log = root / ".orch" / "friction" / "2026-09.jsonl"
+            log.parent.mkdir(parents=True)
+            log.write_text(
+                '{"ts": "2026-09-01T00:00:00Z", "observed": "a", "expected": "b"}\n',
+                encoding="utf-8",
+            )
+            page = ui.render_route(root, ui.FRICTION_ROUTE)[1]
+
+            self.assertNotIn("unreadable", page)
+            self.assertIn("1 entry", page)
+
+    def test_an_entry_missing_a_category_or_host_is_shown_rather_than_dropped(self):
+        # An older logger wrote entries without them. Dropping the entry
+        # would lose the observation the law exists to keep.
+        with tempfile.TemporaryDirectory() as tmp:
+            page = self.feed(tmp)
+
+            self.assertIn("an entry written by an older logger", page)
+            self.assertEqual(2, page.count(ui.EMPTY_UNSET))
+
+    def test_an_untrusted_entry_reaches_the_feed_escaped(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            page = self.feed(tmp)
+
+            self.assertIn("&lt;b&gt;markup&lt;/b&gt;", page)
+            self.assertNotIn("<b>markup</b>", page)
+
+    def test_an_absent_friction_log_is_named_rather_than_an_error(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            page = self.feed(tmp, friction=False)
+
+            self.assertIn(ui.EMPTY_NO_FRICTION, page)
+            self.assertEqual([], TS_RE.findall(page))
+
+    def test_the_index_links_to_the_feed(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            page = ui.render_route(make_checkout(Path(tmp)), "/")[1]
+
+            self.assertIn('href="{0}"'.format(ui.FRICTION_ROUTE), page)
+
+    def test_an_entry_that_is_json_but_not_an_object_never_reaches_a_key_lookup(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = make_checkout(Path(tmp), friction=False)
+            log = root / ".orch" / "friction" / "2026-09.jsonl"
+            log.parent.mkdir(parents=True)
+            log.write_text('"a bare string"\n42\nnull\n[]\n', encoding="utf-8")
+            read = ui.read_friction(root)
+
+            self.assertEqual({"entries": [], "skipped": 4}, read)
+
+
+EVENT_RUN = "run-gamma"
+
+
+class TestEventsSeam(unittest.TestCase):
+    """The deferred hooks seam the spec's `binding_constraints` fix so v2 is
+    additive: `.orch/events/<run>.jsonl`, one JSON object per line. No hook
+    writes it in this version, so the reader has to hold both halves --
+    render the file where it exists, say nothing at all where it does
+    not."""
+
+    def graph(self, root: Path, run: str) -> str:
+        status, page = ui.render_route(root, graph_url(run))
+        self.assertEqual(200, status, run)
+        return page
+
+    def test_a_run_with_an_event_log_renders_it(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            page = self.graph(make_checkout(Path(tmp)), EVENT_RUN)
+
+            self.assertIn("<h2>events</h2>", page)
+            block = block_for(page, "events")
+            self.assertEqual(3, len(block.split('<li class="event">')) - 1, block)
+            for kind in ("tool_pre", "tool_post", "subagent_stop"):
+                self.assertIn(kind, block, kind)
+
+    def test_a_run_with_no_event_log_says_nothing_at_all(self):
+        # The silent half. A heading over an empty feed would promise a
+        # stream nothing in this version produces.
+        with tempfile.TemporaryDirectory() as tmp:
+            main = make_checkout(Path(tmp))
+
+            for run in (SETTLED_RUN, CYCLIC_RUN, EMPTY_RUN):
+                page = self.graph(main, run)
+                self.assertNotIn("<h2>events</h2>", page, run)
+                self.assertEqual("", block_for(page, "events"), run)
+            self.assertIsNone(ui.read_events(main, SETTLED_RUN))
+
+    def test_an_absent_events_directory_is_the_same_silence(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            main = make_checkout(Path(tmp), events=False)
+
+            self.assertIsNone(ui.read_events(main, EVENT_RUN))
+            self.assertNotIn("<h2>events</h2>", self.graph(main, EVENT_RUN))
+
+    def test_every_key_the_seam_fixes_reaches_the_page(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            block = block_for(self.graph(make_checkout(Path(tmp)), EVENT_RUN), "events")
+
+            for value in (
+                "2026-01-01T00:20:00Z",
+                "run-gamma",
+                "G4",
+                "fixture-agent",
+                "tool_pre",
+                "Read",
+                "scripts/ui.py",
+            ):
+                self.assertIn(value, block, value)
+
+    def test_a_nullable_key_left_null_is_named_rather_than_blank(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            block = block_for(self.graph(make_checkout(Path(tmp)), EVENT_RUN), "events")
+            stop = block.split('<li class="event">')[1].split("</li>")[0]
+
+            self.assertIn("subagent_stop", stop)
+            # `ticket`, `tool` and `detail` are all null on that line.
+            self.assertEqual(3, stop.count(ui.EMPTY_UNSET), stop)
+
+    def test_events_are_newest_first(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            main = make_checkout(Path(tmp))
+            block = block_for(self.graph(main, EVENT_RUN), "events")
+
+            stamps = TS_RE.findall(block)
+            self.assertEqual(3, len(stamps))
+            self.assertEqual(sorted(stamps, reverse=True), stamps)
+            self.assertEqual("2026-01-01T00:21:00Z", stamps[0])
+
+    def test_a_malformed_line_is_skipped_and_counted_as_the_friction_feed_does(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            main = make_checkout(Path(tmp))
+
+            read = ui.read_events(main, EVENT_RUN)
+
+            # Two: a half-written line, and an array that is JSON and still
+            # not an event. The blank line is neither.
+            self.assertEqual(2, read["skipped"])
+            self.assertEqual(3, len(read["entries"]))
+            self.assertIn("2 unreadable lines", block_for(self.graph(main, EVENT_RUN), "events"))
+            self.assertNotIn("a half-written line", self.graph(main, EVENT_RUN))
+
+    def test_an_untrusted_event_reaches_the_page_escaped(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            page = self.graph(make_checkout(Path(tmp)), EVENT_RUN)
+
+            self.assertIn("&lt;b&gt;markup&lt;/b&gt;", page)
+            self.assertNotIn("<b>markup</b>", page)
+
+    def test_the_log_is_read_from_the_run_it_is_named_for_and_no_other(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = make_checkout(Path(tmp), events=False)
+            logs = root / ".orch" / "events"
+            logs.mkdir(parents=True)
+            (logs / "{0}.jsonl".format(SETTLED_RUN)).write_text(
+                '{"ts": "2026-01-01T00:00:00Z", "event": "tool_pre", "detail": "OWN-RUN"}\n',
+                encoding="utf-8",
+            )
+
+            self.assertIn("OWN-RUN", self.graph(root, SETTLED_RUN))
+            self.assertNotIn("OWN-RUN", self.graph(root, EVENT_RUN))
+
+    def test_an_event_log_appearing_moves_the_validator(self):
+        # `STATE_DIRS` omitted the directory, so a log written while a
+        # viewer was open would never have been noticed.
+        with tempfile.TemporaryDirectory() as tmp:
+            root = make_checkout(Path(tmp), events=False)
+            with frozen_clock():
+                before = ui.state_digest(root)
+                logs = root / ".orch" / "events"
+                logs.mkdir(parents=True)
+                (logs / "{0}.jsonl".format(SETTLED_RUN)).write_text(
+                    '{"ts": "2026-01-01T00:00:00Z", "event": "tool_pre"}\n', encoding="utf-8"
+                )
+                after = ui.state_digest(root)
+
+            self.assertNotEqual(before, after)
+            self.assertIn(ui.EVENTS_DIR, ui.STATE_DIRS)
+
+
+class TestValidatorObservesTheWholePage(unittest.TestCase):
+    """The validator's whole job is to be a faithful function of the body it
+    is served with. A tag that observes less than the page does turns the
+    poll into a machine for showing a reader something that is no longer
+    true, and does it silently: the response is a 304, which looks exactly
+    like nothing having happened."""
+
+    def live_root(self, tmp: str) -> Path:
+        """One claim, 90m bound, claimed at `CLAIMED_AT` -- the shape whose
+        rendering moves with the clock and nothing else."""
+
+        root = make_checkout(Path(tmp), runs=(), friction=False, events=False)
+        write_ticket(
+            root / ".orch" / "tickets" / "run-live",
+            "L1",
+            status="claimed",
+            bound="90m",
+            claimed_at="2026-01-01T00:20:00Z",
+        )
+        return root
+
+    def at(self, server, minutes: int, etag=None) -> tuple:
+        headers = {"If-None-Match": etag} if etag else {}
+        with frozen_clock(CLAIMED_AT + timedelta(minutes=minutes)):
+            return fetch(server, "/", headers)
+
+    def test_a_live_meter_advances_under_polling(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            seen = []
+            with serving(self.live_root(tmp)) as server:
+                for minutes in (1, 75, 100):
+                    status, headers, body = self.at(server, minutes)
+                    self.assertEqual(200, status, minutes)
+                    seen.append((headers.get("ETag"), body))
+
+            for (tag, body), wanted in zip(
+                seen, ("1m of 90m", "75m of 90m", "100m of 90m, over bound")
+            ):
+                self.assertIn(wanted, body, wanted)
+                self.assertTrue(tag, wanted)
+            # Three different pages, so three different validators.
+            self.assertEqual(3, len({tag for tag, _ in seen}))
+
+    def test_a_client_holding_last_minutes_tag_is_answered_rather_than_left(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            with serving(self.live_root(tmp)) as server:
+                stale = self.at(server, 1)[1].get("ETag")
+                status, headers, body = self.at(server, 75, stale)
+
+            self.assertEqual(200, status)
+            self.assertNotEqual(stale, headers.get("ETag"))
+            self.assertIn("75m of 90m", body)
+
+    def test_a_bound_is_crossed_under_polling_rather_than_at_the_next_write(self):
+        # Nothing writes to a ticket when its bound expires, so an overrun is
+        # visible only if the clock alone can move the page.
+        with tempfile.TemporaryDirectory() as tmp:
+            with serving(self.live_root(tmp)) as server:
+                inside = self.at(server, 89)
+                status, _, body = self.at(server, 91, inside[1].get("ETag"))
+
+            self.assertNotIn("over bound", inside[2])
+            self.assertEqual(200, status)
+            self.assertIn("over bound", body)
+
+    def test_a_meter_that_has_not_moved_still_answers_304(self):
+        # The 304 is not defeated: within one minute the page is identical
+        # and the poll must stay cheap.
+        with tempfile.TemporaryDirectory() as tmp:
+            with serving(self.live_root(tmp)) as server:
+                first = self.at(server, 30)[1].get("ETag")
+                with frozen_clock(CLAIMED_AT + timedelta(minutes=30, seconds=59)):
+                    status, headers, body = fetch(
+                        server, "/", {"If-None-Match": first}
+                    )
+
+            self.assertEqual(304, status)
+            self.assertEqual("", body)
+            self.assertEqual(first, headers.get("ETag"))
+
+    def test_a_settled_run_answers_304_across_an_hour_of_clock(self):
+        # Criterion 10's own case, kept: where nothing is claimed there is
+        # nothing for the clock to move, so the tag must not move either.
+        with tempfile.TemporaryDirectory() as tmp:
+            main = make_checkout(Path(tmp), runs=(SETTLED_RUN,))
+            with serving(main) as server:
+                first = self.at(server, 0)[1].get("ETag")
+                status, headers, _ = self.at(server, 74, first)
+
+            self.assertEqual(304, status)
+            self.assertEqual(first, headers.get("ETag"))
+
+    def test_a_meter_the_page_draws_is_a_digest_input(self):
+        with tempfile.TemporaryDirectory() as tmp, tempfile.TemporaryDirectory() as other:
+            live = self.live_root(tmp)
+            settled = make_checkout(Path(other), runs=(SETTLED_RUN,))
+            clock = [CLAIMED_AT + timedelta(minutes=minutes) for minutes in (1, 2, 3)]
+
+            self.assertEqual(3, len({ui.state_digest(live, now) for now in clock}))
+            # The clock is an input only where the page reads one.
+            self.assertEqual(1, len({ui.state_digest(settled, now) for now in clock}))
+
+    def test_the_two_empty_states_of_orch_never_share_one_digest(self):
+        # `.orch/` absent and `.orch/` present-but-bare are two different
+        # named pages, so they are two different validators.
+        with tempfile.TemporaryDirectory() as tmp:
+            bare = Path(tmp) / "bare"
+            (bare / ".git").mkdir(parents=True)
+            hollow = Path(tmp) / "hollow"
+            (hollow / ".orch").mkdir(parents=True)
+            tickets = Path(tmp) / "tickets"
+            (tickets / ".orch" / "tickets").mkdir(parents=True)
+
+            digests = [ui.state_digest(root) for root in (bare, hollow, tickets)]
+            pages = [ui.render_route(root, "/")[1] for root in (bare, hollow, tickets)]
+
+            self.assertEqual(3, len(set(digests)), digests)
+            self.assertIn(ui.EMPTY_NO_ORCH, pages[0])
+            self.assertIn(ui.EMPTY_NO_RUNS, pages[1])
+            self.assertIn(ui.EMPTY_NO_RUNS, pages[2])
+
+    def test_an_orch_directory_appearing_repaints_the_empty_state(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            root = Path(tmp) / "bare"
+            (root / ".git").mkdir(parents=True)
+            with serving(root) as server:
+                first = fetch(server, "/")
+                (root / ".orch" / "tickets").mkdir(parents=True)
+                status, headers, body = fetch(
+                    server, "/", {"If-None-Match": first[1].get("ETag")}
+                )
+
+            self.assertIn(ui.EMPTY_NO_ORCH, first[2])
+            self.assertEqual(200, status)
+            self.assertNotEqual(first[1].get("ETag"), headers.get("ETag"))
+            self.assertIn(ui.EMPTY_NO_RUNS, body)
+            self.assertNotIn(ui.EMPTY_NO_ORCH, body)
+
+
+class TestConditionalRequests(unittest.TestCase):
+    """Spec criterion 10. A one-second poll that re-renders every page every
+    second is the cost this view refuses to pay; the 304 is what makes the
+    interval affordable."""
+
+    def setUp(self):
+        # These are tests about a directory that did or did not change. The
+        # fixtures also carry a live meter, which honestly moves the tag at
+        # each minute boundary, so an unpinned clock would make a handful of
+        # them fail on the minute rather than never.
+        freeze(self)
+
+    def touch(self, path: Path):
+        """A rewrite inside the same wall-clock second that leaves the size
+        alone -- the case a mtime-only tag misses."""
+
+        before = path.stat()
+        os.utime(path, ns=(before.st_atime_ns, before.st_mtime_ns + 1000))
+        after = path.stat()
+        if after.st_mtime_ns == before.st_mtime_ns:
+            self.skipTest("filesystem does not record sub-second mtime")
+        self.assertEqual(before.st_size, after.st_size)
+        self.assertEqual(int(before.st_mtime), int(after.st_mtime))
+
+    def test_an_unchanged_ticket_directory_answers_304_to_every_data_route(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            main = make_checkout(Path(tmp))
+            with serving(main) as server:
+                for route in every_route():
+                    status, headers, body = fetch(server, route)
+                    if status != 200:
+                        continue
+                    etag = headers.get("ETag")
+                    self.assertTrue(etag, route)
+                    again = fetch(server, route, {"If-None-Match": etag})
+                    self.assertEqual(304, again[0], route)
+                    self.assertEqual("", again[2], route)
+                    self.assertEqual(etag, again[1].get("ETag"), route)
+                    self.assertNotEqual("", body, route)
+
+    def test_a_ticket_changing_size_answers_200_with_a_different_tag(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            main = make_checkout(Path(tmp))
+            ticket = main / ".orch" / "tickets" / SETTLED_RUN / "D1.md"
+            with serving(main) as server:
+                first = fetch(server, graph_url(SETTLED_RUN))[1].get("ETag")
+                with ticket.open("a", encoding="utf-8") as handle:
+                    handle.write("\nanother line\n")
+                status, headers, _ = fetch(
+                    server, graph_url(SETTLED_RUN), {"If-None-Match": first}
+                )
+
+            self.assertEqual(200, status)
+            self.assertNotEqual(first, headers.get("ETag"))
+
+    def test_a_same_second_rewrite_of_the_same_size_answers_200_with_a_new_tag(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            main = make_checkout(Path(tmp))
+            ticket = main / ".orch" / "tickets" / SETTLED_RUN / "D1.md"
+            with serving(main) as server:
+                first = fetch(server, "/")[1].get("ETag")
+                self.touch(ticket)
+                status, headers, body = fetch(server, "/", {"If-None-Match": first})
+
+            self.assertEqual(200, status)
+            self.assertNotEqual(first, headers.get("ETag"))
+            self.assertNotEqual("", body)
+
+    def test_a_tag_from_another_page_never_satisfies_this_one(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            main = make_checkout(Path(tmp))
+            with serving(main) as server:
+                index = fetch(server, "/")[1].get("ETag")
+                graph = fetch(server, graph_url(SETTLED_RUN))[1].get("ETag")
+                status, _, _ = fetch(server, "/", {"If-None-Match": graph})
+
+            self.assertNotEqual(index, graph)
+            self.assertEqual(200, status)
+
+    def test_a_stale_or_absent_validator_answers_the_whole_page(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            main = make_checkout(Path(tmp))
+            with serving(main) as server:
+                for header in ({}, {"If-None-Match": '"not-a-real-tag"'}):
+                    status, _, body = fetch(server, "/", header)
+                    self.assertEqual(200, status)
+                    self.assertIn("<main", body)
+
+    def test_a_wildcard_or_weak_validator_is_honoured_as_rfc7232_requires(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            main = make_checkout(Path(tmp))
+            with serving(main) as server:
+                etag = fetch(server, "/")[1].get("ETag")
+                for sent in (
+                    "*",
+                    "W/{0}".format(etag),
+                    '"other", {0}'.format(etag),
+                ):
+                    status, _, _ = fetch(server, "/", {"If-None-Match": sent})
+                    self.assertEqual(304, status, sent)
+
+    def test_a_404_carries_no_entity_tag_to_be_cached_against(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            main = make_checkout(Path(tmp))
+            with serving(main) as server:
+                for route in ("/nope", detail_url(SETTLED_RUN, "ZZ9"), graph_url("nope")):
+                    status, headers, _ = fetch(server, route)
+                    self.assertEqual(404, status, route)
+                    self.assertIsNone(headers.get("ETag"), route)
+
+    def test_the_page_is_offered_for_revalidation_rather_than_not_stored(self):
+        # `no-store` forbids keeping the response at all, so the browser has
+        # nothing to revalidate and never sends `If-None-Match`: the 304 above
+        # would be unreachable from a real client.
+        with tempfile.TemporaryDirectory() as tmp:
+            main = make_checkout(Path(tmp))
+            with serving(main) as server:
+                headers = fetch(server, "/")[1]
+
+            self.assertEqual("no-cache", headers.get("Cache-Control"))
+
+    def test_a_304_renders_nothing_at_all(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            main = make_checkout(Path(tmp))
+            etag = ui.respond(main, graph_url(SETTLED_RUN))[1]
+
+            with patch.object(ui, "render_route") as rendered:
+                status, echoed, body = ui.respond(main, graph_url(SETTLED_RUN), etag)
+
+            self.assertEqual((304, etag, ""), (status, echoed, body))
+            rendered.assert_not_called()
+
+
+class TestLoopbackOnly(unittest.TestCase):
+    """Spec `binding_constraints`: bind loopback only, never 0.0.0.0."""
+
+    def test_server_binds_a_loopback_address_and_serves_there(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            main = make_checkout(Path(tmp))
+            with serving(main) as server:
+                host = server.server_address[0]
+
+                self.assertTrue(ipaddress.ip_address(host).is_loopback, host)
+                self.assertNotEqual("0.0.0.0", host)
+                status, page = get(server, "/")
+                self.assertEqual(200, status)
+                self.assertIn("orchflows runs", page)
+
+    def test_an_unavailable_port_exits_2_with_a_message_not_a_traceback(self):
+        # The bind failure is injected rather than provoked by holding the
+        # port: Windows honours SO_REUSEADDR on a live listener, so a real
+        # collision would bind there and serve_forever would hang CI.
+        with tempfile.TemporaryDirectory() as tmp:
+            main = make_checkout(Path(tmp))
+            argv = ["--root", str(main), "--port", "8787"]
+            stderr = io.StringIO()
+            with patch.object(ui, "create_server", side_effect=OSError("in use")):
+                with contextlib.redirect_stderr(stderr):
+                    code = ui.main(argv)
+
+            self.assertEqual(2, code)
+            self.assertIn("8787", stderr.getvalue())
+            self.assertIn("in use", stderr.getvalue())
+
+
+class TestRouteCoverage(unittest.TestCase):
+    """A guard that iterates the routes proves nothing about a route it
+    never visits. U1 registered `/` alone; a route added later and left out
+    of the examples silently shrinks both guards below, so the coverage is
+    asserted rather than assumed."""
+
+    def test_every_served_route_is_reached_by_a_concrete_example(self):
+        for route in ui.ROUTES:
+            self.assertIn(route, ROUTE_EXAMPLES, route)
+            self.assertTrue(ROUTE_EXAMPLES[route], route)
+
+    def test_the_examples_reach_a_rendered_ticket_not_only_its_error_paths(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            main = make_checkout(Path(tmp))
+
+            served = [ui.render_route(main, url)[0] for url in every_route()]
+
+            self.assertIn(200, served)
+            self.assertIn(404, served)
+
+
+class TestReadOnly(unittest.TestCase):
+    """Spec criterion 11."""
+
+    def test_exercising_every_route_writes_nothing_under_orch(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            main = make_checkout(Path(tmp))
+            orch = main / ".orch"
+            before = snapshot(orch)
+            self.assertTrue(before)
+
+            with serving(main) as server:
+                for route in every_route():
+                    status, page = get(server, route)
+                    self.assertIn(status, (200, 404))
+                    self.assertTrue(page)
+
+            self.assertEqual(before, snapshot(orch))
+
+    def test_revalidating_every_route_writes_nothing_either(self):
+        # A 304 short-circuits before `render_route`, so the guard above
+        # never walks that path -- and it is the path a poll takes almost
+        # every second the viewer is open.
+        freeze(self)
+        with tempfile.TemporaryDirectory() as tmp:
+            main = make_checkout(Path(tmp))
+            orch = main / ".orch"
+            before = snapshot(orch)
+            revalidated = 0
+
+            with serving(main) as server:
+                for route in every_route():
+                    etag = fetch(server, route)[1].get("ETag")
+                    if etag is None:
+                        continue
+                    again = fetch(server, route, {"If-None-Match": etag})
+                    self.assertEqual(304, again[0], route)
+                    revalidated += 1
+
+            self.assertEqual(before, snapshot(orch))
+            self.assertGreaterEqual(revalidated, len(ui.ROUTES))
+
+
+class TestNoNetworkAssets(unittest.TestCase):
+    """Spec criterion 12."""
+
+    def test_the_detector_catches_a_remote_asset(self):
+        for markup in (
+            '<script src="https://cdn.example/x.js"></script>',
+            "<link rel=stylesheet href='//cdn.example/x.css'>",
+            '<img src="http://cdn.example/x.png">',
+        ):
+            self.assertIsNotNone(REMOTE_ASSET_RE.search(markup), markup)
+
+    def test_no_route_emits_a_remote_src_or_href(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            main = make_checkout(Path(tmp))
+            with serving(main) as server:
+                for route in every_route():
+                    _, page = get(server, route)
+                    self.assertIsNone(REMOTE_ASSET_RE.search(page), route)
+
+
+def first_import(source: str) -> tuple:
+    """``(module, first name)`` of the earliest import statement, or ``()``."""
+
+    for node in ast.parse(source).body:
+        if isinstance(node, ast.ImportFrom):
+            return (node.module, node.names[0].name)
+        if isinstance(node, ast.Import):
+            return (None, node.names[0].name)
+    return ()
+
+
+# The spec's `binding_constraints` list, as things an AST can be asked
+# about. `zoneinfo` imports on 3.9 and is forbidden anyway: CPython on
+# Windows ships no tz database.
+FLOOR_MODULES = ("tomllib", "zoneinfo")
+FLOOR_NAMES = {"datetime": ("UTC",), "typing": ("Self",), "itertools": ("batched",)}
+FLOOR_NODES = tuple(
+    (getattr(ast, attribute), spelling)
+    for attribute, spelling in (("Match", "match"), ("TryStar", "except*"))
+    if getattr(ast, attribute, None) is not None
+)
+
+
+def evaluated_nodes(tree) -> list:
+    """Every node the interpreter actually runs.
+
+    `from __future__ import annotations` makes an annotation a string that
+    is never evaluated, so PEP 604 inside one is legal at the floor and a
+    detector that flagged it would be reporting a violation that is not one.
+    """
+
+    postponed = []
+    for node in ast.walk(tree):
+        if isinstance(node, ast.AnnAssign):
+            postponed.append(node.annotation)
+        elif isinstance(node, ast.arg) and node.annotation is not None:
+            postponed.append(node.annotation)
+        elif isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            if node.returns is not None:
+                postponed.append(node.returns)
+    skip = set()
+    for annotation in postponed:
+        skip.update(id(child) for child in ast.walk(annotation))
+    return [node for node in ast.walk(tree) if id(node) not in skip]
+
+
+def above_the_floor(source: str) -> list:
+    """Every construct in `source` that Python 3.9 cannot run.
+
+    Parsing alone proves nothing here: a 3.13 interpreter parses all of
+    these happily, and the module has already been imported by the time any
+    test runs, so a `SyntaxError` would have failed collection rather than a
+    test. What CI's 3.9 leg would refuse has to be asked of the tree.
+    """
+
+    found = set()
+    for node in evaluated_nodes(ast.parse(source)):
+        for kind, spelling in FLOOR_NODES:
+            if isinstance(node, kind):
+                found.add(spelling)
+        if isinstance(node, ast.Import):
+            found.update(
+                alias.name
+                for alias in node.names
+                if alias.name.split(".")[0] in FLOOR_MODULES
+            )
+        elif isinstance(node, ast.ImportFrom):
+            module = node.module or ""
+            if module.split(".")[0] in FLOOR_MODULES:
+                found.add(module)
+            found.update(
+                "{0}.{1}".format(module, alias.name)
+                for alias in node.names
+                if alias.name in FLOOR_NAMES.get(module, ())
+            )
+        elif isinstance(node, ast.Attribute) and isinstance(node.value, ast.Name):
+            if node.attr in FLOOR_NAMES.get(node.value.id, ()):
+                found.add("{0}.{1}".format(node.value.id, node.attr))
+        elif isinstance(node, ast.BinOp) and isinstance(node.op, ast.BitOr):
+            # `X | None` is the runtime PEP 604 the spec names; `a | None`
+            # is not arithmetic anyone writes by accident.
+            if any(
+                isinstance(side, ast.Constant) and side.value is None
+                for side in (node.left, node.right)
+            ):
+                found.add("X | None")
+    return sorted(found)
+
+
+class TestModuleFloor(unittest.TestCase):
+    """Spec `binding_constraints`: the 3.9 floor and mandatory postponed
+    annotations."""
+
+    def test_the_module_reaches_for_nothing_above_the_floor(self):
+        self.assertGreaterEqual(sys.version_info[:2], (3, 9))
+
+        self.assertEqual([], above_the_floor(UI_PY.read_text(encoding="utf-8")))
+
+    def test_the_detector_names_every_import_and_name_the_floor_forbids(self):
+        # Every construct here parses on 3.9 and fails at import or call
+        # there, which is exactly the class a parse check cannot catch.
+        source = (
+            "import tomllib\n"
+            "from zoneinfo import ZoneInfo\n"
+            "from typing import Self\n"
+            "import datetime, itertools\n"
+            "stamp = datetime.datetime.now(datetime.UTC)\n"
+            "pairs = itertools.batched(stamp, 2)\n"
+            "fallback = int | None\n"
+        )
+
+        self.assertEqual(
+            [
+                "X | None",
+                "datetime.UTC",
+                "itertools.batched",
+                "tomllib",
+                "typing.Self",
+                "zoneinfo",
+            ],
+            above_the_floor(source),
+        )
+
+    def test_the_detector_names_the_syntax_the_floor_forbids(self):
+        source = "match value:\n    case 1:\n        pass\n"
+
+        if FLOOR_NODES:
+            self.assertEqual(["match"], above_the_floor(source))
+        else:
+            # On the floor interpreter itself the syntax is a `SyntaxError`,
+            # which is the same guarantee arrived at sooner.
+            self.assertRaises(SyntaxError, ast.parse, source)
+
+    def test_a_postponed_annotation_is_not_a_violation(self):
+        # The detector has to be wrong in neither direction: this module's
+        # own `X | None` annotations are strings under the mandatory
+        # `__future__` import and must not be reported.
+        source = (
+            "from __future__ import annotations\n"
+            "held: int | None = None\n"
+            "def read(path: str | None = None) -> dict | None:\n"
+            "    return None\n"
+        )
+
+        self.assertEqual([], above_the_floor(source))
+
+    def test_future_annotations_is_the_first_import(self):
+        self.assertEqual(
+            ("__future__", "annotations"), first_import(UI_PY.read_text(encoding="utf-8"))
+        )
+        # The check discriminates: a module that imports anything first fails it.
+        self.assertNotEqual(
+            ("__future__", "annotations"),
+            first_import("import os\nfrom __future__ import annotations\n"),
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_ui.py
+++ b/tests/test_ui.py
@@ -4,9 +4,11 @@ read-only, no-network and loopback-only guarantees."""
 
 import ast
 import contextlib
+import html
 import http.client
 import io
 import ipaddress
+import json
 import os
 import re
 import shutil
@@ -41,6 +43,74 @@ EMPTY_RUN = "run-empty"
 # interval must not be the live one.
 SETTLED_RUN = "run-delta"
 CYCLIC_RUN = "run-epsilon"
+
+# The synthetic `~/.claude/projects` tree. `tests/fixtures/transcripts/README.md`
+# records what each fixture carries and why.
+FIXTURE_TRANSCRIPTS = Path(__file__).resolve().parent / "fixtures" / "transcripts"
+ALPHA_PROJECT = "-Users-dmcinerney-tools-alpha"
+BETA_PROJECT = "-Users-dmcinerney-tools-beta-repo"
+WORKTREE_PROJECT = "-Users-dmcinerney-tools-beta-repo--claude-worktrees-wt-one"
+UNDECODABLE_PROJECT = "not-an-encoded-path"
+
+TITLED_SESSION = "11111111-1111-4111-8111-111111111111"
+UNTITLED_SESSION = "22222222-2222-4222-8222-222222222222"
+MARKUP_SESSION = "33333333-3333-4333-8333-333333333333"
+MALFORMED_SESSION = "44444444-4444-4444-8444-444444444444"
+TRUNCATED_SESSION = "55555555-5555-4555-8555-555555555555"
+EMPTY_SESSION = "66666666-6666-4666-8666-666666666666"
+
+SESSION_PROJECT = {
+    TITLED_SESSION: ALPHA_PROJECT,
+    UNTITLED_SESSION: ALPHA_PROJECT,
+    MARKUP_SESSION: BETA_PROJECT,
+    MALFORMED_SESSION: BETA_PROJECT,
+    TRUNCATED_SESSION: WORKTREE_PROJECT,
+    EMPTY_SESSION: UNDECODABLE_PROJECT,
+}
+
+# Deliberately interleaved across the project directories: an index that
+# grouped by directory and ordered within it would still satisfy an
+# ordering assertion made over one directory's sessions.
+SESSIONS_NEWEST_FIRST = (
+    MARKUP_SESSION,
+    TITLED_SESSION,
+    TRUNCATED_SESSION,
+    UNTITLED_SESSION,
+    MALFORMED_SESSION,
+    EMPTY_SESSION,
+)
+# An hour apart from a fixed instant, so an ordering assertion never
+# depends on the second the copy happened to run in.
+SESSION_EPOCH = 1780000000
+SESSION_STEP = 3600
+# Subagent files sit after every session file and a minute apart, so a
+# subagent's rendered last activity is distinguishable from its session's
+# and from every other subagent's.
+AGENT_EPOCH = SESSION_EPOCH + 1800
+AGENT_STEP = 60
+
+# Present in every `user` and `assistant` body, every `last-prompt`,
+# attachment, tool input, tool result and file-history record in the
+# fixture corpus, and in none of its renderable fields.
+TRANSCRIPT_SENTINEL = "ZQXJVWNTRPKB-transcript-content-must-not-render"
+LAST_AI_TITLE = "Alpha, the last title recorded"
+SUPERSEDED_AI_TITLE = "Alpha, the title that was superseded"
+
+# The corpus's subagents, by the shape each one is here to carry.
+RETURNED_AGENT = "agent-aa11"
+CALLED_AGENT = "agent-aa12"
+UNEVIDENCED_AGENT = "agent-aa13"
+ALPHA_AGENTS = (RETURNED_AGENT, CALLED_AGENT, UNEVIDENCED_AGENT)
+MARKUP_AGENT = "agent-bb21"
+BAD_FIELDS_AGENT = "agent-bb22"
+UNREADABLE_AGENT = "agent-bb23"
+PARENT_AGENT = "agent-cc31"
+CHILD_AGENT = "agent-cc32"
+MARKUP_AGENT_TYPE = PAYLOAD
+# Quote characters as well as angle brackets: an attribute context breaks
+# on the quote alone, and `html.escape` is only proved by a value that
+# would break both contexts differently.
+MARKUP_AGENT_DESCRIPTION = '<img src="x" onerror="alert(1)">'
 
 
 def contract_statuses() -> tuple:
@@ -108,6 +178,88 @@ def make_worktree(tmp: Path, main_root: Path) -> Path:
     return worktree
 
 
+def fixture_agent_files() -> list:
+    """Every subagent file in the corpus, by tree-relative name.
+
+    Derived from the tree rather than listed, so adding a fixture subagent
+    never needs a table here kept in step with it.
+    """
+
+    return sorted(
+        path.relative_to(FIXTURE_TRANSCRIPTS).as_posix()
+        for path in FIXTURE_TRANSCRIPTS.rglob("agent-*")
+        if path.is_file()
+    )
+
+
+def make_transcripts(tmp: Path) -> Path:
+    """The synthetic transcript root, materialized under a temporary
+    directory with a deterministic last-activity time per session.
+
+    The index orders on the transcript's mtime and a copy takes whatever
+    the clock says, so the order is stamped here rather than inherited from
+    the order `copytree` happened to walk in. A subagent's stamp is its own
+    file's, for the same reason: the flowchart draws it as a last activity.
+    """
+
+    dest = tmp / "transcripts"
+    shutil.copytree(str(FIXTURE_TRANSCRIPTS), str(dest))
+    for index, session in enumerate(SESSIONS_NEWEST_FIRST):
+        stamp = SESSION_EPOCH - index * SESSION_STEP
+        path = dest / SESSION_PROJECT[session] / (session + ".jsonl")
+        os.utime(str(path), (stamp, stamp))
+    for index, name in enumerate(fixture_agent_files()):
+        stamp = AGENT_EPOCH + index * AGENT_STEP
+        os.utime(str(dest / name), (stamp, stamp))
+    return dest
+
+
+# The year 30828, which is where an NTFS FILETIME runs out. No filesystem
+# this suite can write reaches it -- APFS clamps at 2262 -- so the mtime is
+# substituted at the one seam that reads one.
+FAR_FUTURE_MTIME_NS = 910692730085000000000
+
+
+@contextlib.contextmanager
+def far_future_mtimes():
+    """Every file the session views stat, dated past the calendar."""
+
+    real = ui._stat_identity
+
+    def stamped(path):
+        identity = real(path)
+        return None if identity is None else identity[:2] + (FAR_FUTURE_MTIME_NS,)
+
+    with patch.object(ui, "_stat_identity", stamped):
+        yield
+
+
+def utc_stamp(seconds: int) -> str:
+    return datetime.fromtimestamp(seconds, timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def session_stamp(session: str) -> str:
+    """The last-activity stamp `make_transcripts` gave one session."""
+
+    return utc_stamp(SESSION_EPOCH - SESSIONS_NEWEST_FIRST.index(session) * SESSION_STEP)
+
+
+def agent_stamp(agent: str) -> str:
+    """The newest stamp `make_transcripts` gave any file of one subagent.
+
+    Two files carry one subagent -- its metadata and its own transcript --
+    and the later of them is when it was last heard from.
+    """
+
+    names = fixture_agent_files()
+    newest = max(
+        index
+        for index, name in enumerate(names)
+        if name.rsplit("/", 1)[-1].startswith(agent + ".")
+    )
+    return utc_stamp(AGENT_EPOCH + newest * AGENT_STEP)
+
+
 def ticket_paths(discovery: dict) -> list:
     return [ticket["path"] for run in discovery["runs"] for ticket in run["tickets"]]
 
@@ -130,6 +282,45 @@ def row_for(page: str, ticket_id: str) -> str:
     return ""
 
 
+# The id is a link now that `/session` exists, and an empty cell is still a
+# cell: both shapes have to reach `session_ids` or an ordering assertion
+# quietly stops seeing rows.
+SESSION_ID_RE = re.compile(r'<td class="sid">(?:<a [^>]*>)?([^<]*)')
+
+
+def session_ids(page: str) -> list:
+    """The session index's rows, in the order it drew them."""
+
+    return SESSION_ID_RE.findall(page)
+
+
+def session_cell(page: str, session: str, name: str) -> str:
+    """One named cell of one session's own row.
+
+    The page inlines its own stylesheet and its own script, so a substring
+    search over it is weak in both directions -- `U3`'s `node_for` exists
+    for the same reason.
+    """
+
+    row = row_for(page, session)
+    found = re.search(r'<td class="{0}">(.*?)</td>'.format(name), row, re.S)
+    return found.group(1) if found else ""
+
+
+ROW_COLUMN_RE = re.compile(r'<td class="([a-z-]+)"')
+
+
+def row_columns(page: str, row_id: str) -> list:
+    """The column names one rendered row actually carried, in order.
+
+    Read off the page rather than off the constant that is supposed to fix
+    it: a cell written beside the closed renderable set is invisible to a
+    guard that only ever reads the set.
+    """
+
+    return ROW_COLUMN_RE.findall(row_for(page, row_id))
+
+
 def block_for(page: str, class_name: str, close: str = "</section>") -> str:
     """The element carrying ``class_name``, so an assertion about one part
     of the page cannot be satisfied by another part of it."""
@@ -146,6 +337,10 @@ def graph_url(run: str) -> str:
     return "/graph?run={0}".format(run)
 
 
+def session_url(session: str) -> str:
+    return "/session?id={0}".format(session)
+
+
 NODE_RE = re.compile(
     r'<g class="nd (nd-[a-z]+)"[^>]*>.*?<text class="nd-id"[^>]*>([^<]+)</text>'
 )
@@ -160,6 +355,33 @@ def node_for(page: str, ticket_id: str) -> str:
         if drawn == ticket_id:
             return status_class
     return ""
+
+
+SESSION_NODE_RE = re.compile(
+    r'<a href="#(?P<anchor>[^"]*)" aria-label="(?P<label>[^"]*)">'
+    r'<g class="nd (?P<state>nd-[a-z-]+)"[^>]*>(?P<body>.*?)</g></a>',
+    re.S,
+)
+INFERRED_EDGE_RE = re.compile(r'<line class="edge edge-inferred"')
+EDGE_RE = re.compile(r'<line class="edge')
+
+
+def session_anchors(page: str) -> list:
+    """What the flowchart drew, in order, by the row each node links to."""
+
+    return [found.group("anchor") for found in SESSION_NODE_RE.finditer(page)]
+
+
+def session_node(page: str, anchor: str) -> dict:
+    """One flowchart node by the row it links to: its state class, its
+    accessible label and the text drawn inside it. Every state word also
+    appears in the stylesheet and every label also appears in the table, so
+    a substring search over the page proves nothing about what was drawn."""
+
+    for found in SESSION_NODE_RE.finditer(page):
+        if found.group("anchor") == anchor:
+            return found.groupdict()
+    return {}
 
 
 def section_for(page: str, run: str) -> str:
@@ -194,6 +416,16 @@ ROUTE_EXAMPLES = {
         graph_url("no-such-run"),
     ),
     ui.FRICTION_ROUTE: ("/friction",),
+    ui.SESSIONS_ROUTE: ("/sessions",),
+    ui.SESSION_ROUTE: (
+        "/session",
+        session_url(TITLED_SESSION),
+        session_url(MARKUP_SESSION),
+        session_url(TRUNCATED_SESSION),
+        session_url(UNTITLED_SESSION),
+        session_url(EMPTY_SESSION),
+        session_url("no-such-session"),
+    ),
 }
 
 
@@ -235,10 +467,15 @@ def freeze(case, now=FROZEN_NOW):
 
 
 @contextlib.contextmanager
-def serving(root: Path):
-    """The real server on an ephemeral loopback port."""
+def serving(root: Path, transcripts=None):
+    """The real server on an ephemeral loopback port.
 
-    server = ui.create_server(root, 0)
+    ``transcripts`` is passed explicitly or not at all: the reader resolves
+    the `~/.claude/projects` default in `main` alone, so a caller that omits
+    it gets the named empty state rather than the operator's real tree.
+    """
+
+    server = ui.create_server(root, 0, transcripts)
     thread = threading.Thread(target=server.serve_forever)
     thread.daemon = True
     thread.start()
@@ -2315,8 +2552,11 @@ class TestRouteCoverage(unittest.TestCase):
     def test_the_examples_reach_a_rendered_ticket_not_only_its_error_paths(self):
         with tempfile.TemporaryDirectory() as tmp:
             main = make_checkout(Path(tmp))
+            transcripts = make_transcripts(Path(tmp))
 
-            served = [ui.render_route(main, url)[0] for url in every_route()]
+            served = [
+                ui.render_route(main, url, transcripts)[0] for url in every_route()
+            ]
 
             self.assertIn(200, served)
             self.assertIn(404, served)
@@ -2328,11 +2568,12 @@ class TestReadOnly(unittest.TestCase):
     def test_exercising_every_route_writes_nothing_under_orch(self):
         with tempfile.TemporaryDirectory() as tmp:
             main = make_checkout(Path(tmp))
+            transcripts = make_transcripts(Path(tmp))
             orch = main / ".orch"
             before = snapshot(orch)
             self.assertTrue(before)
 
-            with serving(main) as server:
+            with serving(main, transcripts) as server:
                 for route in every_route():
                     status, page = get(server, route)
                     self.assertIn(status, (200, 404))
@@ -2347,11 +2588,12 @@ class TestReadOnly(unittest.TestCase):
         freeze(self)
         with tempfile.TemporaryDirectory() as tmp:
             main = make_checkout(Path(tmp))
+            transcripts = make_transcripts(Path(tmp))
             orch = main / ".orch"
             before = snapshot(orch)
             revalidated = 0
 
-            with serving(main) as server:
+            with serving(main, transcripts) as server:
                 for route in every_route():
                     etag = fetch(server, route)[1].get("ETag")
                     if etag is None:
@@ -2378,7 +2620,8 @@ class TestNoNetworkAssets(unittest.TestCase):
     def test_no_route_emits_a_remote_src_or_href(self):
         with tempfile.TemporaryDirectory() as tmp:
             main = make_checkout(Path(tmp))
-            with serving(main) as server:
+            transcripts = make_transcripts(Path(tmp))
+            with serving(main, transcripts) as server:
                 for route in every_route():
                     _, page = get(server, route)
                     self.assertIsNone(REMOTE_ASSET_RE.search(page), route)
@@ -2539,6 +2782,1541 @@ class TestModuleFloor(unittest.TestCase):
             ("__future__", "annotations"),
             first_import("import os\nfrom __future__ import annotations\n"),
         )
+
+
+class TranscriptCase(unittest.TestCase):
+    """A fixture transcript root and a fixture checkout, plus a clean parse
+    cache -- the cache is module state that outlives a test, so a case that
+    counts parses must not inherit another case's hits."""
+
+    def setUp(self):
+        ui.TRANSCRIPT_CACHE.clear()
+        self.addCleanup(ui.TRANSCRIPT_CACHE.clear)
+        stack = contextlib.ExitStack()
+        self.addCleanup(stack.close)
+        tmp = Path(stack.enter_context(tempfile.TemporaryDirectory()))
+        self.tmp = tmp
+        self.main = make_checkout(tmp)
+        self.transcripts = make_transcripts(tmp)
+
+    def sessions(self, transcripts=True) -> str:
+        root = self.transcripts if transcripts is True else transcripts
+        status, page = ui.render_route(self.main, ui.SESSIONS_ROUTE, root)
+        self.assertEqual(200, status)
+        return page
+
+
+class TestTranscriptRoot(TranscriptCase):
+    """`S1` completion test 2, spec criterion 5."""
+
+    def test_the_flag_selects_the_root_the_index_reads(self):
+        page = self.sessions()
+
+        self.assertEqual(list(SESSIONS_NEWEST_FIRST), session_ids(page))
+        self.assertIn(str(self.transcripts), block_for(page, "root", "</p>"))
+
+    def test_the_default_is_the_operators_projects_directory(self):
+        self.assertEqual(
+            Path.home() / ".claude" / "projects", ui.transcript_root(None)
+        )
+        # Derived from the running user's home rather than a literal, and
+        # by arithmetic alone: the directory patched in here does not exist,
+        # and resolving the default must not care.
+        with patch.object(Path, "home", return_value=self.tmp / "elsewhere"):
+            self.assertEqual(
+                self.tmp / "elsewhere" / ".claude" / "projects", ui.transcript_root(None)
+            )
+        self.assertFalse((self.tmp / "elsewhere").exists())
+
+    def test_the_flag_overrides_the_default(self):
+        self.assertEqual(self.transcripts, ui.transcript_root(str(self.transcripts)))
+
+    def test_the_entry_point_hands_the_resolved_root_to_the_server(self):
+        seen = {}
+
+        def capture(root, port, transcripts=None):
+            seen["transcripts"] = transcripts
+            raise OSError("stopped before serving")
+
+        with patch.object(ui, "create_server", capture):
+            with contextlib.redirect_stderr(io.StringIO()):
+                flagged = ui.main(
+                    ["--root", str(self.main), "--transcripts", str(self.transcripts)]
+                )
+                self.assertEqual(2, flagged)
+                self.assertEqual(self.transcripts, seen["transcripts"])
+
+                self.assertEqual(2, ui.main(["--root", str(self.main)]))
+
+        self.assertEqual(Path.home() / ".claude" / "projects", seen["transcripts"])
+
+    def test_no_root_configured_reads_nothing_at_all(self):
+        # The guarantee that keeps this suite off the operator's machine: a
+        # caller that supplies no root gets the named empty state, so a test
+        # that forgets one cannot fall back to `~/.claude/projects`.
+        with patch.object(ui, "_transcript_summary") as parsed:
+            page = self.sessions(None)
+
+        parsed.assert_not_called()
+        self.assertIn(ui.EMPTY_NO_TRANSCRIPTS, block_for(page, "empty", "</p>"))
+
+    def test_only_the_entry_point_resolves_the_default(self):
+        callers = set()
+        for node in ast.walk(ast.parse(UI_PY.read_text(encoding="utf-8"))):
+            if not isinstance(node, ast.FunctionDef):
+                continue
+            for inner in ast.walk(node):
+                if (
+                    isinstance(inner, ast.Call)
+                    and isinstance(inner.func, ast.Name)
+                    and inner.func.id == "transcript_root"
+                ):
+                    callers.add(node.name)
+
+        self.assertEqual({"main"}, callers)
+
+
+class TestSessionIndex(TranscriptCase):
+    """`S1` completion test 3, spec criterion 6."""
+
+    def test_every_project_directory_contributes_to_one_index(self):
+        page = self.sessions()
+
+        self.assertEqual(sorted(SESSIONS_NEWEST_FIRST), sorted(session_ids(page)))
+        self.assertEqual(4, len(set(SESSION_PROJECT.values())))
+
+    def test_sessions_are_ordered_by_last_activity_newest_first(self):
+        page = self.sessions()
+
+        self.assertEqual(list(SESSIONS_NEWEST_FIRST), session_ids(page))
+
+    def test_the_ordering_is_the_activity_time_and_not_the_directory_walk(self):
+        # Two directories interleave in the expected order, so an index that
+        # grouped by directory could not produce it.
+        drawn = session_ids(self.sessions())
+        projects = [SESSION_PROJECT[session] for session in drawn]
+
+        self.assertNotEqual(sorted(projects), projects)
+
+    def test_each_row_carries_its_last_activity_stamp(self):
+        page = self.sessions()
+
+        for session in SESSIONS_NEWEST_FIRST:
+            self.assertIn(session_stamp(session), session_cell(page, session, "when"))
+
+    def test_a_worktree_state_record_supplies_the_working_directory(self):
+        page = self.sessions()
+
+        self.assertIn(
+            "/Users/dmcinerney/tools/alpha", session_cell(page, TITLED_SESSION, "cwd")
+        )
+        self.assertIn(ui.CWD_FROM_RECORD, session_cell(page, TITLED_SESSION, "cwd"))
+
+    def test_the_worktree_path_wins_over_the_directory_it_was_opened_from(self):
+        self.assertIn(
+            "/Users/dmcinerney/tools/beta-repo/.claude/worktrees/wt-one",
+            session_cell(self.sessions(), TRUNCATED_SESSION, "cwd"),
+        )
+
+    def test_a_session_with_no_record_decodes_the_directory_name(self):
+        cell = session_cell(self.sessions(), UNTITLED_SESSION, "cwd")
+
+        self.assertIn("/Users/dmcinerney/tools/alpha", cell)
+        self.assertIn(ui.CWD_FROM_NAME, cell)
+
+    def test_the_decode_is_named_as_a_guess_where_it_provably_is_one(self):
+        # Both sessions sit in `-Users-dmcinerney-tools-beta-repo`. The
+        # record says `/Users/dmcinerney/tools/beta-repo`; the name decodes
+        # to `/Users/dmcinerney/tools/beta/repo`, because a `-` already in a
+        # directory name is indistinguishable from an encoded separator.
+        page = self.sessions()
+        recorded = session_cell(page, MARKUP_SESSION, "cwd")
+        guessed = session_cell(page, MALFORMED_SESSION, "cwd")
+
+        self.assertIn("/Users/dmcinerney/tools/beta-repo", recorded)
+        self.assertIn(ui.CWD_FROM_RECORD, recorded)
+        self.assertIn("/Users/dmcinerney/tools/beta/repo", guessed)
+        self.assertIn(ui.CWD_FROM_NAME, guessed)
+
+    def test_a_directory_name_that_is_not_a_path_is_a_named_diagnostic(self):
+        page = self.sessions()
+
+        self.assertIn(ui.DIAGNOSTIC_UNDECODABLE_SLUG, block_for(page, "diagnostics", "</ul>"))
+        self.assertIn(UNDECODABLE_PROJECT, block_for(page, "diagnostics", "</ul>"))
+        self.assertIn(ui.EMPTY_NO_CWD, session_cell(page, EMPTY_SESSION, "cwd"))
+
+    def test_each_row_carries_its_subagent_count(self):
+        page = self.sessions()
+
+        self.assertIn("3", session_cell(page, TITLED_SESSION, "agents"))
+        self.assertIn("0", session_cell(page, UNTITLED_SESSION, "agents"))
+
+    def test_a_subagent_transcript_is_not_itself_a_session(self):
+        self.assertNotIn("agent-aa11", session_ids(self.sessions()))
+
+    def test_the_run_index_offers_the_session_index(self):
+        page = ui.render_route(self.main, "/")[1]
+
+        self.assertIn('href="{0}"'.format(ui.SESSIONS_ROUTE), page)
+
+
+class TestSessionLabel(TranscriptCase):
+    """`S1` completion test 4, spec criterion 7."""
+
+    def test_the_label_is_the_last_ai_title_record(self):
+        page = self.sessions()
+
+        self.assertIn(LAST_AI_TITLE, session_cell(page, TITLED_SESSION, "title"))
+        self.assertNotIn(SUPERSEDED_AI_TITLE, page)
+
+    def test_a_session_with_no_ai_title_renders_a_named_fallback(self):
+        cell = session_cell(self.sessions(), UNTITLED_SESSION, "title")
+
+        self.assertIn(ui.EMPTY_NO_TITLE, cell)
+
+    def test_a_title_carrying_markup_reaches_the_page_escaped(self):
+        cell = session_cell(self.sessions(), MARKUP_SESSION, "title")
+
+        self.assertIn(html.escape(PAYLOAD), cell)
+        self.assertNotIn(PAYLOAD, cell)
+
+
+class TestContentWall(TranscriptCase):
+    """`S1` completion test 5, spec criterion 10. A transcript holds the
+    operator's prompts, file contents and command output for every project
+    on the machine. The renderable set is closed and this is its guard."""
+
+    def carriers(self) -> list:
+        return [
+            path
+            for path in sorted(self.transcripts.rglob("*"))
+            if path.is_file()
+            and TRANSCRIPT_SENTINEL in path.read_text(encoding="utf-8", errors="replace")
+        ]
+
+    def test_the_fixture_really_carries_the_sentinel(self):
+        # Without this the sweep below passes over a corpus that never had
+        # anything to leak.
+        carriers = self.carriers()
+
+        self.assertGreaterEqual(len(carriers), 6)
+        self.assertIn(
+            "agent-aa11.jsonl", [path.name for path in carriers]
+        )
+
+    def test_the_sentinel_reaches_no_route(self):
+        with serving(self.main, self.transcripts) as server:
+            for route in every_route():
+                status, page = get(server, route)
+
+                self.assertIn(status, (200, 404), route)
+                self.assertNotIn(TRANSCRIPT_SENTINEL, page, route)
+
+    def test_the_sweep_still_renders_what_it_is_allowed_to(self):
+        # The sweep above would also pass on a page that rendered nothing.
+        page = self.sessions()
+
+        self.assertIn(LAST_AI_TITLE, session_cell(page, TITLED_SESSION, "title"))
+        self.assertEqual(len(SESSIONS_NEWEST_FIRST), len(session_ids(page)))
+
+    def test_the_index_emits_only_the_fields_the_spec_admits(self):
+        # Named here so widening the row is a decision rather than a slip.
+        self.assertEqual(
+            ("sid", "title", "cwd", "when", "size", "agents", "notes"),
+            ui.SESSION_COLUMNS,
+        )
+        self.assertEqual(len(ui.SESSION_COLUMNS), len(ui.SESSION_HEADINGS))
+
+    def test_the_rendered_row_carries_exactly_the_closed_set(self):
+        # The tuple above is only a wall if the page is built from it. An
+        # eighth cell written beside it renders a transcript field the spec
+        # does not admit, and the tuple still reads as correct.
+        page = self.sessions()
+
+        for session in SESSIONS_NEWEST_FIRST:
+            self.assertEqual(
+                list(ui.SESSION_COLUMNS), row_columns(page, session), session
+            )
+
+    def test_narrowing_the_closed_set_narrows_the_row_it_renders(self):
+        # Proves the row derives from the tuple rather than merely agreeing
+        # with it: a row spelled out in a format string is unmoved by this.
+        with patch.object(ui, "SESSION_COLUMNS", ("sid", "title")):
+            page = self.sessions()
+
+        self.assertEqual(["sid", "title"], row_columns(page, TITLED_SESSION))
+
+
+class TestTranscriptsAreReadOnly(TranscriptCase):
+    """`S1` completion test 6, spec criterion 11."""
+
+    def test_exercising_every_route_writes_nothing_under_the_transcript_root(self):
+        before = snapshot(self.transcripts)
+        self.assertTrue(before)
+
+        with serving(self.main, self.transcripts) as server:
+            for route in every_route():
+                status, page = get(server, route)
+                self.assertIn(status, (200, 404), route)
+                self.assertTrue(page, route)
+
+        self.assertEqual(before, snapshot(self.transcripts))
+
+    def test_the_snapshot_would_notice_a_write(self):
+        before = snapshot(self.transcripts)
+        (self.transcripts / ALPHA_PROJECT / "intruder.jsonl").write_text(
+            "{}\n", encoding="utf-8"
+        )
+
+        self.assertNotEqual(before, snapshot(self.transcripts))
+
+
+class TestTranscriptDegradation(TranscriptCase):
+    """`S1` completion test 7, spec criterion 12. The layout is another
+    program's undocumented implementation detail: it must degrade visibly,
+    never silently and never by raising."""
+
+    def notes(self, session: str) -> str:
+        return session_cell(self.sessions(), session, "notes")
+
+    def test_a_malformed_transcript_names_its_unreadable_lines_and_still_lists(self):
+        notes = self.notes(MALFORMED_SESSION)
+
+        self.assertIn(ui.DIAGNOSTIC_UNREADABLE_LINES, notes)
+        self.assertIn(MALFORMED_SESSION, session_ids(self.sessions()))
+
+    def test_a_truncated_transcript_names_its_unreadable_line(self):
+        self.assertIn(ui.DIAGNOSTIC_UNREADABLE_LINES, self.notes(TRUNCATED_SESSION))
+
+    def test_a_truncated_transcript_still_yields_the_records_before_the_cut(self):
+        page = self.sessions()
+
+        self.assertIn(
+            "Worktree session, cut short", session_cell(page, TRUNCATED_SESSION, "title")
+        )
+
+    def test_an_empty_transcript_names_a_diagnostic_rather_than_looking_healthy(self):
+        notes = self.notes(EMPTY_SESSION)
+
+        self.assertIn(ui.DIAGNOSTIC_NO_RECORDS, notes)
+
+    def test_a_healthy_transcript_carries_no_diagnostic_at_all(self):
+        # Otherwise every assertion above is satisfied by a page that warns
+        # about everything.
+        self.assertEqual("", self.notes(TITLED_SESSION).strip())
+
+    def test_a_session_with_no_subagents_directory_still_lists(self):
+        page = self.sessions()
+
+        self.assertFalse((self.transcripts / ALPHA_PROJECT / UNTITLED_SESSION).exists())
+        self.assertIn(UNTITLED_SESSION, session_ids(page))
+        self.assertIn("0", session_cell(page, UNTITLED_SESSION, "agents"))
+
+    def test_a_transcript_that_cannot_be_opened_is_named_rather_than_raised(self):
+        with patch.object(Path, "open", side_effect=OSError("gone")):
+            page = self.sessions()
+
+        self.assertEqual(len(SESSIONS_NEWEST_FIRST), len(session_ids(page)))
+        self.assertIn(
+            ui.DIAGNOSTIC_UNREADABLE_TRANSCRIPT, session_cell(page, TITLED_SESSION, "notes")
+        )
+
+    def test_a_record_of_the_wrong_shape_is_dropped_rather_than_believed(self):
+        path = self.transcripts / ALPHA_PROJECT / (TITLED_SESSION + ".jsonl")
+        path.write_text(
+            '{"type":"ai-title","aiTitle":["not","a","string"]}\n'
+            '{"type":"worktree-state","worktreeSession":"not an object"}\n',
+            encoding="utf-8",
+        )
+        cell = session_cell(self.sessions(), TITLED_SESSION, "title")
+
+        self.assertIn(ui.EMPTY_NO_TITLE, cell)
+
+
+class TestTranscriptParseCache(TranscriptCase):
+    """`S1` completion test 8, spec criterion 13. A transcript is megabytes
+    of conversation and the poll asks for the page every second."""
+
+    def counted(self):
+        seen = []
+        real = ui._transcript_summary
+
+        def counting(path):
+            seen.append(str(path))
+            return real(path)
+
+        return seen, counting
+
+    def test_two_requests_over_an_unchanged_root_parse_each_session_once(self):
+        seen, counting = self.counted()
+
+        with patch.object(ui, "_transcript_summary", counting):
+            first = self.sessions()
+            second = self.sessions()
+
+        self.assertEqual(first, second)
+        self.assertEqual(sorted(set(seen)), sorted(seen))
+        self.assertEqual(len(SESSIONS_NEWEST_FIRST), len(seen))
+
+    def test_a_changed_transcript_is_parsed_again(self):
+        # A cache with no invalidation would satisfy the count above and
+        # serve a label the transcript no longer carries.
+        path = self.transcripts / ALPHA_PROJECT / (TITLED_SESSION + ".jsonl")
+        self.sessions()
+        path.write_text(
+            '{"type":"ai-title","aiTitle":"Alpha, renamed"}\n', encoding="utf-8"
+        )
+        seen, counting = self.counted()
+
+        with patch.object(ui, "_transcript_summary", counting):
+            page = self.sessions()
+
+        self.assertEqual([str(path)], seen)
+        self.assertIn("Alpha, renamed", session_cell(page, TITLED_SESSION, "title"))
+
+    def test_the_cache_is_bounded_so_a_long_lived_viewer_cannot_grow_forever(self):
+        for index in range(ui.TRANSCRIPT_CACHE_LIMIT + 10):
+            ui.cached_transcript(Path("/nowhere"), ("/nowhere", index, index))
+
+        self.assertLessEqual(len(ui.TRANSCRIPT_CACHE), ui.TRANSCRIPT_CACHE_LIMIT)
+
+
+class TestTranscriptValidatorBasis(TranscriptCase):
+    """`U3`'s lesson, applied to the tree this ticket adds. A validator whose
+    basis is narrower than the route's read set answers 304 to a page that
+    has already moved, and a 304 is indistinguishable from nothing having
+    happened. `S2` owns the `/session` tag end to end; what is held here is
+    the narrower claim that the transcript root is inside the basis at all."""
+
+    def digest(self, transcripts=True) -> str:
+        root = self.transcripts if transcripts is True else transcripts
+        with frozen_clock():
+            return ui.state_digest(self.main, None, root)
+
+    def test_a_transcript_that_changes_moves_the_validator(self):
+        before = self.digest()
+        (self.transcripts / ALPHA_PROJECT / (TITLED_SESSION + ".jsonl")).write_text(
+            '{"type":"ai-title","aiTitle":"Alpha, renamed"}\n', encoding="utf-8"
+        )
+
+        self.assertNotEqual(before, self.digest())
+
+    def test_a_session_appearing_moves_the_validator(self):
+        before = self.digest()
+        (self.transcripts / ALPHA_PROJECT / "77777777-7777-4777-8777-777777777777.jsonl").write_text(
+            '{"type":"ai-title","aiTitle":"newly opened"}\n', encoding="utf-8"
+        )
+
+        self.assertNotEqual(before, self.digest())
+
+    def test_a_subagent_appearing_moves_the_validator(self):
+        # The count is on the page, so the metadata beside the transcript is
+        # part of the read set even though no line of it is ever rendered.
+        before = self.digest()
+        (self.transcripts / ALPHA_PROJECT / TITLED_SESSION / "subagents" / "agent-aa14.meta.json").write_text(
+            '{"agentType":"orch-worker","spawnDepth":1}\n', encoding="utf-8"
+        )
+
+        self.assertNotEqual(before, self.digest())
+
+    def test_an_unchanged_root_holds_the_validator_still(self):
+        # Otherwise the 304 is unreachable and the poll re-renders forever.
+        self.assertEqual(self.digest(), self.digest())
+
+    def test_the_orch_root_alone_no_longer_determines_the_tag(self):
+        bare = self.tmp / "bare"
+        bare.mkdir()
+
+        self.assertNotEqual(self.digest(), self.digest(bare))
+        self.assertNotEqual(self.digest(bare), self.digest(None))
+
+    def test_a_root_that_appears_moves_the_validator(self):
+        # Three pages with no file between them: no root configured, a root
+        # that is not there yet, and a root holding nothing. A viewer opened
+        # before Claude Code first ran sits on the middle one.
+        absent = self.tmp / "not-yet"
+        before = self.digest(absent)
+        absent.mkdir()
+
+        self.assertNotEqual(before, self.digest(absent))
+
+    def test_a_reader_with_no_transcript_root_reads_no_tree_for_its_tag(self):
+        # The unconfigured case contributes that it is unconfigured and
+        # nothing else -- there is no path it could have walked.
+        self.assertEqual((("transcripts", 0, ""),), ui.transcript_state(None))
+
+    # Every route that renders no transcript at all. On a host with a live
+    # Claude Code session -- the normal case, and the case this viewer is
+    # opened for -- the transcript root is rewritten every second.
+    ORCH_ONLY = ("/", ui.FRICTION_ROUTE, graph_url("run-gamma"), detail_url("run-gamma", "G1"))
+
+    def rename_a_transcript(self):
+        (self.transcripts / ALPHA_PROJECT / (TITLED_SESSION + ".jsonl")).write_text(
+            '{"type":"ai-title","aiTitle":"Alpha, renamed"}\n', encoding="utf-8"
+        )
+
+    def tags(self, routes) -> dict:
+        return dict(
+            (route, ui.entity_tag(self.main, route, None, self.transcripts))
+            for route in routes
+        )
+
+    def bodies(self, routes) -> dict:
+        return dict(
+            (route, ui.render_route(self.main, route, self.transcripts)[1])
+            for route in routes
+        )
+
+    def test_a_route_that_renders_no_transcript_holds_its_tag_across_a_write(self):
+        # The basis is the route's read set, which is `U3`'s lesson in both
+        # directions: too narrow serves a 304 to a page that moved, and too
+        # wide denies the 304 to a page that did not. Too wide is what a
+        # live session makes permanent -- the poll then swaps `main` once a
+        # second over a byte-identical body, churning scroll and focus.
+        with frozen_clock():
+            before, drawn = self.tags(self.ORCH_ONLY), self.bodies(self.ORCH_ONLY)
+            self.rename_a_transcript()
+
+            self.assertEqual(before, self.tags(self.ORCH_ONLY))
+            self.assertEqual(drawn, self.bodies(self.ORCH_ONLY))
+
+    def test_the_session_routes_still_see_the_write_the_others_ignore(self):
+        # Otherwise the narrowing above is satisfied by a validator that
+        # observes the transcript tree nowhere at all.
+        polled = (ui.SESSIONS_ROUTE, session_url(TITLED_SESSION))
+        with frozen_clock():
+            before = self.tags(polled)
+            self.rename_a_transcript()
+            after = self.tags(polled)
+
+        for route in polled:
+            self.assertNotEqual(before[route], after[route], route)
+
+    def test_an_orch_page_is_answered_304_while_a_session_writes(self):
+        with frozen_clock():
+            with serving(self.main, self.transcripts) as server:
+                status, headers, _body = fetch(server, ui.FRICTION_ROUTE)
+                self.assertEqual(200, status)
+                held = {"If-None-Match": headers["ETag"]}
+                self.rename_a_transcript()
+                status, _headers, body = fetch(server, ui.FRICTION_ROUTE, held)
+
+        self.assertEqual(304, status)
+        self.assertEqual("", body)
+
+    def test_the_poll_is_not_answered_304_after_a_transcript_moves(self):
+        with serving(self.main, self.transcripts) as server:
+            status, headers, _body = fetch(server, ui.SESSIONS_ROUTE)
+            self.assertEqual(200, status)
+            tag = headers["ETag"]
+            held = {"If-None-Match": tag}
+            self.assertEqual(304, fetch(server, ui.SESSIONS_ROUTE, held)[0])
+
+            (self.transcripts / ALPHA_PROJECT / (TITLED_SESSION + ".jsonl")).write_text(
+                '{"type":"ai-title","aiTitle":"Alpha, renamed"}\n', encoding="utf-8"
+            )
+
+            status, _headers, body = fetch(server, ui.SESSIONS_ROUTE, held)
+
+        self.assertEqual(200, status)
+        self.assertIn("Alpha, renamed", session_cell(body, TITLED_SESSION, "title"))
+
+
+class TestAbsentTranscriptRoot(TranscriptCase):
+    """`S1` completion test 9, spec criterion 16."""
+
+    def missing(self) -> Path:
+        absent = self.tmp / "no-transcripts-here"
+        self.assertFalse(absent.exists())
+        return absent
+
+    def test_every_pre_existing_route_still_answers(self):
+        with serving(self.main, self.missing()) as server:
+            served = {}
+            for route in every_route():
+                served[route] = get(server, route)
+
+        self.assertEqual({200, 404}, set(status for status, _ in served.values()))
+        self.assertIn(SETTLED_RUN, served["/"][1])
+
+    def test_the_session_index_names_an_empty_state(self):
+        page = self.sessions(self.missing())
+
+        self.assertIn(ui.EMPTY_NO_TRANSCRIPTS, block_for(page, "empty", "</p>"))
+        self.assertEqual([], session_ids(page))
+
+    def test_a_present_but_sessionless_root_is_a_different_empty_state(self):
+        bare = self.tmp / "bare"
+        bare.mkdir()
+
+        page = self.sessions(bare)
+
+        self.assertIn(ui.EMPTY_NO_SESSIONS, block_for(page, "empty", "</p>"))
+
+
+class TestTranscriptContainment(TranscriptCase):
+    """`_in_tree`'s guarantee, over the tree it was not yet applied to.
+
+    The transcript root is the entire scope of what this viewer may open, and
+    `~/.claude/projects` is a directory anything on the machine can be linked
+    into. `_subagent_files` already checks containment; the project walk one
+    level above it is the same question about the same tree.
+    """
+
+    LEAKED_TITLE = "LEAKED-TITLE"
+
+    def link_out(self, name: str = "-Users-dmcinerney-tools-leaked") -> Path:
+        """A project-shaped symlink under the root, pointing out of it."""
+
+        outside = self.tmp / "outside"
+        outside.mkdir()
+        (outside / "1e6f0000-0000-4000-8000-00000000beef.jsonl").write_text(
+            '{"type":"ai-title","aiTitle":"%s"}\n' % self.LEAKED_TITLE,
+            encoding="utf-8",
+        )
+        link = self.transcripts / name
+        try:
+            link.symlink_to(outside, target_is_directory=True)
+        except (OSError, NotImplementedError) as error:
+            # Windows only permits this under Developer Mode or admin.
+            self.skipTest("cannot create a directory symlink here: %s" % error)
+        return link
+
+    def test_the_link_is_an_entry_the_walk_would_otherwise_take(self):
+        # The premise. Without it the two cases below are proved by a link
+        # `iterdir` never returned or `is_dir` already rejected.
+        link = self.link_out()
+
+        self.assertIn(link, list(self.transcripts.iterdir()))
+        self.assertTrue(link.is_dir())
+
+    def test_a_project_linked_out_of_the_root_is_not_a_project(self):
+        link = self.link_out()
+
+        self.assertNotIn(link, ui._project_directories(self.transcripts))
+        # Not by returning nothing: the real projects are still walked.
+        self.assertEqual(
+            sorted(set(SESSION_PROJECT.values())),
+            sorted(path.name for path in ui._project_directories(self.transcripts)),
+        )
+
+    def test_nothing_outside_the_root_reaches_any_route(self):
+        self.link_out()
+
+        with serving(self.main, self.transcripts) as server:
+            for route in every_route():
+                self.assertNotIn(self.LEAKED_TITLE, get(server, route)[1], route)
+
+        self.assertEqual(list(SESSIONS_NEWEST_FIRST), session_ids(self.sessions()))
+
+
+class TestUnaddressableSessions(TranscriptCase):
+    """A row is a promise that the link on it opens.
+
+    `/session` takes its id in a query string and `_safe_name` is the
+    boundary that query crosses, so a filename the walk finds and the
+    boundary refuses cannot be both listed and linked: the reader clicks it
+    and is told there is no such session, about a file this page just drew.
+    """
+
+    # `Path("..jsonl").stem` is `"."`, which `_safe_name` refuses outright.
+    # An ordinary filename on every filesystem this suite runs on, Windows
+    # included -- not a traversal, and not a control character Windows
+    # forbids.
+    UNADDRESSABLE = "..jsonl"
+
+    def plant(self) -> Path:
+        path = self.transcripts / ALPHA_PROJECT / self.UNADDRESSABLE
+        path.write_text('{"type":"ai-title","aiTitle":"Nameless"}\n', encoding="utf-8")
+        return path
+
+    def test_the_walk_finds_it_and_the_lookup_boundary_refuses_it(self):
+        # The premise, on both sides. Without it the cases below are proved
+        # by a file the glob never returned or a name the boundary allows.
+        path = self.plant()
+
+        self.assertIn(path, list((self.transcripts / ALPHA_PROJECT).glob("*.jsonl")))
+        self.assertEqual("", ui._safe_name(path.stem))
+        self.assertIsNone(ui.find_session(self.transcripts, path.stem))
+
+    def test_a_session_that_cannot_be_opened_is_not_offered_as_a_link(self):
+        self.plant()
+
+        self.assertEqual(list(SESSIONS_NEWEST_FIRST), session_ids(self.sessions()))
+
+    def test_the_page_says_why_rather_than_dropping_it_in_silence(self):
+        self.plant()
+        notes = block_for(self.sessions(), "diagnostics", "</ul>")
+
+        self.assertIn(ui.DIAGNOSTIC_UNADDRESSABLE_SESSION, notes)
+        self.assertIn(self.UNADDRESSABLE, notes)
+
+    def test_a_healthy_root_carries_no_such_diagnostic(self):
+        # Otherwise the case above is satisfied by a page that warns about
+        # every session it lists.
+        self.assertNotIn(
+            ui.DIAGNOSTIC_UNADDRESSABLE_SESSION,
+            block_for(self.sessions(), "diagnostics", "</ul>"),
+        )
+
+    def test_the_validator_moves_when_such_a_file_appears(self):
+        # The diagnostic is part of the page, so a basis blind to the file
+        # behind it serves a 304 to a page that has moved -- `U3` again. No
+        # directory is stat'd by this walk, so nothing else here would notice.
+        with frozen_clock():
+            before = ui.entity_tag(self.main, ui.SESSIONS_ROUTE, None, self.transcripts)
+            self.plant()
+            after = ui.entity_tag(self.main, ui.SESSIONS_ROUTE, None, self.transcripts)
+
+        self.assertNotEqual(before, after)
+
+
+class TestSessionRouteRegistration(TranscriptCase):
+    """`S1` completion test 10. `U1`'s tuple is what makes the read-only,
+    no-network and escaping guards sweep a route at all."""
+
+    def test_the_route_is_declared_and_carries_concrete_examples(self):
+        self.assertIn(ui.SESSIONS_ROUTE, ui.ROUTES)
+        self.assertTrue(ROUTE_EXAMPLES[ui.SESSIONS_ROUTE])
+        self.assertIn(ui.SESSIONS_ROUTE, every_route())
+
+    def test_the_route_is_not_branched_in_behind_the_tuple(self):
+        # A route served but undeclared is a route no whole-corpus guard
+        # visits, which is the failure `U1` recorded against itself.
+        status, page = ui.render_route(self.main, ui.SESSIONS_ROUTE, self.transcripts)
+
+        self.assertEqual(200, status)
+        self.assertIn(ui.SESSIONS_ROUTE, ui.ROUTES)
+
+
+class SessionCase(TranscriptCase):
+    """One session's flowchart, fetched through the route rather than built
+    from the renderer, so every assertion below is about a served page."""
+
+    def flowchart(self, session=TITLED_SESSION, transcripts=True) -> str:
+        root = self.transcripts if transcripts is True else transcripts
+        status, page = ui.render_route(self.main, session_url(session), root)
+        self.assertEqual(200, status)
+        return page
+
+    def read(self, session=TITLED_SESSION) -> dict:
+        found = ui.find_session(self.transcripts, session)
+        self.assertIsNotNone(found, session)
+        return ui.read_session(found)
+
+    def graph(self, session=TITLED_SESSION) -> tuple:
+        return ui.session_graph(self.read(session)["agents"])
+
+    def subagents(self, session: str) -> Path:
+        return self.transcripts / SESSION_PROJECT[session] / session / "subagents"
+
+
+class TestSessionRoute(SessionCase):
+    """`S2` completion test 9. `U1`'s tuple is what makes the read-only,
+    no-network, escaping and conditional-request guards sweep a route."""
+
+    def test_the_route_is_declared_and_carries_concrete_examples(self):
+        self.assertIn(ui.SESSION_ROUTE, ui.ROUTES)
+        self.assertTrue(ROUTE_EXAMPLES[ui.SESSION_ROUTE])
+        for url in ROUTE_EXAMPLES[ui.SESSION_ROUTE]:
+            self.assertIn(url, every_route(), url)
+
+    def test_the_examples_reach_a_drawn_flowchart_and_not_only_its_errors(self):
+        served = [
+            ui.render_route(self.main, url, self.transcripts)[0]
+            for url in ROUTE_EXAMPLES[ui.SESSION_ROUTE]
+        ]
+
+        self.assertIn(200, served)
+        self.assertIn(404, served)
+
+    def test_the_session_index_links_each_row_to_its_own_flowchart(self):
+        # `S1` left the id unlinked deliberately: there was nowhere to go.
+        page = self.sessions()
+
+        self.assertIn('href="/session?id={0}"'.format(TITLED_SESSION), page)
+        self.assertEqual(list(SESSIONS_NEWEST_FIRST), session_ids(page))
+
+
+class TestSessionFlowchart(SessionCase):
+    """`S2` completion test 2, spec criterion 8."""
+
+    def test_one_node_for_the_orchestrator_and_one_for_each_subagent(self):
+        drawn = session_anchors(self.flowchart())
+
+        self.assertEqual(
+            sorted(ALPHA_AGENTS + (ui.ORCHESTRATOR_ANCHOR,)), sorted(drawn)
+        )
+
+    def test_the_node_set_is_the_metadata_files_and_not_the_agent_transcripts(self):
+        # `agent-aa11.jsonl` sits beside `agent-aa11.meta.json`; two files
+        # about one subagent must not draw two nodes.
+        subagents = self.transcripts / ALPHA_PROJECT / TITLED_SESSION / "subagents"
+        drawn = session_anchors(self.flowchart())
+
+        self.assertEqual(4, len(list(subagents.glob("agent-*"))))
+        self.assertEqual(len(set(drawn)), len(drawn))
+        self.assertEqual(1 + len(ALPHA_AGENTS), len(drawn))
+
+    def test_each_node_carries_its_type_description_and_depth(self):
+        page = self.flowchart()
+
+        self.assertIn("orch-worker", session_cell(page, RETURNED_AGENT, "type"))
+        self.assertIn(
+            "Implement the session index",
+            session_cell(page, RETURNED_AGENT, "description"),
+        )
+        self.assertIn("1", session_cell(page, RETURNED_AGENT, "depth"))
+        self.assertIn("2", session_cell(page, UNEVIDENCED_AGENT, "depth"))
+        self.assertIn("Explore", session_cell(page, UNEVIDENCED_AGENT, "type"))
+
+    def test_the_drawn_node_names_the_agent_rather_than_only_its_row(self):
+        # A table under an anonymous picture is not a flowchart of anything.
+        node = session_node(self.flowchart(), RETURNED_AGENT)
+
+        self.assertIn("orch-worker", node["body"])
+        self.assertIn("orch-worker", node["label"])
+        self.assertIn("Implement the session index", node["label"])
+
+    def test_the_orchestrator_node_names_itself_and_what_it_spawned(self):
+        node = session_node(self.flowchart(), ui.ORCHESTRATOR_ANCHOR)
+
+        self.assertIn("orchestrator", node["body"])
+        self.assertIn("3", node["body"])
+        self.assertIn(LAST_AI_TITLE, node["label"])
+
+    def test_every_depth_one_agent_is_drawn_from_the_orchestrator(self):
+        nodes, edges, _inferred = self.graph()
+
+        self.assertIn(ui.ORCHESTRATOR_NODE, nodes)
+        self.assertIn((ui.ORCHESTRATOR_NODE, RETURNED_AGENT), edges)
+        self.assertIn((ui.ORCHESTRATOR_NODE, CALLED_AGENT), edges)
+        self.assertEqual(len(nodes) - 1, len(edges))
+
+    def test_the_page_names_the_session_it_drew(self):
+        page = self.flowchart()
+
+        self.assertIn(TITLED_SESSION, page)
+        self.assertIn(LAST_AI_TITLE, page)
+        self.assertIn("/Users/dmcinerney/tools/alpha", page)
+
+
+class TestSubagentEdges(SessionCase):
+    """`S2` completion test 3. Most subagent metadata records no parent at
+    all, so most of this tree is a guess -- and a guess drawn like a fact is
+    the one failure a flowchart of somebody else's process can commit."""
+
+    def test_a_depth_two_agent_with_no_recorded_parent_hangs_off_the_root(self):
+        # There is nowhere else to hang it: depth says a parent exists and
+        # nothing says which agent it is.
+        _nodes, edges, inferred = self.graph()
+
+        self.assertIn((ui.ORCHESTRATOR_NODE, UNEVIDENCED_AGENT), edges)
+        self.assertEqual(((ui.ORCHESTRATOR_NODE, UNEVIDENCED_AGENT),), tuple(inferred))
+
+    def test_that_edge_is_dashed_and_the_page_says_what_a_dashed_edge_means(self):
+        page = self.flowchart()
+
+        self.assertEqual(1, len(INFERRED_EDGE_RE.findall(page)))
+        self.assertEqual(len(ALPHA_AGENTS), len(EDGE_RE.findall(page)))
+        self.assertIn(
+            ui.DIAGNOSTIC_INFERRED_EDGE, block_for(page, "diagnostics", "</ul>")
+        )
+
+    def test_each_row_names_what_its_agent_hangs_off_and_how_that_was_known(self):
+        page = self.flowchart()
+        proven = session_cell(page, RETURNED_AGENT, "attached")
+        guessed = session_cell(page, UNEVIDENCED_AGENT, "attached")
+
+        self.assertIn(ui.EDGE_FROM_DEPTH, proven)
+        self.assertNotIn(ui.EDGE_INFERRED, proven)
+        self.assertIn(ui.EDGE_INFERRED, guessed)
+
+    def test_an_unprovable_depth_two_agent_still_says_it_is_at_depth_two(self):
+        # It cannot be nested under anything: nothing records what. Its
+        # depth is on the node's own face as well as on its row, so the
+        # picture does not read as three siblings of equal standing.
+        page = self.flowchart()
+
+        self.assertIn("d2", session_node(page, UNEVIDENCED_AGENT)["body"])
+        self.assertIn("depth 2", session_node(page, UNEVIDENCED_AGENT)["label"])
+        self.assertIn("2", session_cell(page, UNEVIDENCED_AGENT, "depth"))
+
+    def test_a_recorded_parent_attaches_the_child_to_that_agent_as_a_fact(self):
+        _nodes, edges, inferred = self.graph(TRUNCATED_SESSION)
+
+        self.assertIn((ui.ORCHESTRATOR_NODE, PARENT_AGENT), edges)
+        self.assertIn((PARENT_AGENT, CHILD_AGENT), edges)
+        self.assertNotIn((ui.ORCHESTRATOR_NODE, CHILD_AGENT), edges)
+        self.assertEqual((), tuple(inferred))
+
+    def test_the_recorded_child_is_drawn_a_layer_below_its_own_parent(self):
+        # Nesting is the picture, not the prose: a child drawn beside its
+        # parent is not nested however its row reads.
+        nodes, edges, _inferred = self.graph(TRUNCATED_SESSION)
+        layers = dict(
+            (node.id, node.layer) for node in ui.cached_layout(nodes, edges)["nodes"]
+        )
+
+        self.assertEqual(0, layers[ui.ORCHESTRATOR_NODE])
+        self.assertEqual(1, layers[PARENT_AGENT])
+        self.assertEqual(2, layers[CHILD_AGENT])
+
+    def test_a_parent_pointer_naming_nobody_falls_back_to_an_inferred_edge(self):
+        # The pointer's spelling is undocumented and observed, never
+        # promised: one that resolves to no sibling is not a node.
+        meta = self.subagents(TRUNCATED_SESSION) / (CHILD_AGENT + ".meta.json")
+        meta.write_text(
+            '{"agentType":"Explore","spawnDepth":2,"parentAgentId":"nobody"}',
+            encoding="utf-8",
+        )
+        _nodes, edges, inferred = self.graph(TRUNCATED_SESSION)
+
+        self.assertIn((ui.ORCHESTRATOR_NODE, CHILD_AGENT), edges)
+        self.assertEqual(((ui.ORCHESTRATOR_NODE, CHILD_AGENT),), tuple(inferred))
+
+    # The three shapes a recorded `parentAgentId` takes that resolve to no
+    # node on the page: a stranger, the agent itself, and the orchestrator,
+    # which no subagent's metadata is allowed to name.
+    UNRESOLVED_PARENTS = (
+        ("a stranger", "nobody"),
+        ("its own agent", "cc32"),
+        ("the orchestrator", ui.ORCHESTRATOR_NODE),
+    )
+
+    def unresolved(self, recorded: str, depth: int = 2) -> str:
+        """`TRUNCATED_SESSION`'s child, rewritten to record a parent that
+        resolves to nothing, and its flowchart."""
+
+        meta = self.subagents(TRUNCATED_SESSION) / (CHILD_AGENT + ".meta.json")
+        meta.write_text(
+            json.dumps(
+                {"agentType": "Explore", "spawnDepth": depth, "parentAgentId": recorded}
+            ),
+            encoding="utf-8",
+        )
+        return self.flowchart(TRUNCATED_SESSION)
+
+    def test_a_recorded_parent_that_did_not_resolve_is_not_called_an_absent_one(self):
+        # `inferred: no parent recorded` states two things about another
+        # program's data and both are false here: a parent *was* recorded,
+        # and it failed to resolve. The edge shape is the same for either;
+        # the sentence is not, and the sentence is what a reader acts on.
+        for shape, recorded in self.UNRESOLVED_PARENTS:
+            cell = session_cell(self.unresolved(recorded), CHILD_AGENT, "attached")
+
+            self.assertIn(ui.EDGE_PARENT_UNRESOLVED, cell, shape)
+            self.assertNotIn(ui.EDGE_INFERRED, cell, shape)
+
+    def test_the_page_names_which_of_the_two_guesses_it_made(self):
+        for shape, recorded in self.UNRESOLVED_PARENTS:
+            notes = block_for(self.unresolved(recorded), "diagnostics", "</ul>")
+
+            self.assertIn(ui.DIAGNOSTIC_UNRESOLVED_PARENT, notes, shape)
+            self.assertNotIn(ui.DIAGNOSTIC_INFERRED_EDGE, notes, shape)
+
+    def test_the_sentence_does_not_contradict_the_depth_it_is_drawn_at(self):
+        # A depth-3 record drawn on the orchestrator is not drawn "by its
+        # spawn depth alone": its own depth says two agents stand between
+        # the two, and the page must not say otherwise in the same breath.
+        page = self.unresolved("nobody", depth=3)
+
+        self.assertNotIn("spawn depth alone", page)
+        self.assertIn("3", session_cell(page, CHILD_AGENT, "depth"))
+        self.assertIn(
+            ui.DIAGNOSTIC_UNRESOLVED_PARENT, block_for(page, "diagnostics", "</ul>")
+        )
+
+    def test_a_record_that_truly_names_no_parent_still_says_exactly_that(self):
+        # Otherwise the distinction above is bought by renaming the honest
+        # case rather than by naming the case that was missing.
+        page = self.flowchart()
+        cell = session_cell(page, UNEVIDENCED_AGENT, "attached")
+        notes = block_for(page, "diagnostics", "</ul>")
+
+        self.assertIn(ui.EDGE_INFERRED, cell)
+        self.assertNotIn(ui.EDGE_PARENT_UNRESOLVED, cell)
+        self.assertIn(ui.DIAGNOSTIC_INFERRED_EDGE, notes)
+        self.assertNotIn(ui.DIAGNOSTIC_UNRESOLVED_PARENT, notes)
+
+    def test_a_depth_one_agent_hangs_off_the_orchestrator_whatever_it_records(self):
+        # Spec criterion 8 is unconditional. Depth 1 means the session
+        # spawned it and nothing else could have, so a pointer at a sibling
+        # is a contradiction the depth wins; without this the criterion
+        # holds only for the records that happen to omit the key.
+        meta = self.subagents(TRUNCATED_SESSION) / (CHILD_AGENT + ".meta.json")
+        meta.write_text(
+            '{"agentType":"Explore","spawnDepth":1,"parentAgentId":"cc31"}',
+            encoding="utf-8",
+        )
+        _nodes, edges, inferred = self.graph(TRUNCATED_SESSION)
+        cell = session_cell(self.flowchart(TRUNCATED_SESSION), CHILD_AGENT, "attached")
+
+        self.assertIn((ui.ORCHESTRATOR_NODE, CHILD_AGENT), edges)
+        self.assertNotIn((PARENT_AGENT, CHILD_AGENT), edges)
+        self.assertEqual((), tuple(inferred))
+        self.assertIn(ui.EDGE_FROM_DEPTH, cell)
+
+    def test_a_parent_pointer_naming_its_own_agent_still_draws_a_graph(self):
+        # `graph_layout` breaks cycles, but a self-edge is not a dependency
+        # anybody can lay out, and the metadata is another program's.
+        meta = self.subagents(TRUNCATED_SESSION) / (CHILD_AGENT + ".meta.json")
+        meta.write_text(
+            '{"agentType":"Explore","spawnDepth":2,"parentAgentId":"cc32"}',
+            encoding="utf-8",
+        )
+        nodes, edges, _inferred = self.graph(TRUNCATED_SESSION)
+
+        self.assertNotIn((CHILD_AGENT, CHILD_AGENT), edges)
+        self.assertEqual(sorted(set(nodes)), sorted(nodes))
+        self.assertEqual(
+            sorted((ui.ORCHESTRATOR_NODE, PARENT_AGENT, CHILD_AGENT)), sorted(nodes)
+        )
+
+
+class TestActivityState(SessionCase):
+    """`S2` completion test 4, spec criterion 9. `running` is a claim about
+    a process this reader cannot see, and the only evidence of one anywhere
+    in the tree is the call and the return in the parent's own transcript."""
+
+    def states(self, session=TITLED_SESSION) -> dict:
+        return dict((agent["id"], agent["state"]) for agent in self.read(session)["agents"])
+
+    def test_a_call_whose_result_came_back_is_the_only_thing_read_as_finished(self):
+        page = self.flowchart()
+
+        self.assertEqual(ui.ACTIVITY_FINISHED, self.states()[RETURNED_AGENT])
+        self.assertIn(ui.ACTIVITY_FINISHED, session_cell(page, RETURNED_AGENT, "state"))
+        self.assertIn(ui.EVIDENCE_RETURNED, session_cell(page, RETURNED_AGENT, "state"))
+
+    def test_a_call_with_no_result_yet_is_read_as_running(self):
+        page = self.flowchart()
+
+        self.assertEqual(ui.ACTIVITY_RUNNING, self.states()[CALLED_AGENT])
+        self.assertIn(ui.ACTIVITY_RUNNING, session_cell(page, CALLED_AGENT, "state"))
+        self.assertIn(ui.EVIDENCE_CALLED, session_cell(page, CALLED_AGENT, "state"))
+
+    def test_an_agent_the_transcript_never_calls_is_unknown_with_its_last_time(self):
+        page = self.flowchart()
+
+        self.assertEqual(ui.ACTIVITY_UNKNOWN, self.states()[UNEVIDENCED_AGENT])
+        self.assertIn(ui.EVIDENCE_NONE, session_cell(page, UNEVIDENCED_AGENT, "state"))
+        self.assertIn(
+            agent_stamp(UNEVIDENCED_AGENT), session_cell(page, UNEVIDENCED_AGENT, "when")
+        )
+
+    def test_a_tool_call_that_is_not_an_agent_call_is_evidence_of_nothing(self):
+        # `toolu_alpha_03` is `agent-aa13`'s id, and the transcript carries a
+        # `Bash` call and a `Bash` result under it. A reader matching on the
+        # id alone reads a finished shell command as a finished subagent.
+        found = ui.find_session(self.transcripts, TITLED_SESSION)
+        summary = ui.cached_transcript(found["path"], found["identity"])
+
+        self.assertIn("toolu_alpha_03", found["path"].read_text(encoding="utf-8"))
+        self.assertEqual({"toolu_alpha_01", "toolu_alpha_02"}, set(summary["agent_calls"]))
+        self.assertEqual({"toolu_alpha_01"}, set(summary["agent_returns"]))
+
+    def test_no_agent_in_the_corpus_is_running_without_a_call_behind_it(self):
+        running = 0
+        for session in SESSIONS_NEWEST_FIRST:
+            found = self.read(session)
+            calls = ui.cached_transcript(found["path"], found["identity"])["agent_calls"]
+            for agent in found["agents"]:
+                if agent["state"] != ui.ACTIVITY_UNKNOWN:
+                    running += 1
+                    self.assertIn(agent["tool_use_id"], calls, agent["id"])
+        # Six sessions of `unknown` would satisfy the sweep above and prove
+        # nothing at all.
+        self.assertEqual(2, running)
+
+    def test_no_agent_defaults_to_finished_when_no_result_was_recorded(self):
+        # Every `tool_result` gone, and the calls left standing: nothing on
+        # the page may still read as done.
+        path = self.transcripts / ALPHA_PROJECT / (TITLED_SESSION + ".jsonl")
+        path.write_text(
+            "".join(
+                line
+                for line in path.read_text(encoding="utf-8").splitlines(True)
+                if "tool_result" not in line
+            ),
+            encoding="utf-8",
+        )
+        states = self.states()
+
+        self.assertNotIn(ui.ACTIVITY_FINISHED, states.values())
+        self.assertEqual(ui.ACTIVITY_RUNNING, states[RETURNED_AGENT])
+        self.assertEqual(ui.ACTIVITY_UNKNOWN, states[UNEVIDENCED_AGENT])
+
+    def test_a_result_for_a_call_that_never_happened_is_not_a_finished_agent(self):
+        path = self.transcripts / ALPHA_PROJECT / (TITLED_SESSION + ".jsonl")
+        path.write_text(
+            "".join(
+                line
+                for line in path.read_text(encoding="utf-8").splitlines(True)
+                if '"name":"Agent"' not in line
+            ),
+            encoding="utf-8",
+        )
+        found = ui.find_session(self.transcripts, TITLED_SESSION)
+        summary = ui.cached_transcript(found["path"], found["identity"])
+
+        self.assertEqual(set(), set(summary["agent_returns"]))
+        self.assertEqual({ui.ACTIVITY_UNKNOWN}, set(self.states().values()))
+
+    def test_the_node_is_drawn_in_the_state_its_row_reports(self):
+        page = self.flowchart()
+
+        self.assertEqual("nd-running", session_node(page, CALLED_AGENT)["state"])
+        self.assertIn(ui.ACTIVITY_RUNNING, session_node(page, CALLED_AGENT)["body"])
+        self.assertIn(ui.ACTIVITY_FINISHED, session_node(page, RETURNED_AGENT)["body"])
+        self.assertIn(ui.ACTIVITY_UNKNOWN, session_node(page, UNEVIDENCED_AGENT)["body"])
+
+    def test_every_state_the_view_can_draw_has_a_declared_presentation(self):
+        # `U2`'s hue tokens are a closed set, so a state drawn in a colour
+        # family the stylesheet does not declare renders as nothing at all.
+        for state in ui.ACTIVITY_STATES:
+            seen = ui.activity_presentation(state)
+
+            self.assertIn(seen.hue, ui.HUE_TOKENS, state)
+            self.assertTrue(seen.glyph, state)
+            self.assertEqual(state, seen.word)
+            self.assertIn(".st-{0} {{".format(state), ui.PAGE_CSS)
+            self.assertIn(".nd-{0} rect {{".format(state), ui.PAGE_CSS)
+
+
+class TestSessionPolling(SessionCase):
+    """`S2` completion test 5, spec criterion 14. The flowchart is the page
+    an orchestrator leaves open while the work it is watching runs."""
+
+    def setUp(self):
+        super(TestSessionPolling, self).setUp()
+        # The fixtures also carry a live elapsed meter, which honestly moves
+        # the tag on each minute boundary.
+        freeze(self)
+
+    def polled(self) -> tuple:
+        return (ui.SESSIONS_ROUTE, session_url(TITLED_SESSION))
+
+    def test_both_session_routes_answer_304_over_an_unchanged_root(self):
+        with serving(self.main, self.transcripts) as server:
+            for route in self.polled():
+                status, headers, body = fetch(server, route)
+                self.assertEqual(200, status, route)
+                self.assertTrue(body, route)
+
+                again = fetch(server, route, {"If-None-Match": headers["ETag"]})
+
+                self.assertEqual((304, ""), (again[0], again[2]), route)
+
+    def test_a_subagent_appearing_answers_200_with_a_new_tag_on_both(self):
+        with serving(self.main, self.transcripts) as server:
+            held = dict(
+                (route, fetch(server, route)[1]["ETag"]) for route in self.polled()
+            )
+            (self.subagents(TITLED_SESSION) / "agent-aa14.meta.json").write_text(
+                '{"agentType":"Plan","description":"just spawned",'
+                '"toolUseId":"toolu_alpha_04","spawnDepth":1}',
+                encoding="utf-8",
+            )
+            served = dict(
+                (route, fetch(server, route, {"If-None-Match": held[route]}))
+                for route in self.polled()
+            )
+
+        for route in self.polled():
+            status, headers, _body = served[route]
+            self.assertEqual(200, status, route)
+            self.assertNotEqual(held[route], headers["ETag"], route)
+        self.assertIn("agent-aa14", session_anchors(served[self.polled()[1]][2]))
+
+    def test_a_subagent_returning_answers_200_with_a_new_tag(self):
+        # The node set has not moved and the picture has: an ETag over the
+        # listing alone would sit on a page that says `running` forever.
+        path = self.transcripts / ALPHA_PROJECT / (TITLED_SESSION + ".jsonl")
+        route = session_url(TITLED_SESSION)
+        with serving(self.main, self.transcripts) as server:
+            held = {"If-None-Match": fetch(server, route)[1]["ETag"]}
+            with path.open("a", encoding="utf-8") as handle:
+                handle.write(
+                    '{"type":"user","message":{"role":"user","content":'
+                    '[{"type":"tool_result","tool_use_id":"toolu_alpha_02",'
+                    '"content":"%s"}]}}\n' % TRANSCRIPT_SENTINEL
+                )
+            status, _headers, body = fetch(server, route, held)
+
+        self.assertEqual(200, status)
+        self.assertEqual("nd-finished", session_node(body, CALLED_AGENT)["state"])
+
+    def test_one_session_never_answers_another_sessions_tag(self):
+        with serving(self.main, self.transcripts) as server:
+            first = fetch(server, session_url(TITLED_SESSION))[1]["ETag"]
+            other = fetch(server, session_url(MARKUP_SESSION))
+            status, _headers, body = fetch(
+                server, session_url(MARKUP_SESSION), {"If-None-Match": first}
+            )
+
+        self.assertNotEqual(first, other[1]["ETag"])
+        self.assertEqual(200, status)
+        self.assertIn(MARKUP_SESSION, body)
+
+    def test_a_missing_session_offers_no_tag_to_be_cached_against(self):
+        with serving(self.main, self.transcripts) as server:
+            status, headers, _body = fetch(server, session_url("no-such-session"))
+
+        self.assertEqual(404, status)
+        self.assertIsNone(headers.get("ETag"))
+
+
+class TestSessionEscaping(SessionCase):
+    """`S2` completion test 6, spec criterion 15. Every value on this page
+    is another program's undocumented JSON, and it reaches three contexts:
+    a table cell, an SVG text node, and an attribute."""
+
+    def markup(self) -> str:
+        return self.flowchart(MARKUP_SESSION)
+
+    def test_the_fixture_really_carries_markup_in_all_three_fields(self):
+        # Without this the assertions below sweep a page that never had
+        # anything on it to escape.
+        source = self.subagents(MARKUP_SESSION) / (MARKUP_AGENT + ".meta.json")
+        recorded = json.loads(source.read_text(encoding="utf-8"))
+        transcript = self.transcripts / BETA_PROJECT / (MARKUP_SESSION + ".jsonl")
+
+        self.assertEqual(MARKUP_AGENT_TYPE, recorded["agentType"])
+        self.assertEqual(MARKUP_AGENT_DESCRIPTION, recorded["description"])
+        self.assertIn(PAYLOAD, transcript.read_text(encoding="utf-8"))
+
+    def test_none_of_the_three_reaches_the_page_as_markup(self):
+        page = self.markup()
+
+        self.assertNotIn(PAYLOAD, page)
+        self.assertNotIn('onerror="alert(1)"', page)
+        self.assertIn("&lt;script&gt;alert(1)&lt;/script&gt;", page)
+
+    def test_the_agent_type_is_escaped_in_the_cell_and_in_the_svg_text_node(self):
+        page = self.markup()
+        node = session_node(page, MARKUP_AGENT)
+
+        self.assertIn("&lt;script&gt;", session_cell(page, MARKUP_AGENT, "type"))
+        self.assertIn("&lt;", node["body"])
+        self.assertNotIn("<script", node["body"])
+
+    def test_the_description_is_escaped_in_the_attribute_it_is_carried_in(self):
+        # An unescaped quote here closes `aria-label` early and everything
+        # after it becomes attributes of the anchor.
+        node = session_node(self.markup(), MARKUP_AGENT)
+
+        self.assertIn("&quot;", node["label"])
+        self.assertNotIn("onerror", node["label"].split("&quot;")[0])
+        self.assertIn(
+            "&lt;img src=&quot;x&quot;",
+            session_cell(self.markup(), MARKUP_AGENT, "description"),
+        )
+
+    def test_the_session_title_is_escaped_in_the_heading_and_in_the_svg_label(self):
+        page = self.markup()
+
+        self.assertIn("&lt;script&gt;", block_for(page, "title", "</p>"))
+        self.assertIn("&lt;script&gt;", session_node(page, ui.ORCHESTRATOR_ANCHOR)["label"])
+
+    def test_removing_the_escaping_breaks_every_assertion_above(self):
+        # The guards are only worth what their mutation says they are: with
+        # `html.escape` neutered the same page carries the live payload in
+        # all three contexts.
+        with patch.object(ui.html, "escape", lambda value, quote=True: value):
+            page = self.markup()
+
+        self.assertIn(PAYLOAD, page)
+        self.assertIn('onerror="alert(1)"', page)
+        self.assertIn("<script>alert(1)</script>", block_for(page, "title", "</p>"))
+
+
+class TestSessionLayoutCache(SessionCase):
+    """`S2` completion test 7. `U3`'s cache, and `U3`'s reason: at a
+    one-second poll a layout recomputed for a picture that did not move is
+    paid for once a second forever. A second layout algorithm in this module
+    would be the same defect wearing a different name."""
+
+    def setUp(self):
+        super(TestSessionLayoutCache, self).setUp()
+        ui.LAYOUT_CACHE.clear()
+        self.addCleanup(ui.LAYOUT_CACHE.clear)
+
+    @contextlib.contextmanager
+    def counting(self):
+        with patch.object(ui, "graph_layout", side_effect=ui.graph_layout) as computed:
+            yield computed
+
+    def test_two_requests_over_an_unchanged_subagent_set_lay_out_exactly_once(self):
+        with self.counting() as computed:
+            first = self.flowchart()
+            second = self.flowchart()
+
+        self.assertEqual(1, computed.call_count)
+        self.assertEqual(first, second)
+        # The counter can reach two, so one is a measurement rather than a
+        # mock that was never wired to anything.
+        with self.counting() as recomputed:
+            ui.LAYOUT_CACHE.clear()
+            self.flowchart()
+            ui.LAYOUT_CACHE.clear()
+            self.flowchart()
+
+        self.assertEqual(2, recomputed.call_count)
+
+    def test_an_activity_change_repaints_without_laying_the_graph_out_again(self):
+        path = self.transcripts / ALPHA_PROJECT / (TITLED_SESSION + ".jsonl")
+        with self.counting() as computed:
+            before = self.flowchart()
+            with path.open("a", encoding="utf-8") as handle:
+                handle.write(
+                    '{"type":"user","message":{"role":"user","content":'
+                    '[{"type":"tool_result","tool_use_id":"toolu_alpha_02",'
+                    '"content":"%s"}]}}\n' % TRANSCRIPT_SENTINEL
+                )
+            after = self.flowchart()
+
+        self.assertEqual(1, computed.call_count)
+        self.assertEqual("nd-running", session_node(before, CALLED_AGENT)["state"])
+        self.assertEqual("nd-finished", session_node(after, CALLED_AGENT)["state"])
+
+    def test_a_subagent_appearing_does_lay_the_graph_out_again(self):
+        with self.counting() as computed:
+            self.flowchart()
+            (self.subagents(TITLED_SESSION) / "agent-aa14.meta.json").write_text(
+                '{"agentType":"Plan","spawnDepth":1}', encoding="utf-8"
+            )
+            page = self.flowchart()
+
+        self.assertEqual(2, computed.call_count)
+        self.assertIn("agent-aa14", session_anchors(page))
+
+    def test_the_run_graph_and_the_flowchart_share_the_one_cache(self):
+        self.flowchart()
+        ui.render_route(self.main, graph_url(SETTLED_RUN))
+
+        self.assertEqual(2, len(ui.LAYOUT_CACHE))
+
+    def test_one_layout_function_serves_both_views(self):
+        # The structural half of the claim above: a private copy of the
+        # algorithm would pass every count in this class.
+        calls = set()
+        for node in ast.walk(ast.parse(UI_PY.read_text(encoding="utf-8"))):
+            if not isinstance(node, ast.FunctionDef):
+                continue
+            for inner in ast.walk(node):
+                if isinstance(inner, ast.Call) and isinstance(inner.func, ast.Name):
+                    if inner.func.id in ("graph_layout", "cached_layout"):
+                        calls.add((node.name, inner.func.id))
+
+        self.assertEqual(
+            {("cached_layout", "graph_layout")},
+            set(call for call in calls if call[1] == "graph_layout"),
+        )
+        self.assertEqual(
+            {"render_graph", "render_session"},
+            set(call[0] for call in calls if call[1] == "cached_layout"),
+        )
+
+
+class TestSessionEmptyStates(SessionCase):
+    """`S2` completion test 8. A session that spawned nothing is the common
+    case on a real host, and an id that names no session is one keystroke
+    away from every id that does."""
+
+    def test_a_session_that_spawned_nothing_draws_the_orchestrator_alone(self):
+        page = self.flowchart(UNTITLED_SESSION)
+
+        self.assertEqual([ui.ORCHESTRATOR_ANCHOR], session_anchors(page))
+        self.assertEqual([], EDGE_RE.findall(page))
+        self.assertIn(ui.EMPTY_NO_AGENTS, block_for(page, "agents empty", "</p>"))
+
+    def test_an_unknown_session_id_is_a_named_404_rather_than_a_traceback(self):
+        status, page = ui.render_route(
+            self.main, session_url("no-such-session"), self.transcripts
+        )
+
+        self.assertEqual(404, status)
+        self.assertIn(ui.EMPTY_NO_SESSION, page)
+        self.assertIn("no-such-session", page)
+
+    def test_an_id_that_is_not_a_name_at_all_is_refused_the_same_way(self):
+        for identifier in ("", "..", "../" + TITLED_SESSION, "a/b", PAYLOAD):
+            status, page = ui.render_route(
+                self.main, "/session?id=" + identifier, self.transcripts
+            )
+
+            self.assertEqual(404, status, identifier)
+            self.assertNotIn(PAYLOAD, page, identifier)
+
+    def test_a_traversal_shaped_id_is_refused_before_any_directory_is_read(self):
+        # The listing would refuse it too, by never matching -- so without
+        # this the guard is untested and its removal changes no page. It is
+        # here to keep a query-string value from reaching the filesystem at
+        # all, and that is a claim about what was read, not what was drawn.
+        with patch.object(ui, "discover_sessions") as listed:
+            found = ui.find_session(self.transcripts, "../" + TITLED_SESSION)
+
+        self.assertIsNone(found)
+        listed.assert_not_called()
+
+    def test_no_transcript_root_configured_reads_nothing_and_says_so(self):
+        with patch.object(ui, "_transcript_summary") as parsed:
+            status, page = ui.render_route(self.main, session_url(TITLED_SESSION), None)
+
+        parsed.assert_not_called()
+        self.assertEqual(404, status)
+        self.assertIn(ui.EMPTY_NO_SESSION, page)
+
+    def test_metadata_that_cannot_be_read_still_draws_its_node_and_says_so(self):
+        page = self.flowchart(MARKUP_SESSION)
+
+        self.assertIn(UNREADABLE_AGENT, session_anchors(page))
+        self.assertIn(
+            ui.DIAGNOSTIC_UNREADABLE_AGENT, block_for(page, "diagnostics", "</ul>")
+        )
+
+    def test_a_field_of_the_wrong_type_is_a_named_absence_rather_than_a_value(self):
+        page = self.flowchart(MARKUP_SESSION)
+
+        self.assertIn(ui.EMPTY_NO_TYPE, session_cell(page, BAD_FIELDS_AGENT, "type"))
+        self.assertIn(
+            ui.EMPTY_NO_DESCRIPTION, session_cell(page, BAD_FIELDS_AGENT, "description")
+        )
+        self.assertIn(ui.EMPTY_NO_DEPTH, session_cell(page, BAD_FIELDS_AGENT, "depth"))
+        self.assertEqual(
+            "nd-" + ui.ACTIVITY_UNKNOWN, session_node(page, BAD_FIELDS_AGENT)["state"]
+        )
+
+
+class TestUnrenderableTimestamps(SessionCase):
+    """Spec criterion 12 over the one field that comes from the filesystem
+    rather than from a transcript. `U3` shipped a traceback in the handler
+    once already: the client gets no HTTP response at all and the absolute
+    module path goes to stderr. A stamp is the remaining door."""
+
+    def test_a_time_beyond_the_calendar_is_a_named_diagnostic_not_a_raise(self):
+        # APFS clamps at 2262 and cannot reach this; an NTFS FILETIME
+        # reaches the year 30828, so the Windows leg can.
+        self.assertEqual(
+            ui.DIAGNOSTIC_UNRENDERABLE_STAMP, ui._stamp(FAR_FUTURE_MTIME_NS)
+        )
+
+    def test_an_ordinary_time_is_untouched_by_the_guard(self):
+        # Otherwise the assertion above is satisfied by a stamp that never
+        # renders anything.
+        self.assertEqual(utc_stamp(SESSION_EPOCH), ui._stamp(SESSION_EPOCH * 1000000000))
+
+    def test_both_session_routes_still_answer_over_such_a_file(self):
+        with far_future_mtimes():
+            with serving(self.main, self.transcripts) as server:
+                index = get(server, ui.SESSIONS_ROUTE)
+                detail = get(server, session_url(TITLED_SESSION))
+
+        self.assertEqual(200, index[0])
+        self.assertEqual(200, detail[0])
+        self.assertIn(
+            ui.DIAGNOSTIC_UNRENDERABLE_STAMP,
+            session_cell(index[1], TITLED_SESSION, "when"),
+        )
+        self.assertIn(
+            ui.DIAGNOSTIC_UNRENDERABLE_STAMP,
+            session_cell(detail[1], RETURNED_AGENT, "when"),
+        )
+
+
+class TestSubagentContentWall(SessionCase):
+    """`S2`'s half of spec criterion 10. The flowchart reads the one file
+    the index does not, and the evidence it reads the activity off is a
+    prompt -- the single most sensitive thing in the tree."""
+
+    def test_the_flowchart_emits_only_the_fields_the_spec_admits(self):
+        # Named here so widening the row is a decision rather than a slip.
+        self.assertEqual(
+            ("agent", "type", "description", "depth", "state", "attached", "when"),
+            ui.AGENT_COLUMNS,
+        )
+        self.assertEqual(len(ui.AGENT_COLUMNS), len(ui.AGENT_HEADINGS))
+
+    def test_the_rendered_row_carries_exactly_the_closed_set(self):
+        # `agentType`, `description`, `toolUseId` and `spawnDepth` are the
+        # whole of what a subagent's metadata may render. An eighth cell is
+        # a field off a transcript, and the tuple above would not see it.
+        page = self.flowchart()
+
+        for agent in ALPHA_AGENTS:
+            self.assertEqual(list(ui.AGENT_COLUMNS), row_columns(page, agent), agent)
+
+    def test_narrowing_the_closed_set_narrows_the_row_it_renders(self):
+        with patch.object(ui, "AGENT_COLUMNS", ("agent", "type")):
+            page = self.flowchart()
+
+        self.assertEqual(["agent", "type"], row_columns(page, RETURNED_AGENT))
+
+    def test_no_flowchart_in_the_corpus_leaks_a_line_of_any_transcript(self):
+        for session in SESSIONS_NEWEST_FIRST:
+            status, page = ui.render_route(
+                self.main, session_url(session), self.transcripts
+            )
+
+            self.assertEqual(200, status, session)
+            self.assertNotIn(TRANSCRIPT_SENTINEL, page, session)
+
+    def test_the_state_is_read_off_a_prompt_the_page_never_shows(self):
+        # The `Agent` call carrying `toolu_alpha_01` holds the subagent's
+        # whole prompt. What comes off it is one word.
+        page = self.flowchart()
+
+        self.assertIn(ui.ACTIVITY_FINISHED, session_cell(page, RETURNED_AGENT, "state"))
+        self.assertIn(TRANSCRIPT_SENTINEL, (self.transcripts / ALPHA_PROJECT / (
+            TITLED_SESSION + ".jsonl")).read_text(encoding="utf-8"))
+        self.assertNotIn(TRANSCRIPT_SENTINEL, page)
+
+    def test_the_sweep_still_renders_what_it_is_allowed_to(self):
+        # The sweep above would also pass on a page that rendered nothing.
+        page = self.flowchart()
+
+        self.assertIn("orch-worker", session_cell(page, RETURNED_AGENT, "type"))
+        self.assertEqual(1 + len(ALPHA_AGENTS), len(session_anchors(page)))
+
+    def test_a_subagents_own_transcript_is_listed_and_never_opened(self):
+        opened = []
+        real = Path.open
+
+        def watching(self, *args, **kwargs):
+            opened.append(self.name)
+            return real(self, *args, **kwargs)
+
+        with patch.object(Path, "open", watching):
+            self.flowchart()
+
+        self.assertNotIn(RETURNED_AGENT + ".jsonl", opened)
+        self.assertIn(TITLED_SESSION + ".jsonl", opened)
+
+
+class TestSessionRouteIsReadOnly(SessionCase):
+    """`S2` completion test 10, spec criterion 11 over the routes this
+    ticket adds."""
+
+    def test_drawing_every_flowchart_writes_nothing_under_the_transcript_root(self):
+        before = snapshot(self.transcripts)
+        self.assertTrue(before)
+
+        with serving(self.main, self.transcripts) as server:
+            for session in SESSIONS_NEWEST_FIRST:
+                status, _headers, body = fetch(server, session_url(session))
+
+                self.assertEqual(200, status, session)
+                self.assertTrue(body, session)
+
+        self.assertEqual(before, snapshot(self.transcripts))
+
+    def test_the_new_route_is_inside_the_sweeps_that_already_exist(self):
+        # The read-only, no-network and content-wall guards all walk
+        # `every_route()`; a route absent from it is a route none of them
+        # ever visits, which is the failure `U1` recorded against itself.
+        self.assertTrue(set(ROUTE_EXAMPLES[ui.SESSION_ROUTE]) <= set(every_route()))
+        self.assertIn(session_url(TITLED_SESSION), every_route())
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
`scripts/ui.py` serves a loopback HTTP view of a main checkout's `.orch/` — run index, ticket detail, dependency graph, friction feed. One tuple entry in `install.py` ships it to `~/.orchflows/bin/ui.py`, so it runs against any repository, not just this one.

Read-only forever: the process writes nothing under `.orch/`, and a snapshot of the real 43-entry tree is byte-identical before and after every route is exercised.

## Shape

Stdlib only, no network at run time, no build step, Python 3.9 floor. CSS and JS are module constants rather than sidecar files, because `SCRIPT_NAMES` carries flat filenames and a sidecar asset would never install.

Graph layout is a Coffman-Graham layered sort **computed in Python**, so it falls under `unittest discover` instead of being verified by eye. It terminates on cyclic `depends_on` with a named diagnostic, and coordinates are byte-identical across processes at different `PYTHONHASHSEED`.

Change detection is an ETag over the observed trees plus the rendered meter minute, polled by a `setTimeout` loop at 1s live / 5s terminal / 15s hidden. Not SSE: stdlib `http.server` never speaks HTTP/2, so the 6-connections-per-origin cap applies in full, and plain `HTTPServer` is serial — one held stream deadlocks it.

`.orch/` is untrusted data per `rules/visibility.md` §6, so every interpolated value is escaped in text, attribute and SVG contexts, and no ticket content reaches the page as markup.

## Degrading visibly

Real ticket data is irregular in specific observed ways, and the viewer names each rather than guessing:

- A `## Verification` section that is not a five-column table renders `unparsed` with the section verbatim — never a fabricated zero count. Both shapes exist in this repo's own tickets.
- A `bound` that is not a duration (the real observed value is `one session`) renders no meter, rather than one computed from a 60-minute default.
- A frontmatter `id` diverging from its filename is named as a diagnostic instead of silently emitting a dead link.

## Verification

`Ran 737 tests`, `OK (skipped=4)` — 158 added over the 579 baseline. The other three required checks are unchanged: `tools/validate.py` exit 0 with zero output, `install.py --dry-run` exit 0, `git diff --check` exit 0. No file under `contracts/`, `rules/`, `skills/`, `packs/` or `compositions/` is touched.

Delivered as run `orchflows-ui-2026-08-10` (tickets U1–U3) through one `orch-review-fix` gate. The reviewer lane, working in an independent context against the artifact pinned by sha256, found eight defects — all fixed here:

- The ETag served a **stale 304 in exactly the state the 1s poll exists for** — the elapsed meter varies with wall-clock time, which the digest did not observe.
- `%00` or a ≥256-byte run name **raised out of the handler**: no HTTP response at all, plus a traceback disclosing absolute paths, re-triggered every second by the retrying poll loop.
- The `.orch/events/` seam was **entirely unimplemented** despite being fixed in the spec's binding constraints.
- Three test assertions that passed for the wrong reason, including a named escaping guard that still passed after the markup was removed from its fixture.

This is the reader half. Visual design — an OKLCH token set with contrast and accessibility oracles — is a separate spec, deliberately not in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
