### PR TITLE
Planner at max, and a README that says what profiles.md says

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,9 +73,9 @@ Runs survive session death: specs, tickets, and worklogs are files in
 Team setup: `python install.py --project PATH` writes a committable
 routing block for a repo. Uninstall: `python install.py --user
 --uninstall` removes only what it generated; `--dry-run` previews
-either. Default model bindings: the planner/reviewer is Fable 5 on
-high effort (Claude Code) or GPT-5.6 Sol on ultra (Codex); workers are
-Sonnet 5 on xhigh and GPT-5.6 Sol on high.
+either. Default model bindings: the planner/reviewer is Opus 5 on max
+effort (Claude Code) or GPT-5.6 Sol on ultra (Codex); workers are
+Opus 5 on xhigh and GPT-5.6 Sol on high.
 
 ## The interesting parts
 

--- a/skills/kernel/orch-delegate/references/profiles.md
+++ b/skills/kernel/orch-delegate/references/profiles.md
@@ -5,7 +5,7 @@ file solely owns default model mappings and the child-naming algorithm.
 
 | Profile | Role | Codex | Claude Code |
 | --- | --- | --- | --- |
-| `orch-planner` | planner | agent_type `orch_planner`, model `gpt-5.6-sol`, model_reasoning_effort `ultra` | model `claude-opus-5`, effort `xhigh` |
+| `orch-planner` | planner | agent_type `orch_planner`, model `gpt-5.6-sol`, model_reasoning_effort `ultra` | model `claude-opus-5`, effort `max` |
 | `orch-worker` | worker | agent_type `orch_worker`, model `gpt-5.6-sol`, model_reasoning_effort `high`, service_tier `fast` | model `claude-opus-5`, effort `xhigh` |
 
 Use native invocation fields when available; a prompt-only request is


### PR DESCRIPTION
The Claude Code planner binding moves from `xhigh` to `max`. The worker stays `claude-opus-5` at `xhigh` and is unchanged. Codex bindings are untouched.

| Profile | Claude Code — before | Claude Code — after |
|---|---|---|
| `orch-planner` | `claude-opus-5`, effort `xhigh` | `claude-opus-5`, effort **`max`** |
| `orch-worker` | `claude-opus-5`, effort `xhigh` | unchanged |

## This makes lawful a setting that was already live

`/Users/dmcinerney/.claude/agents/orch-planner.md` on this host already read `effort: max` — hand-edited into installer-generated output, which the host block explicitly forbids (*"read it, never edit it — an amendment lands in the library's own source repository and reaches here by reinstall"*).

The edit was invisible until it broke something: `install.py` refuses to overwrite a native role profile changed since the recorded install, so **every reinstall failed** until the source agreed with the tree:

```
error: install failed: refusing to overwrite native role profile(s):
  /Users/dmcinerney/.claude/agents/orch-planner.md (changed since the recorded install)
```

Changing `profiles.md` is what makes the running config reproducible from the tree instead of from one machine's hand-edit.

## README was stale in both Claude cells

It claimed the planner/reviewer is *"Fable 5 on high effort (Claude Code)"* and workers are *"Sonnet 5 on xhigh"*. Neither had been true since opus-5 was adopted for the worker and then the planner. The Codex cells were correct throughout. `profiles.md` solely owns these mappings, so README now restates them correctly rather than carrying an independent claim that can drift again.

## Verification

`install.py` requires a Claude binding to name a `model` and does not constrain `effort` to an enum, so `max` needs no parser change. The rendered binding is the assertion that matters:

```
$ python3 -c "import install; ..."
orch-planner -> {'model': 'claude-opus-5', 'effort': 'max'}
orch-worker  -> {'model': 'claude-opus-5', 'effort': 'xhigh'}
```

Benchmark records under `benchmarks/` that mention `xhigh` are attestations of what a past run *requested* and are deliberately untouched.

## Checks

- `python tools/validate.py` — silent
- `python -m unittest discover -s tests` — `Ran 901 tests … OK (skipped=4)`
- `git diff --check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
