### PR TITLE
Ship one default binding and let one machine overlay it

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,8 @@ routing block for a repo. Uninstall: `python install.py --user
 --uninstall` removes only what it generated; `--dry-run` previews
 either. Default model bindings: the planner/reviewer is Fable 5 on
 high effort (Claude Code) or GPT-5.6 Sol on ultra (Codex); workers are
-Sonnet 5 on xhigh and GPT-5.6 Sol on high.
+Opus 5 on high and GPT-5.6 Sol on high. One machine overrides only the
+cells it differs on in `~/.orchflows/profiles.local.md`.
 
 ## The interesting parts
 

--- a/install.py
+++ b/install.py
@@ -106,6 +106,8 @@ HOST_BLOCK_TEMPLATE = REPO_ROOT / "templates" / "host-block.md"
 CODEX_LIMITS_START = "# BEGIN ORCHFLOWS AGENT LIMITS"
 CODEX_LIMITS_END = "# END ORCHFLOWS AGENT LIMITS"
 PROFILE_ROLES = ("planner", "worker")
+HOST_BINDINGS = ("codex", "claude")
+PROFILES_LOCAL_NAME = "profiles.local.md"
 # The routed composition ``fix`` replaced the demoted ``orch-fix`` skill.
 CODEX_SKILL_REDIRECT_NAMES = ("orch-spec", "orch-task", "fix", "orch-build")
 AUTO_REMOVE_KINDS = frozenset(("adapter", "prompt", "codex-skill"))
@@ -346,9 +348,8 @@ def _parse_binding(cell: str) -> dict:
     return {match.group("key"): match.group("value") for match in _BINDING_RE.finditer(cell)}
 
 
-def load_role_profiles(profiles_md_path: Path = PROFILES_MD):
-    text = profiles_md_path.read_text(encoding="utf-8")
-    profiles = {}
+def _profile_rows(text: str) -> dict:
+    rows = {}
     for line in text.splitlines():
         cells = [cell.strip() for cell in line.strip().strip("|").split("|")]
         if len(cells) != 4 or not cells[0].startswith("`orch-"):
@@ -357,22 +358,64 @@ def load_role_profiles(profiles_md_path: Path = PROFILES_MD):
         role = cells[1]
         if role not in PROFILE_ROLES:
             continue
-        profiles[name] = {"role": role, "codex": _parse_binding(cells[2]), "claude": _parse_binding(cells[3])}
+        rows[name] = {"role": role, "codex": _parse_binding(cells[2]), "claude": _parse_binding(cells[3])}
+    return rows
+
+
+def local_profiles_path() -> Path:
+    """This machine's optional binding overlay: never generated, never removed.
+
+    A host whose bindings differ from the shipped defaults states only the
+    differing cells here, so the rest keeps tracking the library. The
+    rendered agent then equals what the installer expects and the receipt
+    stays consistent, which a hand-edit of a generated agent cannot do.
+    """
+
+    return Path.home() / ".orchflows" / PROFILES_LOCAL_NAME
+
+
+def load_role_profiles(profiles_md_path: Path = PROFILES_MD, local_path: Path | None = None):
+    """The shipped bindings, optionally overlaid by one machine's own.
+
+    ``local_path`` defaults to no overlay rather than to this machine's,
+    so the shipped table is what a bare call reads and a test never
+    inherits the developer's own bindings. ``build_plan`` is what opts a
+    real install in, by naming :func:`local_profiles_path`.
+    """
+
+    profiles = _profile_rows(profiles_md_path.read_text(encoding="utf-8"))
     missing = [f"orch-{role}" for role in PROFILE_ROLES if f"orch-{role}" not in profiles]
     if missing:
         raise ValueError(f"{profiles_md_path}: missing role profile row(s) for {', '.join(missing)}")
