### PR TITLE
Ask before replacing a role agent this machine changed

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,8 @@ routing block for a repo. Uninstall: `python install.py --user
 --uninstall` removes only what it generated; `--dry-run` previews
 either. Default model bindings: the planner/reviewer is Fable 5 on
 high effort (Claude Code) or GPT-5.6 Sol on ultra (Codex); workers are
-Sonnet 5 on xhigh and GPT-5.6 Sol on high.
+Opus 5 on high and GPT-5.6 Sol on high. Edit a rendered role agent to
+run your own; installs ask before replacing it and keep it by default.
 
 ## The interesting parts
 

--- a/install.py
+++ b/install.py
@@ -1123,14 +1123,20 @@ def _remove_stale(old_receipt, kind: str, keep_paths: set, boundary: Path) -> No
         _prune_empty_dirs(path.parent, boundary)
 
 
-def _preflight_role_agents(plan: Plan, old_receipt: dict | None) -> None:
-    """Refuse to replace native role profiles not owned by an unchanged receipt."""
+def _diverged_role_agents(plan: Plan, old_receipt: dict | None) -> list:
+    """Role agents on disk whose content is not what this install would write.
+
+    Returned rather than raised: the ordinary reason is a machine
+    deliberately running different bindings, and the caller asks before
+    replacing one. A path that is not a regular file still raises, since
+    writing through it would clobber something this installer never made.
+    """
 
     old_entries = {
         (entry.get("path"), entry.get("kind")): entry
         for entry in (old_receipt or {}).get("files", [])
     }
-    conflicts = []
+    unwritable, diverged = [], []
     for kind, files in (
         ("claude-agent", plan.claude_agents),
         ("codex-agent", plan.codex_agents),
@@ -1139,30 +1145,53 @@ def _preflight_role_agents(plan: Plan, old_receipt: dict | None) -> None:
             if not path.exists() and not path.is_symlink():
                 continue
             if not path.is_file() or path.is_symlink():
-                conflicts.append(f"{path} (not a regular file)")
+                unwritable.append(f"{path} (not a regular file)")
                 continue
-            current = path.read_text(encoding="utf-8")
-            if current == desired:
+            if path.read_text(encoding="utf-8") == desired:
                 continue
             old_entry = old_entries.get((str(path), kind))
             recorded_hash = old_entry.get("sha256") if old_entry else None
             if not recorded_hash:
-                conflicts.append(f"{path} (not owned by this install receipt)")
-                continue
-            if _sha256_file(path) != recorded_hash:
-                conflicts.append(f"{path} (changed since the recorded install)")
+                diverged.append((path, kind, "not written by this installer"))
+            elif _sha256_file(path) != recorded_hash:
+                diverged.append((path, kind, "edited since the last install"))
 
-    if conflicts:
-        rendered = "\n  ".join(conflicts)
+    if unwritable:
         raise FileExistsError(
-            "refusing to overwrite native role profile(s):\n  "
-            f"{rendered}\nMove or remove the conflicting files, then reinstall."
+            "refusing to write role profile(s) that are not regular files:\n  "
+            + "\n  ".join(unwritable)
+            + "\nMove or remove them, then reinstall."
         )
+    return diverged
 
 
-def apply_plan(plan: Plan) -> dict:
+def _prompt_keep_role_agents(diverged: list) -> bool:
+    print("These orchflows role agents differ from the shipped bindings:")
+    for path, _kind, reason in diverged:
+        print(f"  {path} ({reason})")
+    print("Keep them? [Y] keep this machine's  [n] overwrite with the defaults")
+    try:
+        choice = input("> ").strip().lower()
+    except EOFError:
+        # Non-interactive: keep, because reverting a deliberate binding
+        # unasked is the one outcome nobody can undo from the receipt.
+        choice = ""
+    return choice != "n"
+
+
+def apply_plan(plan: Plan, keep_role_agents: bool | None = None) -> dict:
     old_receipt = _load_json(plan.receipt_path)
-    _preflight_role_agents(plan, old_receipt)
+    diverged = _diverged_role_agents(plan, old_receipt)
+    # A kept agent stays in the plan so ``_remove_stale`` still counts it as
+    # wanted; only its write is skipped. Dropping it from the plan would
+    # delete the very file the answer asked to keep. It is left out of the
+    # receipt too, so the next install asks again rather than silently
+    # reverting a binding whose hash it had adopted as its own.
+    kept_role_agents = set()
+    if diverged:
+        keep = _prompt_keep_role_agents(diverged) if keep_role_agents is None else keep_role_agents
+        if keep:
+            kept_role_agents = {(str(path), kind) for path, kind, _ in diverged}
     old_entries = {
         (entry.get("path"), entry.get("kind")): entry
         for entry in (old_receipt or {}).get("files", [])
@@ -1236,6 +1265,9 @@ def apply_plan(plan: Plan) -> dict:
         ):
             _remove_stale(old_receipt, kind, {str(dest) for dest, _ in files}, boundary)
             for dest, content in files:
+                if (str(dest), kind) in kept_role_agents:
+                    print(f"keeping this machine's {dest}")
+                    continue
                 action = install_action(dest, kind, dest.is_file())
                 dest.parent.mkdir(parents=True, exist_ok=True)
                 dest.write_text(content, encoding="utf-8")
@@ -1549,7 +1581,11 @@ def build_arg_parser() -> argparse.ArgumentParser:
         metavar="PATH",
         help="Install scope: project, optionally at PATH (default: current directory).",
     )
