### PR TITLE
Give the eight CI cells a local answer instead of a four-minute round trip

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -44,6 +44,22 @@ python -m unittest discover -s tests -v  # serial; proves no cross-module residu
 python install.py --dry-run
 git diff --check
 
+Before pushing, close what can be closed here rather than four minutes
+later in a matrix cell:
+
+python tools/preflight.py   # the whole suite under every CI interpreter installed
+
+Nine cells; a local run is one. Two of the three axes have local
+answers. `tools/run_tests.py --no-cache` schedules alphabetically, as a
+cold checkout does — the duration cache is gitignored, so a warm local
+run and CI co-schedule different modules, and a module only races the
+modules beside it; `preflight.py` runs it under each interpreter CI uses
+that is installed here, and names the ones that are not. What is left is
+the OS axis: `tests/_windows_semantics.py` makes POSIX refuse the
+directory deletions Windows refuses, installed for every runner by
+`tests/__init__.py`, and `tests/test_static_tree_invariants.py` refuses
+the same shape statically. Everything past that is genuinely CI's.
+
 ## Friction law (always on)
 
 The law is `rules/improvement.md` §1; this repository's command:

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,11 @@
+"""Test package. Importing it installs the suite's platform guards.
+
+Every runner that can load a test module imports this first, which is
+why the guards live here rather than in one runner: `tools/run_tests.py`,
+`unittest discover`, and a single `python -m unittest tests.test_x` all
+get the same platform.
+"""
+
+from . import _windows_semantics
+
+_windows_semantics.install()

--- a/tests/_windows_semantics.py
+++ b/tests/_windows_semantics.py
@@ -1,0 +1,104 @@
+"""Make POSIX refuse the directory deletions Windows refuses.
+
+Windows cannot delete a directory that is any process's current
+directory, or any ancestor of one: the open handle behind the CWD holds
+it and the call fails with ``WinError 32``. POSIX carries no such
+handle, so the same code deletes the tree, leaves the process sitting in
+a path that no longer resolves, and passes.
+
+That difference is invisible on this host and fatal on three of CI's
+nine cells, and it is where this suite's Windows failures have come
+from. Installed on POSIX, these guards raise before the deletion so the
+test fails here, where the diagnosis is a stack trace rather than a
+matrix cell. On Windows they are not installed: the platform already
+enforces this, and better.
+
+Imported for effect by ``tests/__init__.py``, so every runner that can
+load a test module has already installed it.
+"""
+
+from __future__ import annotations
+
+import os
+import pathlib
+import shutil
+
+SKIP_ENV = "ORCHFLOWS_NO_WINDOWS_SEMANTICS"
+
+_installed = False
+
+
+class WindowsWouldRefuse(RuntimeError):
+    """A deletion this platform allows and Windows does not.
+
+    Deliberately not an ``OSError``: a caller guarding its own cleanup
+    with ``except OSError`` would swallow the very report this exists to
+    make, and ``TemporaryDirectory(ignore_cleanup_errors=True)`` would
+    do the same.
+    """
+
+
+def _holds_the_cwd(target) -> bool:
+    """True when the process's current directory is at or under ``target``.
+
+    Both sides are resolved because the two can name one directory
+    differently -- a macOS temporary tree is reached as ``/var/...`` and
+    reported as ``/private/var/...`` -- and a prefix test on unresolved
+    names would miss every such case.
+    """
+
+    try:
+        here = os.path.realpath(os.getcwd())
+        there = os.path.realpath(os.fspath(target))
+    except (OSError, ValueError, TypeError):
+        return False  # Nothing to say about a path the OS cannot answer for.
+    return here == there or here.startswith(there + os.sep)
+
+
+def _refuse(target) -> None:
+    raise WindowsWouldRefuse(
+        "Windows would refuse to remove %s: it is, or contains, this "
+        "process's current directory (%s). Restore the current directory "
+        "before the tree is removed -- unittest runs cleanups last-in "
+        "first-out, so an addCleanup(os.chdir, before) registered after "
+        "the tree's own cleanup runs first. Set %s=1 to run without this "
+        "guard." % (os.fspath(target), os.getcwd(), SKIP_ENV)
+    )
+
+
+def install() -> None:
+    """Wrap the directory-removal entry points. Idempotent; POSIX only."""
+
+    global _installed
+    if _installed or os.name == "nt" or os.environ.get(SKIP_ENV):
+        return
+    _installed = True
+
+    for module, name in ((shutil, "rmtree"), (os, "rmdir"), (os, "removedirs")):
+        setattr(module, name, _guarded(getattr(module, name)))
+    # Patched separately because pathlib does not always route here:
+    # through 3.9 `Path.rmdir` is bound to `os.rmdir` when the class is
+    # defined, so a later patch of `os.rmdir` never reaches it.
+    pathlib.Path.rmdir = _guarded_method(pathlib.Path.rmdir)
+
+
+def _guarded(original):
+    def guarded(path, *args, **kwargs):
+        if _holds_the_cwd(path):
+            _refuse(path)
+        return original(path, *args, **kwargs)
+
+    guarded.__name__ = getattr(original, "__name__", "guarded")
+    guarded.__doc__ = getattr(original, "__doc__", None)
+    return guarded
+
+
+def _guarded_method(original):
+    def guarded(self, *args, **kwargs):
+        if _holds_the_cwd(self):
+            _refuse(self)
+        return original(self, *args, **kwargs)
+
+    guarded.__name__ = getattr(original, "__name__", "guarded")
+    guarded.__doc__ = getattr(original, "__doc__", None)
+    return guarded