+
+    # Which file each host binding came from, so a rejected cell names the
+    # file its author would open rather than the one it was merged into.
+    origin = {name: dict.fromkeys(HOST_BINDINGS, profiles_md_path) for name in profiles}
+    overlay = local_path
+    if overlay is not None and overlay.is_file():
+        for name, row in _profile_rows(overlay.read_text(encoding="utf-8")).items():
+            if name not in profiles:
+                raise ValueError(f"{overlay}: unknown role profile: {name}")
+            for host in HOST_BINDINGS:
+                # An empty cell inherits; a stated one replaces that host
+                # outright, since a half-stated binding names no model.
+                if row[host]:
+                    profiles[name][host] = row[host]
+                    origin[name][host] = overlay
+
     codex_agent_types = set()
     for name, profile in profiles.items():
+        codex_from, claude_from = origin[name]["codex"], origin[name]["claude"]
         if not {"agent_type", "model", "model_reasoning_effort"} <= set(profile["codex"]):
-            raise ValueError(f"{profiles_md_path}: incomplete Codex binding for {name}")
+            raise ValueError(f"{codex_from}: incomplete Codex binding for {name}")
         agent_type = profile["codex"]["agent_type"]
         if _CODEX_AGENT_TYPE_RE.fullmatch(agent_type) is None:
-            raise ValueError(f"{profiles_md_path}: invalid Codex agent_type for {name}: {agent_type}")
+            raise ValueError(f"{codex_from}: invalid Codex agent_type for {name}: {agent_type}")
         if agent_type in codex_agent_types:
-            raise ValueError(f"{profiles_md_path}: duplicate Codex agent_type: {agent_type}")
+            raise ValueError(f"{codex_from}: duplicate Codex agent_type: {agent_type}")
         codex_agent_types.add(agent_type)
         if "model" not in profile["claude"]:
-            raise ValueError(f"{profiles_md_path}: incomplete Claude binding for {name}")
+            raise ValueError(f"{claude_from}: incomplete Claude binding for {name}")
     return profiles
 
 
@@ -883,7 +926,7 @@ def _build_user_plan() -> Plan:
                 )
 
     roles_path = (lib_home / "rules" / "roles.md").resolve()
-    profiles = load_role_profiles()
+    profiles = load_role_profiles(local_path=local_profiles_path())
     claude_agents = []
     codex_agents = []
     for name in (f"orch-{role}" for role in PROFILE_ROLES):

--- a/skills/kernel/orch-delegate/references/profiles.md
+++ b/skills/kernel/orch-delegate/references/profiles.md
@@ -5,8 +5,15 @@ file solely owns default model mappings and the child-naming algorithm.
 
 | Profile | Role | Codex | Claude Code |
 | --- | --- | --- | --- |
-| `orch-planner` | planner | agent_type `orch_planner`, model `gpt-5.6-sol`, model_reasoning_effort `ultra` | model `claude-opus-5`, effort `xhigh` |
-| `orch-worker` | worker | agent_type `orch_worker`, model `gpt-5.6-sol`, model_reasoning_effort `high`, service_tier `fast` | model `claude-opus-5`, effort `xhigh` |
+| `orch-planner` | planner | agent_type `orch_planner`, model `gpt-5.6-sol`, model_reasoning_effort `ultra` | model `claude-fable-5`, effort `high` |
+| `orch-worker` | worker | agent_type `orch_worker`, model `gpt-5.6-sol`, model_reasoning_effort `high`, service_tier `fast` | model `claude-opus-5`, effort `high` |
+
+A machine whose bindings differ states only the differing cells in
+`~/.orchflows/profiles.local.md` — the same four-column table, an empty
+cell inheriting the row above. The installer merges it over this file, so
+the rendered agent is what the receipt records and a reinstall stays
+clean. Editing a generated role agent instead sets the same value and
+blocks every later install.
 
 Use native invocation fields when available; a prompt-only request is
 requested, not verified. An unsupported or blocked model binding stops

--- a/tests/test_installer.py
+++ b/tests/test_installer.py
@@ -274,6 +274,117 @@ class TestScopedHostConfiguration(unittest.TestCase):
             with self.assertRaisesRegex(ValueError, "invalid Codex agent_type"):
                 install.load_role_profiles(profiles)
 
