### PR TITLE
Review the cut before executing it

### DIFF
--- a/skills/workflows/orch-deliver/SKILL.md
+++ b/skills/workflows/orch-deliver/SKILL.md
@@ -5,18 +5,21 @@ role: none
 ---
 
 Require: a frozen, routing-stamped [spec](../../../contracts/spec.md).
-This body never names a domain; every domain fact comes from the
-stamped pack's cells.
 
 Open the run: `orch-worklog`, then `orch-workspace` for the run's
 target per the pack's workspace cell. Decompose through
 `orch-decompose`; a returned decision_gap rides this body's own Return
 and routes to the caller while the covered remainder still executes.
 
-Plan gate: when the caller asked for a plan, or the spec sets
-`plan_gate`, stop here and return the plan — items, edges, budgets,
-risks, uncovered remainder. Execution resumes only on approval, against
-the frozen plan.
+Critique the cut, when it issued more than one item or any edge, before
+executing it: `orch-critique`, independent of the decomposition,
+supplying its Require by name — the ticket directory with its item ids,
+the spec, and [references/cut-lens.md](references/cut-lens.md); one
+re-cut through `orch-decompose` answers a blocking finding, a second
+rides decision_gap. When the caller asked for a plan or the spec sets
+`plan_gate`, stop and return the plan — items, edges, budgets, risks,
+uncovered remainder, findings — resuming only on approval, against the
+frozen plan.
 
 Execute the graph through `orch-frontier`. When the frontier exits
 carrying a failed, blocked, or unparked-open item, set the worklog
@@ -24,24 +27,21 @@ terminal state through `orch-worklog` and return per
 [rules/composition.md](../../../rules/composition.md) rule 8 without
 crossing the gate. A parked-only remainder returns the same way but
 leaves `terminal` empty — the run stays open; re-invoked on an open
-run, this body skips decomposition and re-enters the frontier over
-the existing tickets; the gate crosses only once every unit item is
-complete. Otherwise the terminal assembly item, if the pack declares
-one, runs last and invalidates unit verification it rewrites, per
-[rules/topology.md](../../../rules/topology.md) rule 4 — the gate
-re-verifies the assembled artifact. Cross one `orch-review-fix` gate,
-supplying its Require by name: the fixed result identity (the
-assembled artifact), the pack's stamped lens, the pack's oracle
-policy, the spec, the standards owner by pointer where the workspace
-names one, the pack's craft reference, and the write scope; record
-anything it queues into the worklog's `queued_scope`.
+run, this body skips decomposition and its critique and re-enters the
+frontier over the existing tickets; the gate crosses only once every
+unit item is complete. Otherwise the terminal assembly item, if the pack
+declares one, runs last, per
+[rules/topology.md](../../../rules/topology.md) rule 4. Cross one
+`orch-review-fix` gate, supplying its Require by name: the fixed result
+identity (the assembled artifact), the pack's stamped lens, the pack's
+oracle policy, the spec, the standards owner by pointer where the
+workspace names one, the pack's craft reference, and the write scope;
+record anything it queues into the worklog's `queued_scope`.
 Finish with `orch-verify` over the spec's acceptance under the pack's
 oracle policy, reusing the gate's covered verdicts and verifying only
 uncovered criteria per
-[rules/verification.md](../../../rules/verification.md) §7; a judged or
-evidence overall verdict is reported as such, never laundered into a
-deterministic green. Set the worklog terminal state through
-`orch-worklog` at close.
+[rules/verification.md](../../../rules/verification.md) §7. Set the
+worklog terminal state through `orch-worklog` at close.
 
 Never: edit the spec; run a second gate; end a judged run on its own
 claimed green; cross the gate with an open unit item.

--- a/skills/workflows/orch-deliver/references/cut-lens.md
+++ b/skills/workflows/orch-deliver/references/cut-lens.md
@@ -1,0 +1,28 @@
+# Cut lens (for `orch-critique` over an issued ticket set)
+
+Judge the cut, never the deliverable, from the frozen spec and the
+issued items alone.
+
+- Scope coverage: each item's `write_scope` covers every artifact its
+  own objective and completion test name, resolved against the
+  workspace before issue
+  ([rules/topology.md](../../../../rules/topology.md) §3).
+- Self-contradiction: `excluded_actions` against `write_scope`
+  ([contracts/work-item.md](../../../../contracts/work-item.md)),
+  criteria that cannot jointly hold, an item stricter than the spec it
+  cuts.
+- Decidable criteria: each names an oracle that can FAIL against a wrong
+  result, and states a condition rather than a reading of current state
+  ([rules/verification.md](../../../../rules/verification.md) §3, §8).
+- Acceptance coverage: every spec criterion reaches an item, the gate,
+  or declared remainder; every item reaches a criterion.
+- Unowned outcome: some item's completion test observes the spec's
+  outcome across item boundaries, in the pack's workspace semantics — a
+  set whose oracles each exercise only inputs they construct themselves
+  decides nothing about what crosses between them.
+- Slicing fidelity: the cut is the shape the stamped pack's `slicing`
+  cell prescribes, terminal assembly item included
+  ([contracts/pack-signature.md](../../../../contracts/pack-signature.md)).
+- Parallel safety: sibling items share no write scope and no output
+  field ([rules/composition.md](../../../../rules/composition.md) §7);
+  an overlap appears only where an edge orders them.


