### PR TITLE
Bind a cut's scope to what it names; forbid frozen readings

### DIFF
--- a/docs/vocabulary.md
+++ b/docs/vocabulary.md
@@ -59,7 +59,8 @@ that needs a different meaning needs a different word.
 - **identity** — what fixes a thing across change: a revision, a content
   digest, a symbol, a run or item id. A coordinate another context can
   move — a line number, a list index, a path into a tree being edited —
-  is not one.
+  is not one, and neither is a count nor a reading taken from the
+  environment.
 - **run** — one execution of a workflow against one spec; owns a run id
   (`<utc-stamp>-<slug>`), a worklog, and a ticket directory. An ad-hoc
   run executes one ad-hoc ticket — or an ad-hoc set — instead: the

--- a/rules/topology.md
+++ b/rules/topology.md
@@ -43,7 +43,10 @@
    is forced only by parallelism, disjoint write scopes, isolation, or
    resumption — never made to look thorough. A decomposition that
    cannot cover most acceptance criteria under the stamped slicing
-   returns a decision gap, never a forced slicing.
+   returns a decision gap, never a forced slicing. A cut's write scope
+   covers every artifact its own objective and completion test name,
+   resolved against the workspace before issue; a cut that cannot cover
+   them is widened or re-cut, never issued.
 4. At most one terminal assembly item per run, depending on every unit
    item. Assembly rewrites its inputs, so unit verification upstream of
    it is invalidated at the join; the final gate re-verifies the

--- a/rules/verification.md
+++ b/rules/verification.md
@@ -9,7 +9,9 @@
    UNVERIFIED; overall PASS requires every required criterion and states
    its weakest oracle_class.
 3. Freeze criteria and their oracles before the first unit of work; a
-   criterion added mid-run is queued scope, not a moving target.
+   criterion added mid-run is queued scope, not a moving target. A
+   criterion states the condition its oracle decides, never a reading of
+   current state — a frozen count is a target, not a check.
 4. Verification never edits its target. A verifier that fixes what it
    checks has become an executor and its verdicts are void.
 5. The class policy in [contracts/verdict.md](../contracts/verdict.md)


### PR DESCRIPTION
Three sentences, each closing a failure class measured in this repository's own friction logs (912 entries) and completed tickets (~122 across 22 runs, since 2026-07-25).

## What changed

**`rules/topology.md` §3** — a cut's write scope covers every artifact its own objective and completion test name, resolved against the workspace before issue.

The largest cluster in the logs is a `write_scope` narrower than the completion test paired with it in the same ticket: **53 entries across eight runs and two repositories**. One entry states it exactly: *"A write_scope should be derivable from the completion test it is paired with. The decomposition wrote both, in the same ticket, and they disagreed twice out of three dispatched items."* The cost curve is in the record too — one run hit the same defect four times: caught after three commits, then after a watchdog death, then before any code was written.

Note this rule sets a **floor** on scope, not a ceiling. It constrains the cutter, not the executor.

**`rules/verification.md` §3** — a criterion states the condition its oracle decides, never a reading of current state.

Every handed-down count checked in the ticket corpus was wrong. One executor kept entries it should have retired *"rather than delete to hit a number the caller had asserted"*. §3 is the sentence that currently invites freezing such a count.

**`docs/vocabulary.md`** — a count and a reading taken from the environment join the coordinates already excluded from identity. This closes the same class where `by identity` already binds: `## Fixed inputs`, `## Result`, `## Handoff`. One run shipped a ticket whose fixed inputs asserted two host facts that were false of the executing host, with the dispatch instructing the executor to trust them.

## Landing zones

`rules/` and `docs/`, not `contracts/`: the eight T0 files are hash-pinned in `tests/pins.json`, and `orch-build` forbids touching one outside a supersession change. `skills/workflows/orch-build/references/scopes.md` puts always-on canonical rules in `rules/`.

`skills/kernel/orch-decompose/SKILL.md` is **unchanged** — it already links topology §3, so the law propagates with no addition to a kernel body already near its 25-line budget.

## Verification

- `python3 tools/validate.py` — exit 0
- `python3 -m unittest discover -s tests` — 901 tests, OK (4 skipped)
- `python3 install.py --dry-run` — exit 0
- `git diff --check` — clean

Gated twice through an independent context under `skills/workflows/orch-build/references/library-lens.md`. The first round rejected both original wordings — one restated executor law owned in six other places, the other contradicted `contracts/delegation.md:9` (*"A packet says what to do. Only `inputs` says what is true"*). The second round caught that a draft clause excluding "an observation a later context re-derives" would have swallowed *content digest* and *symbol*, both named as identities in the same sentence.

Replay per `rules/improvement.md` §5 was **text-level, not a re-run**: checked against `20260810T092133Z-keyless-acquisition/T03-run-local-cache`, whose objective requires every served-from-cache record to carry `cache_hit=true` while its write scope names only `cache.py` and its tests — the record is built in `normalize.py`/`schema.py`, outside the grant. The amended §3 makes that cut widen-or-re-cut before issue. The ticket was not re-executed.

## Known consequence, not fixed here

`.orch/canary/golden.json` pins `canary-scope-reject`'s blame as `child under-delivered`, on a fixture whose objective deliberately names a file its `write_scope` omits. The new topology sentence makes the caller reading defensible too, so that canary may diverge. Per `.orch/canary/README.md`, goldens are compared and never enforced — a divergence surfaces as a `surprising-output` friction entry for a human, not a build failure.

## Deliberately not included

A mechanical check. `rules/token-economy.md` §4 would mandate one at the second repetition and this cluster has 53, but the check is necessarily partial — it catches path-vs-scope mismatches and cannot catch the more expensive variant, where four tickets pass green and no ticket owns the seam between them. Left as a separate decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
