### PR TITLE
Mine the corrections a ticket already records

### DIFF
--- a/skills/workflows/orch-self-improve/SKILL.md
+++ b/skills/workflows/orch-self-improve/SKILL.md
@@ -15,27 +15,27 @@ the window names it; a recurring prior cluster routes to
 
 Widen the windowed pool: exclude byte-identical duplicates, then
 synthesize one entry-shaped observation, citing its file, per silent
-signal — a non-terminal worklog, a bounced or abandoned ticket, a
-trace's repeated failure — each lacking a matching friction entry.
+signal lacking a matching friction entry — a non-terminal worklog, a
+trace's repeated failure, and every correction a
+[ticket](../../../contracts/work-item.md) records: a bounce, its
+`## Feedback`, a checker's appended `## Result` pass, a `## Handoff`,
+a criterion reading FAIL before the join wrote `complete`. List
+tickets with `scripts/tickets.py list`.
 
 Cluster by observed-text similarity and assign each cluster its one
-causal owner and scope per [§3](../../../rules/improvement.md)
-yourself: the entry's `skill` field records where friction was hit,
-not what owns the defect; a trace-carrying cluster records its model
-distribution for §3's routing. Apply §4's qualification, checking any
-claimed contradiction against the owner's current text yourself; the
-rest stays noise, untouched in the log.
+causal owner and scope per §3 yourself: the entry's `skill` field and
+a correction's own named cause record where the defect was felt, not
+what owns it. Apply §4's qualification yourself; the rest stays
+noise, untouched in the log.
 
 For each qualified cluster, write one proposal to
-`.orch/improvement/proposals/<date>-<slug>.md`, typed `fix` or
-[§4](../../../rules/improvement.md) `consolidate`: the single causal
-owner and its scope; the exact change (for `environment`, the remedy
-and its reproducing probe); every evidence entry verbatim; the blame
-class where a join recorded one. An amendment verifies the owner's
-dependents still hold and says so. A ticket-naming entry whose run's
-frozen statement survives replays through `orch-task` in isolation
-against the amended owner — a red replay disqualifies
-([§5](../../../rules/improvement.md)); one that cannot replay says so.
+`.orch/improvement/proposals/<date>-<slug>.md`, typed `fix` or §4
+`consolidate`: the single causal owner and its scope; the exact
+change; every evidence entry verbatim; the blame class where a join
+recorded one. An amendment verifies the owner's dependents still
+hold. A ticket-naming entry whose run's frozen statement survives
+replays through `orch-task` in isolation against the amended owner —
+a red replay disqualifies (§5).
 
 Rank by evidence strength — green replay, checked contradiction or
 probe, then recurrence — ties breaking toward deletion. Close with


### PR DESCRIPTION
`orch-self-improve` mined friction logs and failure-shaped run state. It did not read the corrections tickets already carry.

## The gap

The silent-signal list named a non-terminal worklog, a bounced or abandoned ticket, and a trace's repeated failure. A ticket that failed a criterion, was corrected, and reached `complete` matched none of them — which on the current corpus is **38 of 40 tickets** carrying a non-empty `## Feedback`, about 117 KB of recorded diagnosis.

Only **13 of those 38** say they were also logged as friction, so roughly two thirds of the signal existed nowhere a cycle looked.

The two sources are complementary by construction. `rules/improvement.md` §1 requires a friction entry to record observations and **never causes**; `## Feedback` is where the executing context is allowed to write the cause. Mining one without the other collects every symptom and no diagnosis.

## The change

Four correction records join the silent-signal list, each split by who wrote it:

| Record | Written by | Present |
|---|---|---|
| `## Feedback` | the executor, about its own dispatch | 38/40 |
| `## Result` appendix + `checked_by` | the §10 checker (`orch-check`) | 0/40 |
| `## Handoff` | the executor, escalating | 6/40 |
| a criterion reading FAIL before `complete` | executor self-correction | 12/40 |

All four stay filtered by the existing *"lacking a matching friction entry"* clause, so the 13 duplicates drop out on the path already there. Clustering, owner assignment, §4 qualification and §5 replay are untouched — they consume entry-shaped observations and never asked where one came from.

One clause guards the new input: a correction's own named cause records where the defect was **felt**, not what owns it. `Never: attribute cause beyond what entries show` already covered the rest.

## Enumeration fix

Pinned to `scripts/tickets.py list`. On this host:

```
find .orch/tickets -name "*.md" | wc -l   # 15   (exit 0)
python3 scripts/tickets.py list           # 40
```

Two run directories are symlinks into a worktree and `find` does not follow them. `tickets.py` walks with `iterdir()`/`is_dir()` and sees all 40. A cycle that shelled out to `find` would have silently mined 37% of the corpus and reported completeness.

## Budget

The workflows body budget is 40 non-empty lines and this skill sat at exactly 40, so the change is net zero — **17 insertions, 17 deletions**. The additions are paid for by dropping restatements the owning rule already holds: §4's contradiction check, §5's "cannot replay says so", §4's environment probe, and three repeated full link paths (the Return section's bare `per §3` is the precedent).

## Checks

All four from `AGENTS.md`, on `python3` (3.13):

- `python tools/validate.py` — silent
- `python -m unittest discover -s tests` — `Ran 901 tests … OK (skipped=4)`
- `python install.py --dry-run` — clean
- `git diff --check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