--- a/tests/test_static_tree_invariants.py
+++ b/tests/test_static_tree_invariants.py
@@ -8,6 +8,7 @@ test_benchmark_architecture.py, which walked the tree four times over. Every
 test here reads committed files; the only subprocess is the one git index read
 that no filesystem check can substitute for.
 """
+import ast
 import re
 import subprocess
 import sys
@@ -293,6 +294,72 @@ class TestCompositionLinks(unittest.TestCase):
                         f"{path} cites {target}, which does not exist",
                     )
         self.assertTrue(checked, "found no composition links to resolve")
+
+
+def _called_name(node):
+    """The bare name of a call's target: `os.chdir` and `chdir` both give
+    `chdir`, so a module's import style does not decide what is checked."""
+
+    function = node.func
+    if isinstance(function, ast.Attribute):
+        return function.attr
+    return function.id if isinstance(function, ast.Name) else None
+
+
+def _calls_named(node, name):
+    return any(
+        isinstance(child, ast.Call) and _called_name(child) == name
+        for child in ast.walk(node)
+    )
+
+
+class TestNoTempTreeIsDeletedWhileItIsTheCwd(unittest.TestCase):
+    """Windows refuses to delete a directory that is any process's current
+    directory; POSIX allows it. So this shape passes every POSIX runner and
+    fails every Windows one, deterministically:
+
+        with tempfile.TemporaryDirectory() as raw:
+            os.chdir(Path(raw) / "repo")
+            self.addCleanup(os.chdir, before)
+
+    The block deletes the tree when it exits, and `addCleanup` does not run
+    until the whole test method has returned -- so the restore lands after
+    the delete has already been attempted, and the delete dies on WinError
+    32. The two safe shapes are both in this suite and both stay legal
+    here: restore inside the block through `try/finally`, or hold the
+    directory open (`tempfile.TemporaryDirectory()` bound to a name, its
+    `cleanup` registered with `addCleanup` *before* the chdir's restore, so
+    LIFO runs the restore first).
+
+    Caught by CI three times in two days and never once locally, because
+    the only host that can see it is the one this suite is least often run
+    on. It is a shape, not a behavior, so a reader can see it here instead.
+    """
+
+    def test_no_chdir_inside_a_temporary_directory_block_defers_its_restore(self):
+        offenders = []
+        for path in sorted(Path(__file__).resolve().parent.glob("*.py")):
+            tree = ast.parse(path.read_text(encoding="utf-8"))
+            for node in ast.walk(tree):
+                if not isinstance(node, ast.With):
+                    continue
+                opens_temp_tree = any(
+                    isinstance(item.context_expr, ast.Call)
+                    and _called_name(item.context_expr) == "TemporaryDirectory"
+                    for item in node.items
+                )
+                if not opens_temp_tree or not _calls_named(node, "chdir"):
+                    continue
+                # A restore anywhere in a `finally` inside the block runs
+                # before the block's own cleanup, which is the whole point.
+                restored = any(
+                    isinstance(child, ast.Try)
+                    and any(_calls_named(stmt, "chdir") for stmt in child.finalbody)
+                    for child in ast.walk(node)
+                )
+                if not restored:
+                    offenders.append(f"{path.name}:{node.lineno}")
+        self.assertEqual([], offenders, "chdir inside a self-deleting temp tree")
 
 
 class TestBenchmarkArchitecture(unittest.TestCase):