### PR DESCRIPTION
## The gap

orchflows applies independence rigorously to **results** and not at all to **plans**. `rules/verification.md` §10:

> Acceptance resting only on checks the executing context authored is UNVERIFIED.

Yet `orch-decompose` self-reports its own `uncovered remainder` and `decision_gap`, and nothing re-derives them. `orch-review-fix` — the one gate — reviews the revision, not the cut.

Mining this repository's friction logs (912 entries) and completed tickets (~122 across 22 runs since 2026-07-25) puts **~92% of defects in the cut rather than the executor**:

- A **53-instance** cluster of `write_scope` narrower than the completion test paired with it in the same ticket, across eight runs and two repositories. One entry: *"The decomposition wrote both, in the same ticket, and they disagreed twice out of three dispatched items."*
- One run where **four tickets went green while the feature was inert on every production path**, because every completion test built its own fixture and no item owned what ran between them. Found only by the gate reviewer, after merge.

Spec Kit reaches the same conclusion from the other direction: `/speckit.analyze` is a read-only cross-artifact pass between task generation and implementation, and one of its detection classes is literally *"tasks referencing files or components not defined in spec/plan."*

## What changed

`orch-deliver` critiques the cut through `orch-critique`, in a context independent of the decomposition, before entering the frontier. Gated on cut shape — more than one item, or any edge — since on a single-item zero-edge cut most of the lens is vacuous. One re-cut through `orch-decompose` answers a blocking finding; a second rides the `decision_gap` already in this body. Resumption skips the critique along with decomposition, so a re-entered run neither pays again nor raises findings against tickets already `complete`.

`references/cut-lens.md` carries seven checks, each pointing at its owner rather than restating it: scope coverage, self-contradiction, decidable criteria, acceptance coverage, unowned outcome, slicing fidelity, parallel safety.

**Placement** follows `library-lens.md` — the caller owns the lens. It cannot live in a pack's `lens` cell, which `contracts/pack-signature.md` binds to the deliverable revision at the gate; and four pack copies would be four copies of one T0 law.

**Budget.** `orch-deliver` was at exactly 40/40, the workflows limit. Paid for by deleting three restatements the library already forbids — `composition` §9 (domain blindness), `topology` §4's invalidation clause, and a verdict-laundering sentence whose owner `contracts/verdict.md` is declared by `rules/verification.md` §5 to be its only statement. Final body: 40/40.

## Verification

- `python3 tools/validate.py` — exit 0
- `python3 -m unittest discover -s tests` — 901 tests, OK (4 skipped)
- `python3 install.py --dry-run` — exit 0, `cut-lens.md` ships in the plan
- `git diff --check` — clean

Gated twice in independent contexts under the library lens.

- **Round one: REJECT**, nine findings. Two were domain leaks in the lens itself — "seam" is code-pack craft vocabulary (`packs/orch-code-pack/references/craft.md:7`) and "fixture" means a frozen replayable ticket here (`docs/vocabulary.md:265`), not a test double. Also: the call supplied no fixed artifact identity, breaching `composition` §10.
- **Round two: REJECT**, one blocking finding — the re-cut had no named executor, admitting a reading where `orch-deliver` edits the tickets itself and destroys the independence the critique just bought. It also caught that its own round-one replacement wording used "joins", which `docs/vocabulary.md:187` defines as `orch-integrate`.

## Recorded, not fixed here

- `orch-frontier`'s ad-hoc-set route (`topology` §2) also cuts tickets with edges and gets no critique.
- `composition` §9 binds *skills* but not a generic package's `references/` — which is exactly where both lens leaks landed.
- `contracts/result.md`'s Return shape does not name the plan fields this body returns (`items`, `edges`, `budgets`, `risks`, now `findings`) — pre-existing, widened by one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
