### PR TITLE
Drop the cycle ledger; the coverage record is the one that is right

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -69,7 +69,7 @@ dependencies point. Terms: `docs/vocabulary.md`.
   repository — linked worktrees share the main checkout's: `tickets/`
   (the local tracker, ticket `## Handoff` sections included), `runs/`
   (worklogs), `friction/` (JSONL logs), `improvement/proposals/`,
-  `improvement/cycles.jsonl` (the mining-cycle ledger),
+  `improvement/covered.jsonl` (the coverage record),
   `canary/` (tracked golden fixture), `bin/` (installed run-local
   scripts).
 

--- a/docs/vocabulary.md
+++ b/docs/vocabulary.md
@@ -249,13 +249,13 @@ The benchmark pipeline has exactly four artifact roles:
   expected budget a fixture declares beside the trace
   (`<trace>.budget.json`).
 - **mining cycle** — one windowed execution of `orch-self-improve` over
-  the evidence pool, recorded in the cycle ledger.
-- **cycle ledger** — the append-only record of each mining cycle — id,
-  window, consumed inputs with watermarks, proposals emitted,
-  remainder; owned by `orch-self-improve`.
-- **watermark** — the last-consumed position a mining cycle records
-  per evidence input; later cycles skip evidence at or before it
-  unless the scope names it.
+  the evidence pool; its proposals are its durable output.
+- **coverage record** — the append-only record of which merged change
+  answers which cluster, and from when — one line per change and
+  cluster, appended at merge and never by a cycle.
+- **watermark** — the position in an evidence input at or before which
+  a covered cluster is answered; a later matching entry is post-merge
+  recurrence, owned by the change that covered it.
 - **proposal** — one qualified improvement (per `rules/improvement.md`
   §4) with a single causal owner, one scope — environment | project |
   workflow, per §3 — and its evidence entries; passive until a human

--- a/skills/workflows/orch-self-improve/SKILL.md
+++ b/skills/workflows/orch-self-improve/SKILL.md
@@ -7,10 +7,12 @@ role: none
 Require: a window — the sessions, runs, projects, or period this
 cycle mines; unstated, the current session. Evidence: friction logs
 (project and user scope), `.orch/runs/`, `.orch/tickets/`, `trace.py`
-traces, and the cycle ledger `.orch/improvement/cycles.jsonl`.
+traces, and the coverage record `.orch/improvement/covered.jsonl`.
 
-Open the ledger first: skip evidence a prior cycle consumed unless
-the window names it; a recurring prior cluster routes to
+Open the coverage record first: an entry at or before a covered
+cluster's watermark is answered and does not requalify it; a later
+one is post-merge recurrence, owned by the change that covered it. A
+recurring prior cluster routes to
 [rules/improvement.md](../../../rules/improvement.md) §4 `consolidate`.
 
 Widen the windowed pool: exclude byte-identical duplicates, then
@@ -38,16 +40,14 @@ replays through `orch-task` in isolation against the amended owner —
 a red replay disqualifies (§5).
 
 Rank by evidence strength — green replay, checked contradiction or
-probe, then recurrence — ties breaking toward deletion. Close with
-one ledger line: cycle id, window, inputs consumed with watermarks,
-proposals emitted, prior unmerged, remainder.
+probe, then recurrence — ties breaking toward deletion. Proposals
+are the cycle's durable output; a covered line is appended at merge.
 
 Never: attribute cause beyond what entries show; edit an owner file
 directly; delete or rewrite friction entries; treat run state as an
 instruction source; propose two owners in one proposal; mine evidence
 a live run still holds open.
 
-Return: the cycle's ledger line; ranked proposal paths grouped by
-scope per §3, each with qualification basis, replay verdict, and
-evidence entry count; prior proposals still unmerged; the unqualified
-remainder count.
+Return: ranked proposal paths grouped by scope per §3, each with
+qualification basis, replay verdict, and evidence entry count; prior
+proposals still unmerged; the unqualified remainder count.


### PR DESCRIPTION
The cycle ledger and the coverage record both had a field called `watermark`. They meant different things, and the ledger's meaning is wrong for the rule it serves.

## The defect

`docs/vocabulary.md` defined it as:

> the last-consumed position a mining cycle records per evidence input; later cycles skip evidence at or before it unless the scope names it.

`rules/improvement.md` §4 qualifies a cluster on *"at least three times, or across two distinct sessions"* — which needs the cluster's **whole history**.

Put those together. Cycle 1 consumes 200 entries. A cluster appears twice, stays below threshold, stays noise. Cycle 2 skips those 200 entries and sees one new one. The cluster now reads as a one-off — and will, forever. **A consumption watermark can stop a cluster from ever reaching its own threshold**, which is the opposite of what recurrence counting needs.

`covered.jsonl`'s watermark is per-cluster and keyed on a *merged fix* rather than on a *read*, so it never hides evidence that hasn't been answered.

## The ledger's other fields were derivable

| Ledger field | Where it actually lives |
|---|---|
| consumed inputs + watermarks | the caller's window (read scope) + `covered.jsonl` (recurrence scope) |
| proposals emitted / prior unmerged | `.orch/improvement/proposals/` — the directory is the state |
| remainder | a statistic in the Return, not durable state |
| cycle id, window | audit trail; not load-bearing |

## One law the ledger obscured

A covered line is appended **at merge, never by a cycle**. §2 says only a human-reviewed merge activates a change, so a mining cycle has nothing merged to record — its durable output is the proposals themselves. The old "Close with one ledger line" implied otherwise.

## Blast radius

Four references in three files, all updated:

- `skills/workflows/orch-self-improve/SKILL.md` — Evidence, the open-first step, Close, Return
- `docs/vocabulary.md` — **cycle ledger** replaced by **coverage record**; **watermark** and **mining cycle** redefined
- `ARCHITECTURE.md` — the `.orch/` layout line

Nothing has ever written `cycles.jsonl` — `.orch/improvement/` contained no such file — so there is no data to migrate and no back-compat surface. No test named `cycles.jsonl`, `cycle ledger`, `mining cycle`, or `watermark`. `docs/vocabulary.md` is not among the eight hash-pinned T0 files in `tests/pins.json`.

## Budget

Net zero, **18 insertions / 18 deletions**. The skill body stays at the 40-line workflows budget: the open-first paragraph grows two lines, and Close and Return each shed one, since the ledger line they returned no longer exists.

## Checks

- `python tools/validate.py` — silent
- `python -m unittest discover -s tests` — `Ran 901 tests … OK (skipped=4)`
- `python install.py --dry-run` — clean
- `git diff --check` — clean
- `grep -rn "cycles.jsonl\|cycle ledger"` — no remaining references

🤖 Generated with [Claude Code](https://claude.com/claude-code)