--- a/tests/test_windows_semantics.py
+++ b/tests/test_windows_semantics.py
@@ -1,0 +1,158 @@
+"""The guard that makes POSIX refuse what Windows refuses.
+
+A guard nothing exercises is a guard that can stop working without
+anyone noticing, and this one's whole value is that it fires on a host
+where the underlying platform never would. Both sides are asserted: the
+shape that killed a pull request on all three Windows cells, and the
+shape the suite uses everywhere and must never flag.
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+# Absolute, not relative: `unittest discover -s tests` makes `tests` the
+# top-level directory and imports these as bare modules, with no parent
+# package to be relative to. Importing the package by name is also what
+# installs the guard, and discovery imports every module before running
+# any test -- so this line is what guarantees the guard is in place for
+# the whole suite under a runner that never imports the package itself.
+from tests import _windows_semantics as guard  # noqa: E402
+
+ON_WINDOWS = os.name == "nt"
+WHY_SKIPPED = "the guard is not installed on Windows: the platform enforces this itself"
+
+
+class StandsElsewhere(unittest.TestCase):
+    """Base for tests that move the process and must put it back.
+
+    The restore is registered after the tree, so LIFO runs it first --
+    the pattern the guard exists to require, used here on itself.
+    """
+
+    def setUp(self):
+        self._tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self._tmp.cleanup)
+        self.tree = Path(self._tmp.name).resolve()
+        self.addCleanup(os.chdir, os.getcwd())
+
+
+@unittest.skipIf(ON_WINDOWS, WHY_SKIPPED)
+class TestTheGuardRefusesDeletingTheCwd(StandsElsewhere):
+    def test_rmtree_of_the_directory_the_process_stands_in(self):
+        os.chdir(self.tree)
+        with self.assertRaises(guard.WindowsWouldRefuse):
+            shutil.rmtree(self.tree)
+        self.assertTrue(self.tree.is_dir(), "refused, so nothing was removed")
+
+    def test_rmtree_of_an_ancestor_of_the_directory_the_process_stands_in(self):
+        # Windows refuses the ancestor too: the handle on the child keeps
+        # the parent non-empty, so the recursive delete cannot finish.
+        deep = self.tree / "a" / "b"
+        deep.mkdir(parents=True)
+        os.chdir(deep)
+        with self.assertRaises(guard.WindowsWouldRefuse):
+            shutil.rmtree(self.tree / "a")
+
+    def test_temporary_directory_cleanup_of_the_directory_it_moved_into(self):
+        holder = tempfile.TemporaryDirectory()
+        os.chdir(holder.name)
+        with self.assertRaises(guard.WindowsWouldRefuse):
+            holder.cleanup()
+        os.chdir(self.tree)
+        holder.cleanup()
+
+    def test_os_rmdir_and_path_rmdir_and_removedirs(self):
+        # `Path.rmdir` is patched separately from `os.rmdir` because
+        # pathlib binds the latter at class-definition time through 3.9;
+        # one assertion per entry point is what proves both landed.
+        for remove in (os.rmdir, Path.rmdir, os.removedirs):
+            with self.subTest(remove=getattr(remove, "__qualname__", remove)):
+                here = self.tree / "leaf"
+                here.mkdir()
+                os.chdir(here)
+                with self.assertRaises(guard.WindowsWouldRefuse):
+                    remove(here)
+                os.chdir(self.tree)
+                here.rmdir()
+
+    def test_the_refusal_is_not_an_oserror(self):
+        # A caller guarding its own cleanup with `except OSError`, or a
+        # TemporaryDirectory built with ignore_cleanup_errors, would
+        # swallow the report if it were one.
+        os.chdir(self.tree)
+        with self.assertRaises(guard.WindowsWouldRefuse) as caught:
+            shutil.rmtree(self.tree)
+        self.assertNotIsInstance(caught.exception, OSError)
+
+    def test_the_message_names_the_tree_the_cwd_and_the_way_out(self):
+        os.chdir(self.tree)
+        with self.assertRaises(guard.WindowsWouldRefuse) as caught:
+            shutil.rmtree(self.tree)
+        message = str(caught.exception)
+        self.assertIn(str(self.tree), message)
+        self.assertIn("addCleanup", message)
+        self.assertIn(guard.SKIP_ENV, message)
+
+
+@unittest.skipIf(ON_WINDOWS, WHY_SKIPPED)
+class TestTheGuardPassesEverythingElse(StandsElsewhere):
+    def test_a_sibling_tree_is_removed_normally(self):
+        sibling = self.tree / "sibling"
+        sibling.mkdir()
+        (sibling / "f.txt").write_text("x", encoding="utf-8")
+        os.chdir(self.tree)
+        shutil.rmtree(sibling)
+        self.assertFalse(sibling.exists())
+
+    def test_a_prefix_match_that_is_not_a_parent_is_not_refused(self):
+        # `/tmp/x` is a string prefix of `/tmp/xy` and an ancestor of
+        # neither; a naive startswith would refuse this one.
+        (self.tree / "x").mkdir()
+        (self.tree / "xy").mkdir()
+        os.chdir(self.tree / "xy")
+        (self.tree / "x").rmdir()
+        self.assertFalse((self.tree / "x").exists())
+
+    def test_the_restored_cwd_pattern_this_suite_uses_is_never_flagged(self):
+        # tests/test_friction.py's setUp, in miniature.
+        holder = tempfile.TemporaryDirectory()
+        repo = Path(holder.name).resolve() / "repo"
+        repo.mkdir()
+        before = os.getcwd()
+        os.chdir(repo)
+        try:
+            self.assertTrue(Path.cwd().name == "repo")
+        finally:
+            os.chdir(before)
+        holder.cleanup()
+        self.assertFalse(repo.exists())
+
+    def test_a_missing_or_unanswerable_path_is_left_to_the_real_call(self):
+        # The guard reports on Windows semantics, never on whether a path
+        # exists: that answer stays the platform's, unchanged.
+        os.chdir(self.tree)
+        with self.assertRaises(FileNotFoundError):
+            os.rmdir(self.tree / "never-made")
+        self.assertFalse(guard._holds_the_cwd(os.devnull))
+
+
+class TestInstallation(unittest.TestCase):
+    def test_installing_twice_does_not_wrap_twice(self):
+        before = shutil.rmtree
+        guard.install()
+        self.assertIs(shutil.rmtree, before)
+
+    def test_importing_the_package_installed_it(self):
+        # The package `__init__` is the one import every runner makes;
+        # if the guard moved out of it, this is what says so.
+        self.assertEqual(not ON_WINDOWS, guard._installed)

--- a/tools/preflight.py
+++ b/tools/preflight.py
@@ -1,0 +1,219 @@
+#!/usr/bin/env python3
+"""Run the suite under every locally installed interpreter CI uses.
+
+A local green covers one of nine CI cells -- one OS, one interpreter --
+and AGENTS.md calls it provisional for that reason. Two of the three
+axes are closable before a push and this closes one of them: the
+interpreter. What is left uncovered is named in the summary rather than
+left to be discovered by a runner four minutes later.
+
+The version axis is not hypothetical. `Path.resolve()` on a name holding
+a NUL raises through 3.12 and answers a path on 3.13, and the suite
+asserted the first as a premise -- green on this host, red on one CI
+cell. The OS axis stays CI's: what can be caught statically is caught by
+the suite's own invariants (a chdir inside a self-deleting temp tree, a
+cleanup that swallows), and the rest needs the platform.
+
+Stdlib only, no network, Python 3.9+, POSIX and Windows.
+
+Usage:
+    python tools/preflight.py [-j N] [--python PATH ...] [MODULE ...]
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import re
+import subprocess
+import sys
+import time
+from concurrent.futures import ThreadPoolExecutor
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+RUNNER = ROOT / "tools" / "run_tests.py"
+WORKFLOW = ROOT / ".github" / "workflows" / "checks.yml"
+# The matrix is read, never restated: a version added to CI must not need a
+# second edit here to be preflighted.
+MATRIX_RE = re.compile(r"python-version:\s*\[([^\]]*)\]")
+VERSION_RE = re.compile(r"(\d+)\.(\d+)")
+
+
+def ci_minors():
+    """The interpreter versions CI runs, straight out of the workflow."""
+
+    try:
+        found = MATRIX_RE.search(WORKFLOW.read_text(encoding="utf-8"))
+    except OSError:
+        return ()
+    if not found:
+        return ()
+    return tuple(
+        "%s.%s" % pair for pair in VERSION_RE.findall(found.group(1))
+    )
+
+
+def minor_of(executable):
+    """``(major, minor)`` as the interpreter itself reports it, or None.
+
+    Asked rather than parsed out of the path: `python3` is whatever it is,
+    and a preflight that guessed would report a cell it never ran.
+    """
+
+    try:
+        proc = subprocess.run(
+            [executable, "-c", "import sys; print('%d.%d' % sys.version_info[:2])"],
+            stdout=subprocess.PIPE, stderr=subprocess.DEVNULL, timeout=30,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return None
+    answer = proc.stdout.decode("utf-8", "replace").strip()
+    return answer if proc.returncode == 0 and VERSION_RE.fullmatch(answer) else None
+
+
+def uv_candidates():
+    """Interpreter paths `uv python list --only-installed` reports.
+
+    Its rows are ``<key> <path>`` or ``<key> <path> -> <target>``; the
+    path is what is wanted either way, and following the arrow would name
+    the same interpreter twice under two paths.
+    """
+
+    try:
+        proc = subprocess.run(
+            ["uv", "python", "list", "--only-installed"],
+            stdout=subprocess.PIPE, stderr=subprocess.DEVNULL, timeout=60,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return []
+    found = []
+    for line in proc.stdout.decode("utf-8", "replace").splitlines():
+        fields = line.split()
+        if len(fields) >= 2:
+            found.append(fields[1])
+    return found
+
+
+def discover_interpreters():
+    """One interpreter per minor version, this one always included.
+
+    uv's inventory when uv is present, plus the obvious names on PATH.
+    Nothing is downloaded: an absent version is reported as uncovered,
+    which is true and cheap, rather than fetched behind the user's back
+    on what is meant to be a fast local check.
+    """
+
+    candidates = [sys.executable]
+    candidates.extend(uv_candidates())
+    candidates.extend("python" + minor for minor in ci_minors())
+
+    by_minor = {}
+    for candidate in candidates:
+        resolved = candidate if os.path.sep in candidate else _which(candidate)
+        if not resolved or not os.path.exists(resolved):
+            continue
+        minor = minor_of(resolved)
+        if minor and minor not in by_minor:
+            by_minor[minor] = resolved
+    return by_minor
+
+
+def _which(name):
+    for directory in os.environ.get("PATH", "").split(os.pathsep):
+        candidate = os.path.join(directory, name)
+        if os.path.isfile(candidate) and os.access(candidate, os.X_OK):
+            return candidate
+    return None
+
+
+def run_one(minor, executable, jobs, modules):
+    command = [executable, str(RUNNER), "--no-cache", "-j", str(jobs)] + list(modules)
+    started = time.monotonic()
+    proc = subprocess.run(command, stdout=subprocess.PIPE, stderr=subprocess.STDOUT)
+    return {
+        "minor": minor,
+        "executable": executable,
+        "ok": proc.returncode == 0,
+        "duration": time.monotonic() - started,
+        "output": proc.stdout.decode("utf-8", "replace"),
+    }
+
+
+def main(argv=None):
+    parser = argparse.ArgumentParser(
+        prog="preflight.py",
+        description="Run the suite under every locally installed interpreter CI uses.",
+    )
+    parser.add_argument("modules", metavar="MODULE", nargs="*")
+    parser.add_argument("-j", "--jobs", type=int, default=os.cpu_count() or 1,
+                        help="total worker processes, split across interpreters")
+    parser.add_argument("--python", action="append", default=[], metavar="PATH",
+                        help="use this interpreter instead of discovering (repeatable)")
+    args = parser.parse_args(argv)
+
+    if args.python:
+        chosen = {}
+        for executable in args.python:
+            minor = minor_of(executable)
+            if minor is None:
+                raise SystemExit("preflight: not a working interpreter: " + executable)
+            chosen[minor] = executable
+    else:
+        installed = discover_interpreters()
+        wanted = set(ci_minors()) | {minor_of(sys.executable)}
+        # A minor CI does not run buys no cell, and every interpreter here
+        # costs another full suite: 3.12 being installed is not a reason to
+        # run under it. The running interpreter stays in regardless, so
+        # preflight still does something if the workflow cannot be read.
+        chosen = {k: v for k, v in installed.items() if k in wanted}
+    if not chosen:
+        raise SystemExit("preflight: found no interpreters to run")
+
+    required = ci_minors()
+    missing = [minor for minor in required if minor not in chosen]
+    order = sorted(chosen, key=lambda minor: tuple(int(n) for n in minor.split(".")))
+    # Interpreters run together and split the workers between them: the
+    # suite's wall clock is one long module, so three of them overlap for
+    # roughly the cost of one.
+    per = max(2, args.jobs // len(order))
+    print("preflight: %d interpreters (%s), %d workers each"
+          % (len(order), ", ".join(order), per))
+    if missing:
+        print("preflight: CI also runs %s -- not installed here, so still CI-only"
+              % ", ".join(missing))
+
+    started = time.monotonic()
+    with ThreadPoolExecutor(max_workers=len(order)) as pool:
+        results = list(pool.map(
+            lambda minor: run_one(minor, chosen[minor], per, args.modules), order
+        ))
+    wall = time.monotonic() - started
+
+    failed = [record for record in results if not record["ok"]]
+    for record in failed:
+        print("\n" + "=" * 70)
+        print("FAILED under python %s (%s)" % (record["minor"], record["executable"]))
+        print("=" * 70)
+        sys.stdout.write(record["output"])
+
+    print("\n" + "-" * 70)
+    for record in results:
+        print("%-4s python %-5s %7.2fs  %s"
+              % ("ok" if record["ok"] else "FAIL", record["minor"],
+                 record["duration"], record["executable"]))
+    print("preflight wall %.2fs" % wall)
+    covered = [minor for minor in required if minor in chosen]
+    print("CI interpreter cells covered locally: %d of %d%s"
+          % (len(covered), len(required),
+             (" (missing " + ", ".join(missing) + ")") if missing else ""))
+    print("OS cells covered locally: 1 of 3 -- windows and linux stay CI's")
+    if failed:
+        print("FAILED: " + ", ".join("python " + r["minor"] for r in failed))
+        return 1
+    print("OK")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))


### PR DESCRIPTION
## Why

Since 14 Aug every PR here has been red on its first run — #48 needed 5 runs, #50 needed 3, #52 needed 3, #53 needed 2, #51 is still red after 20 hours. The seven PRs before that were green first try. The suite didn't get worse; it got parallel, and parallelism is a platform question.

The five required checks in `AGENTS.md` answer **1 of the 9 matrix cells**. The other 8 are answered by pushing and waiting ~4 minutes. Two of the three axes have local answers, and this PR gives them.

## The OS axis: 3 Windows cells, 100% invisible locally

Windows cannot delete a directory that is any process's current directory (`WinError 32`). POSIX has no handle to object with: the tree goes, the process is left standing in a path that no longer resolves, and the test passes. **Every Windows failure this month has been that one shape**, including all three of PR #51's.

- `tests/_windows_semantics.py` wraps `shutil.rmtree`, `os.rmdir`, `os.removedirs` and `Path.rmdir` and refuses what Windows refuses. Not an `OSError`, so `except OSError` cleanup and `ignore_cleanup_errors=True` can't swallow the report. Not installed on Windows — the platform does it better.
- `tests/__init__.py` installs it; `tests/test_windows_semantics.py` imports the package by name, which is what puts the guard in place under `unittest discover -s tests`, where `tests` is the top-level dir and is never imported as a parent.
- Verified two-sided: raises on PR #51's exact failing test, silent across all 1325 tests here.
- `test_static_tree_invariants.py` also refuses the shape statically (0.2s), which catches it in code paths a run doesn't reach.

## The version axis: 6 cells, all closable

`tools/preflight.py` runs the whole suite under every interpreter in `checks.yml`'s matrix that's installed locally, concurrently, splitting workers between them.

```
preflight: 3 interpreters (3.9, 3.11, 3.13), 4 workers each
ok   python 3.9    122.09s
ok   python 3.11   121.55s
ok   python 3.13   121.56s
preflight wall 122.09s
CI interpreter cells covered locally: 3 of 3
OS cells covered locally: 1 of 3 -- windows and linux stay CI's
```

122s wall against 198s sequential, and against a push. It reads the matrix rather than restating it, asks each interpreter its own version rather than parsing a path, skips minors CI doesn't run, and **names the versions it couldn't cover** instead of implying it covered them.

## What this does not close

The NUL-path divergence that broke #53 was OS *and* version: macOS 3.13 still raises where Windows 3.13 doesn't, so no local interpreter would have found it. The OS axis stays CI's. What changed is that the two classes that cost the last eleven hours now fail on the machine that wrote the code.

## Checks

All five required checks green, plus preflight:

- `tools/validate.py` → 0 (25 warnings, at the ratchet)
- `tools/run_tests.py --no-cache` → 24 modules, 1325 tests, 66s
- `python -m unittest discover -s tests` → 1325 tests, 93s, OK
- `install.py --dry-run` → 0
- `git diff --check` → 0
- `tools/preflight.py` → 3/3 interpreters

🤖 Generated with [Claude Code](https://claude.com/claude-code)