+    def test_shipped_claude_bindings_are_the_documented_defaults(self):
+        profiles = install.load_role_profiles()
+
+        self.assertEqual(
+            {"model": "claude-fable-5", "effort": "high"}, profiles["orch-planner"]["claude"]
+        )
+        self.assertEqual(
+            {"model": "claude-opus-5", "effort": "high"}, profiles["orch-worker"]["claude"]
+        )
+
+    def test_bare_load_reads_no_machine_overlay(self):
+        # The default is no overlay, so this suite never inherits the
+        # bindings of whichever machine happens to run it -- an overlay
+        # sitting at the real path must not reach a bare call.
+        with tempfile.TemporaryDirectory() as tmp:
+            home = Path(tmp)
+            (home / ".orchflows").mkdir(parents=True)
+            (home / ".orchflows" / install.PROFILES_LOCAL_NAME).write_text(
+                "| Profile | Role | Codex | Claude Code |\n"
+                "| --- | --- | --- | --- |\n"
+                "| `orch-worker` | worker |  | model `claude-opus-5`, effort `max` |\n",
+                encoding="utf-8",
+            )
+
+            with patch.object(install.Path, "home", return_value=home):
+                profiles = install.load_role_profiles()
+
+            self.assertEqual(
+                {"model": "claude-opus-5", "effort": "high"}, profiles["orch-worker"]["claude"]
+            )
+
+    def test_local_overlay_replaces_only_the_cells_it_states(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            overlay = Path(tmp) / install.PROFILES_LOCAL_NAME
+            overlay.write_text(
+                "| Profile | Role | Codex | Claude Code |\n"
+                "| --- | --- | --- | --- |\n"
+                "| `orch-planner` | planner |  | model `claude-opus-5`, effort `max` |\n"
+                "| `orch-worker` | worker |  | model `claude-opus-5`, effort `xhigh` |\n",
+                encoding="utf-8",
+            )
+
+            shipped = install.load_role_profiles()
+            merged = install.load_role_profiles(local_path=overlay)
+
+            self.assertEqual(
+                {"model": "claude-opus-5", "effort": "max"}, merged["orch-planner"]["claude"]
+            )
+            self.assertEqual(
+                {"model": "claude-opus-5", "effort": "xhigh"}, merged["orch-worker"]["claude"]
+            )
+            # An empty Codex cell inherits rather than blanking the row.
+            for name in ("orch-planner", "orch-worker"):
+                self.assertEqual(shipped[name]["codex"], merged[name]["codex"])
+
+    def test_absent_overlay_leaves_the_shipped_table(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            absent = Path(tmp) / install.PROFILES_LOCAL_NAME
+
+            self.assertEqual(
+                install.load_role_profiles(),
+                install.load_role_profiles(local_path=absent),
+            )
+
+    def test_overlay_naming_an_unknown_profile_is_rejected(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            overlay = Path(tmp) / install.PROFILES_LOCAL_NAME
+            overlay.write_text(
+                "| Profile | Role | Codex | Claude Code |\n"
+                "| --- | --- | --- | --- |\n"
+                "| `orch-reviewer` | planner |  | model `claude-opus-5`, effort `max` |\n",
+                encoding="utf-8",
+            )
+
+            with self.assertRaisesRegex(ValueError, "unknown role profile: orch-reviewer"):
+                install.load_role_profiles(local_path=overlay)
+
+    def test_overlay_binding_without_a_model_names_the_overlay_file(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            overlay = Path(tmp) / install.PROFILES_LOCAL_NAME
+            overlay.write_text(
+                "| Profile | Role | Codex | Claude Code |\n"
+                "| --- | --- | --- | --- |\n"
+                "| `orch-worker` | worker |  | effort `max` |\n",
+                encoding="utf-8",
+            )
+
+            with self.assertRaisesRegex(ValueError, rf"{re.escape(str(overlay))}: incomplete Claude"):
+                install.load_role_profiles(local_path=overlay)
+
+    def test_rendered_claude_agent_carries_the_overlaid_effort(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            home = Path(tmp)
+            (home / ".claude").mkdir(parents=True)
+            (home / ".orchflows").mkdir(parents=True)
+            (home / ".orchflows" / install.PROFILES_LOCAL_NAME).write_text(
+                "| Profile | Role | Codex | Claude Code |\n"
+                "| --- | --- | --- | --- |\n"
+                "| `orch-planner` | planner |  | model `claude-opus-5`, effort `max` |\n",
+                encoding="utf-8",
+            )
+
+            with patch.object(install.Path, "home", return_value=home), mock_host_clis("claude"):
+                plan = install.build_plan("user", None)
+
+            planner = next(
+                content for dest, content in plan.claude_agents if dest.name == "orch-planner.md"
+            )
+            self.assertIn("model: claude-opus-5", planner)
+            self.assertIn("effort: max", planner)
+
     @requires_tomllib
     def test_codex_role_agent_names_follow_spawn_identifier_grammar(self):
         with tempfile.TemporaryDirectory() as tmp:


### PR DESCRIPTION
Two changes that only make sense together: the shipped Claude bindings change, and `install.py` learns to read one machine's overlay so a host that wants something else no longer has to lie to the installer.

## Shipped defaults

| Profile | Claude Code — before | Claude Code — after |
|---|---|---|
| `orch-planner` | `claude-opus-5`, effort `xhigh` | **`claude-fable-5`, effort `high`** |
| `orch-worker` | `claude-opus-5`, effort `xhigh` | **`claude-opus-5`, effort `high`** |

Codex bindings untouched.

## There was no override mechanism

`_preflight_role_agents` refuses to overwrite a role agent that differs from what `profiles.md` renders *and* whose hash doesn't match the receipt. That's an anti-clobber guard, not a feature. The only way to run different bindings was to hand-edit generated output — which the host block forbids, and which then blocks every later install:

```
error: install failed: refusing to overwrite native role profile(s):
  ~/.claude/agents/orch-planner.md (changed since the recorded install)
```

This host was already in exactly that state.

## The overlay

`~/.orchflows/profiles.local.md` is merged over the shipped table:

```
| Profile | Role | Codex | Claude Code |
| --- | --- | --- | --- |
| `orch-planner` | planner |  | model `claude-opus-5`, effort `max` |
| `orch-worker` | worker |  | model `claude-opus-5`, effort `xhigh` |
```

Same four columns. An **empty cell inherits**; a **stated cell replaces that host's binding outright**, since a half-stated binding names no model. A row naming a profile that doesn't exist is **rejected, not ignored**. A rejected cell names the file its author would open — the overlay, not the shipped table it was merged into.

It's read by the installer, never written by it, so `--uninstall` leaves it alone.

## Hermetic by default

`load_role_profiles` defaults to **no** overlay rather than to this machine's. A bare call reads the shipped table, so the suite can't inherit the bindings of whichever machine runs it; `build_plan` is the single caller that opts a real install in. `test_bare_load_reads_no_machine_overlay` plants an overlay at the real path and proves a bare call ignores it.

## It makes the existing hand-edit lawful rather than stranding it

With the overlay in place, both rendered agents are byte-identical to what's already on disk, so the preflight's `current == desired` branch short-circuits and nothing has to be moved:

```
orch-planner {'model': 'claude-opus-5', 'effort': 'max'}
orch-worker  {'model': 'claude-opus-5', 'effort': 'xhigh'}
orch-planner.md        IDENTICAL
orch-worker.md         IDENTICAL
```

## README

Stale in both Claude cells. "Fable 5 on high" happens to be right again; "Sonnet 5 on xhigh" was never right after opus-5 was adopted. `profiles.md` solely owns these mappings, so README restates them and points at the overlay.

## Tests

Seven new: shipped defaults, overlay merge with Codex inheritance, absent overlay, unknown profile rejected, incomplete overlay binding naming the overlay file, the rendered agent carrying the overlaid effort, and the hermetic default.

- `python tools/validate.py` — silent
- `python -m unittest discover -s tests` — `Ran 908 tests … OK (skipped=4)` (901 before)
- `git diff --check` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