-    parser.add_argument("--yes", action="store_true", help="Skip the interactive scope prompt (defaults to user).")
+    parser.add_argument(
+        "--yes",
+        action="store_true",
+        help="Skip the prompts: user scope, and keep any role agent this machine has changed.",
+    )
     parser.add_argument("--dry-run", action="store_true", help="Print the full plan; write nothing.")
     parser.add_argument(
         "--uninstall",
@@ -1633,7 +1669,7 @@ def main(argv=None) -> int:
 
     old_receipt = _load_json(plan.receipt_path)
     try:
-        receipt = apply_plan(plan)
+        receipt = apply_plan(plan, keep_role_agents=True if args.yes else None)
     except Exception as error:
         print(f"error: install failed: {error}", file=sys.stderr)
         return 1

--- a/skills/kernel/orch-delegate/references/profiles.md
+++ b/skills/kernel/orch-delegate/references/profiles.md
@@ -5,8 +5,12 @@ file solely owns default model mappings and the child-naming algorithm.
 
 | Profile | Role | Codex | Claude Code |
 | --- | --- | --- | --- |
-| `orch-planner` | planner | agent_type `orch_planner`, model `gpt-5.6-sol`, model_reasoning_effort `ultra` | model `claude-opus-5`, effort `xhigh` |
-| `orch-worker` | worker | agent_type `orch_worker`, model `gpt-5.6-sol`, model_reasoning_effort `high`, service_tier `fast` | model `claude-opus-5`, effort `xhigh` |
+| `orch-planner` | planner | agent_type `orch_planner`, model `gpt-5.6-sol`, model_reasoning_effort `ultra` | model `claude-fable-5`, effort `high` |
+| `orch-worker` | worker | agent_type `orch_worker`, model `gpt-5.6-sol`, model_reasoning_effort `high`, service_tier `fast` | model `claude-opus-5`, effort `high` |
+
+One machine runs different bindings by editing its own rendered role
+agent. The installer asks before replacing one it did not last write, and
+keeping it is the default; nothing else has to change.
 
 Use native invocation fields when available; a prompt-only request is
 requested, not verified. An unsupported or blocked model binding stops

--- a/tests/test_installer.py
+++ b/tests/test_installer.py
@@ -137,7 +137,19 @@ class TestInstallReceipt(unittest.TestCase):
                 self.assertEqual(digest(Path(entry["path"])), entry["sha256"])
             self.assertEqual("added-block", receipt["blocks"][0]["install_action"])
 
-    def test_unowned_role_profile_blocks_install_before_any_write(self):
+    def _role_agent_plan(self, project: Path, **kwargs) -> "install.Plan":
+        defaults = dict(
+            scope="project",
+            project_root=project,
+            lib_home=project / ".orchflows" / "lib",
+            scope_home=project / ".orchflows",
+            bin_dir=project / ".orch" / "bin",
+            receipt_path=project / ".orchflows" / "receipt.json",
+        )
+        defaults.update(kwargs)
+        return install.Plan(**defaults)
+
+    def test_unowned_role_profile_is_kept_and_the_install_proceeds(self):
         with tempfile.TemporaryDirectory() as tmp:
             project = Path(tmp)
             source = project / "source.md"
@@ -146,32 +158,33 @@ class TestInstallReceipt(unittest.TestCase):
             agent = project / ".codex" / "agents" / "orch-worker.toml"
             agent.parent.mkdir(parents=True)
             agent.write_text("personal = true\n", encoding="utf-8")
-            plan = install.Plan(
-                scope="project",
-                project_root=project,
-                lib_home=project / ".orchflows" / "lib",
-                scope_home=project / ".orchflows",
-                bin_dir=project / ".orch" / "bin",
-                receipt_path=project / ".orchflows" / "receipt.json",
+            plan = self._role_agent_plan(
+                project,
                 lib_copies=[(source, lib_dest)],
                 codex_agents=[(agent, 'name = "orch-worker"\n')],
             )
 
-            with self.assertRaisesRegex(FileExistsError, "not owned"):
-                install.apply_plan(plan)
+            receipt = install.apply_plan(plan, keep_role_agents=True)
 
             self.assertEqual("personal = true\n", agent.read_text(encoding="utf-8"))
-            self.assertFalse(lib_dest.exists())
+            # The rest of the install is no longer collateral of one
+            # diverged agent: the library still lands.
+            self.assertTrue(lib_dest.exists())
+            # ...and the kept agent is left out of the receipt, so the next
+            # install asks again instead of adopting its hash as its own.
+            self.assertNotIn(
+                str(agent), {entry["path"] for entry in receipt["files"]}
+            )
 
-    def test_modified_receipt_owned_role_profile_blocks_reinstall(self):
+    def test_modified_receipt_owned_role_profile_is_kept(self):
         with tempfile.TemporaryDirectory() as tmp:
             project = Path(tmp)
             agent = project / ".claude" / "agents" / "orch-planner.md"
             agent.parent.mkdir(parents=True)
             agent.write_text("modified\n", encoding="utf-8")
-            receipt = project / ".orchflows" / "receipt.json"
-            receipt.parent.mkdir(parents=True)
-            receipt.write_text(
+            receipt_path = project / ".orchflows" / "receipt.json"
+            receipt_path.parent.mkdir(parents=True)
+            receipt_path.write_text(
                 json.dumps(
                     {
                         "files": [
@@ -185,20 +198,40 @@ class TestInstallReceipt(unittest.TestCase):
                 ),
                 encoding="utf-8",
             )
-            plan = install.Plan(
-                scope="project",
-                project_root=project,
-                lib_home=project / ".orchflows" / "lib",
-                scope_home=project / ".orchflows",
-                bin_dir=project / ".orch" / "bin",
-                receipt_path=receipt,
-                claude_agents=[(agent, "updated\n")],
+            plan = self._role_agent_plan(
+                project, receipt_path=receipt_path, claude_agents=[(agent, "updated\n")]
             )
 
-            with self.assertRaisesRegex(FileExistsError, "changed since"):
-                install.apply_plan(plan)
+            install.apply_plan(plan, keep_role_agents=True)
 
-    def test_legacy_header_role_profile_without_receipt_blocks_install(self):
+            # A receipt-owned path dropped from the plan would be deleted as
+            # stale; keeping it must not mean losing it.
+            self.assertTrue(agent.is_file())
+            self.assertEqual("modified\n", agent.read_text(encoding="utf-8"))
+
+    def test_modified_role_profile_is_replaced_when_overwrite_is_chosen(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            project = Path(tmp)
+            agent = project / ".claude" / "agents" / "orch-planner.md"
+            agent.parent.mkdir(parents=True)
+            agent.write_text("modified\n", encoding="utf-8")
+            plan = self._role_agent_plan(project, claude_agents=[(agent, "updated\n")])
+
+            install.apply_plan(plan, keep_role_agents=False)
+
+            self.assertEqual("updated\n", agent.read_text(encoding="utf-8"))
+
+    def test_role_profile_that_is_not_a_regular_file_still_refuses(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            project = Path(tmp)
+            agent = project / ".claude" / "agents" / "orch-planner.md"
+            agent.mkdir(parents=True)
+            plan = self._role_agent_plan(project, claude_agents=[(agent, "updated\n")])
+
+            with self.assertRaisesRegex(FileExistsError, "not a regular file"):
+                install.apply_plan(plan, keep_role_agents=True)
+
+    def test_legacy_header_role_profile_without_receipt_is_kept(self):
         with tempfile.TemporaryDirectory() as tmp:
             project = Path(tmp)
             agent = project / ".codex" / "agents" / "orch-worker.toml"
@@ -208,20 +241,23 @@ class TestInstallReceipt(unittest.TestCase):
                 "# This complete file is replaced on every orchflows install.\n"
             )
             agent.write_text(legacy_header + "old = true\n", encoding="utf-8")
-            plan = install.Plan(
-                scope="project",
-                project_root=project,
-                lib_home=project / ".orchflows" / "lib",
-                scope_home=project / ".orchflows",
-                bin_dir=project / ".orch" / "bin",
-                receipt_path=project / ".orchflows" / "receipt.json",
-                codex_agents=[(agent, 'name = "orch-worker"\n')],
+            plan = self._role_agent_plan(
+                project, codex_agents=[(agent, 'name = "orch-worker"\n')]
             )
 
-            with self.assertRaisesRegex(FileExistsError, "not owned"):
-                install.apply_plan(plan)
+            install.apply_plan(plan, keep_role_agents=True)
 
             self.assertEqual(legacy_header + "old = true\n", agent.read_text(encoding="utf-8"))
+
+    def test_shipped_claude_bindings_are_the_documented_defaults(self):
+        profiles = install.load_role_profiles()
+
+        self.assertEqual(
+            {"model": "claude-fable-5", "effort": "high"}, profiles["orch-planner"]["claude"]
+        )
+        self.assertEqual(
+            {"model": "claude-opus-5", "effort": "high"}, profiles["orch-worker"]["claude"]
+        )
 
     def test_reinstall_removes_receipt_owned_hyphenated_codex_agent(self):
         with tempfile.TemporaryDirectory() as tmp:


### PR DESCRIPTION
The shipped Claude bindings change, and a diverged role agent stops being a fatal error.

## Shipped defaults

| Profile | Claude Code — before | Claude Code — after |
|---|---|---|
| `orch-planner` | `claude-opus-5`, effort `xhigh` | **`claude-fable-5`, effort `high`** |
| `orch-worker` | `claude-opus-5`, effort `xhigh` | **`claude-opus-5`, effort `high`** |

Codex bindings untouched.

## The abort was the bug

`_preflight_role_agents` refused the **whole install** when it found a role agent that differed from what `profiles.md` renders and whose hash didn't match the receipt:

```
error: install failed: refusing to overwrite native role profile(s):
  ~/.claude/agents/orch-planner.md (changed since the recorded install)
Move or remove the conflicting files, then reinstall.
```

That's an anti-clobber guard doing the only thing it could, and the cost was total — one edited agent blocked every later install, library and all. This host was in exactly that state and no install could run.

It's now `_diverged_role_agents`, which *returns* what it found, and `apply_plan` asks:

```
These orchflows role agents differ from the shipped bindings:
  ~/.claude/agents/orch-planner.md (edited since the last install)
Keep them? [Y] keep this machine's  [n] overwrite with the defaults
> 
```

Keeping is the default answer. A non-interactive run keeps without asking, because reverting a deliberate binding unasked is the one outcome the receipt cannot undo. `--yes` keeps too, and its help now says so.

So overriding the defaults needs no new concept: **edit the rendered role agent, rerun install, say keep.**

## Two traps this had to avoid

**A kept agent stays in the plan.** `_remove_stale` deletes every receipt-listed path of that kind absent from the plan, so filtering a kept agent out of the plan would *delete the file the answer just asked to keep*. Only the write is skipped.

**A kept agent is left out of the new receipt.** If its hash were recorded, the next install would see `current != desired` with a matching hash — the "we own this" branch — and silently revert it. Omitting it means the next install asks again. Stateless and honest.

A path that is not a regular file still raises: writing through a symlink would clobber a target this installer never made.

## Tests

Three changed meaning and say so in their names — an unowned profile, a modified receipt-owned profile, and a legacy-header profile are now **kept** rather than blocking. The first also asserts the library still lands (the rest of the install is no longer collateral of one diverged agent) and that the kept path is absent from the receipt.

Three added: overwrite replaces, a non-regular file still refuses, and the shipped bindings are the documented ones.

- `python tools/validate.py` — silent
- `python -m unittest discover -s tests` — `Ran 904 tests … OK (skipped=4)`
- `git diff --check` — clean

## Note for anyone on the old default

An agent still holding the previous `xhigh` default has a hash matching its receipt, so it counts as installer-owned and moves to the new `high` without a prompt. To pin a different value, edit the file after installing; from then on it's detected and preserved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
