### PR TITLE
Wait out the same Windows instant on the reading side of the identity move

### DIFF
--- a/scripts/tickets.py
+++ b/scripts/tickets.py
@@ -448,6 +448,40 @@ def _writer_identity():
     )
 
 
+# Windows has no unconditional atomic replace, and both sides of one pay
+# for it. ``MoveFileEx`` answers ERROR_ACCESS_DENIED -- WinError 5, which
+# reads like a permission problem and is not one -- for as long as any other
+# handle holds the destination open, and an ``open`` of that same name is
+# refused for the instant the move is in flight. So two workspaces opening
+# one run refuse each other in both directions: the writer for someone
+# else's read, the reader for someone else's write. Every such window is
+# microseconds wide and closes by itself, so both are waited out on one
+# bounded budget rather than reported. POSIX ``rename`` and ``open`` never
+# collide this way, so there the first answer is the only one and a refusal
+# is real.
+REPLACE_BUDGET_SECONDS = 2.0
+REPLACE_RETRY_SECONDS = 0.005
+
+
+def _waiting_out_windows(action):
+    """Run ``action``, retrying only the refusal only Windows raises.
+
+    ``PermissionError`` alone, never ``OSError``: a missing file and an
+    unreachable directory are answers, and waiting two seconds for one of
+    those on every run that has yet to open would cost the ordinary path
+    to spare the rare one.
+    """
+
+    deadline = time.monotonic() + REPLACE_BUDGET_SECONDS
+    while True:
+        try:
+            return action()
+        except PermissionError:
+            if msvcrt is None or time.monotonic() >= deadline:
+                raise
+            time.sleep(REPLACE_RETRY_SECONDS)
+
+
 def _read_identity(path: Path):
     """``(document, error)``: the run's identity, ``(None, None)`` when absent.
 
@@ -457,7 +491,7 @@ def _read_identity(path: Path):
     """
 
     try:
-        text = path.read_text(encoding="utf-8")
+        text = _waiting_out_windows(lambda: path.read_text(encoding="utf-8"))
     except (FileNotFoundError, NotADirectoryError):
         # No document, and no reachable place for one. An unreachable sink is
         # the run-state write's own error to report, in its own words.
@@ -533,31 +567,10 @@ def _identity_document(run: str, path: Path, project: dict, workspace: str, now)
     return (updated, None) if updated != existing else (None, None)
 
 
-# Windows has no unconditional atomic replace. ``MoveFileEx`` answers
-# ERROR_ACCESS_DENIED -- WinError 5, which reads like a permission problem
-# and is not one -- for as long as any other handle holds the destination
-# open: a concurrent reader of the identity document, or a second writer's
-# own move already in flight over the same name. Both windows are
-# microseconds wide and both close by themselves, so the move is waited out
-# rather than reported; reporting it fails a writer for someone else's read.
-# POSIX ``rename`` has neither window, so there the first attempt is the
-# only one and a refusal is real.
-REPLACE_BUDGET_SECONDS = 2.0
-REPLACE_RETRY_SECONDS = 0.005
-
-
 def _replace_atomically(temporary: Path, target: Path) -> None:
     """Move ``temporary`` onto ``target``, waiting out a transient refusal."""
 
-    deadline = time.monotonic() + REPLACE_BUDGET_SECONDS
-    while True:
-        try:
-            temporary.replace(target)
-            return
-        except OSError:
-            if msvcrt is None or time.monotonic() >= deadline:
-                raise
-            time.sleep(REPLACE_RETRY_SECONDS)
+    _waiting_out_windows(lambda: temporary.replace(target))
 
 
 def _write_identity(run_dir: Path, document: dict) -> None:

--- a/tests/test_tickets.py
+++ b/tests/test_tickets.py
@@ -3540,13 +3540,13 @@ class TestRunIdentity(unittest.TestCase):
 
 
 class TestAtomicReplace(unittest.TestCase):
-    """`_replace_atomically`'s two platforms, both graded here.
+    """Both sides of the identity document's move, on both platforms.
 
-    The branch that matters runs on Windows only, where `MoveFileEx` refuses
-    a destination another handle holds open, so on every other host it is
-    unreachable code that three cells of the matrix are the first to run.
-    `msvcrt` is the discriminator the module already uses, so setting it is
-    how this host asks the Windows question.
+    The branch that matters runs on Windows only, where a move and an open
+    of one name refuse each other for the instant the move takes, so on
+    every other host it is unreachable code that three cells of the matrix
+    are the first to run. `msvcrt` is the discriminator the module already
+    uses, so setting it is how this host asks the Windows question.
     """
 
     def refusals(self, count: int):
@@ -3621,6 +3621,63 @@ class TestAtomicReplace(unittest.TestCase):
                 self.assertEqual(1, state["calls"])
                 self.assertFalse(source.exists())
                 self.assertEqual("moved\n", target.read_text(encoding="utf-8"))
+
+    def test_an_absent_file_is_an_answer_and_is_never_waited_on(self):
+        """The refusal is waited out; every other `OSError` is a fact. Most
+        run-state writes open a run that has no identity yet, and a budget
+        spent on that would be paid by the ordinary path to spare the rare
+        one."""
+
+        calls = []
+
+        def missing():
+            calls.append(1)
+            raise FileNotFoundError(2, "No such file or directory")
+
+        with mock.patch.object(tickets_mod, "msvcrt", object()):
+            with self.assertRaises(FileNotFoundError):
+                tickets_mod._waiting_out_windows(missing)
+        self.assertEqual(1, len(calls))
+
+    def test_the_reader_waits_out_a_writers_move_and_returns_the_document(self):
+        """The other side of the same instant: an `open` of the name a move
+        is landing on is refused too, and a run-state write that reported it
+        would fail for someone else's write."""
+
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / "run.json"
+            path.write_text('{"run": "testrun"}\n', encoding="utf-8")
+            real = Path.read_text
+            state = {"left": 3}
+
+            def read_text(self, *args, **kwargs):
+                if state["left"] > 0:
+                    state["left"] -= 1
+                    raise PermissionError(13, "Permission denied")
+                return real(self, *args, **kwargs)
+
+            with mock.patch.object(tickets_mod, "msvcrt", object()), mock.patch.object(
+                Path, "read_text", read_text
+            ):
+                document, error = tickets_mod._read_identity(path)
+            self.assertIsNone(error)
+            self.assertEqual({"run": "testrun"}, document)
+            self.assertEqual(0, state["left"])
+
+    def test_a_reader_refused_past_the_budget_is_still_refused_by_name(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / "run.json"
+            path.write_text('{"run": "testrun"}\n', encoding="utf-8")
+
+            def read_text(self, *args, **kwargs):
+                raise PermissionError(13, "Permission denied")
+
+            with mock.patch.object(tickets_mod, "msvcrt", object()), mock.patch.object(
+                tickets_mod, "REPLACE_BUDGET_SECONDS", 0.05
+            ), mock.patch.object(Path, "read_text", read_text):
+                document, error = tickets_mod._read_identity(path)
+            self.assertIsNone(document)
+            self.assertIn("unreadable run identity", error["error"])
 
 
 class TestRunIdentityCollision(unittest.TestCase):


### PR DESCRIPTION
The writer's half of the identity document's move landed in #51's follow-up; the reader's did not.

On Windows a move and an `open` of one name refuse each other for exactly the instant the move takes. `_write_identity` now waits out its side, but `_read_identity` still answered `unreadable run identity ... [Errno 13] Permission denied` for a document that was never unreadable and was being written correctly by another workspace — `test_two_concurrent_openings_leave_one_well_formed_identity`, on `py3.9 / windows-latest` of main's own run.

One budget covers both directions now. `_waiting_out_windows` catches `PermissionError` alone, never `OSError`: a missing file and an unreachable directory are answers, and most run-state writes open a run with no identity yet, so waiting on those would make the ordinary path pay for the rare one.

The branch is unreachable off Windows, which is how it reached CI unrun. `msvcrt` is the discriminator the module already uses for its append lock, so `TestAtomicReplace` sets it and grades all seven cases — transient refusal waited out on each side, permanent one reported on each side, POSIX first-answer, unobstructed move, and an absent file never waited on — on any host.

Checks, all green locally: `tools/validate.py` (exit 0, 25 warnings), `tools/run_tests.py` (1525 tests), `unittest discover -s tests` (1525, serial), `install.py --dry-run`, `git diff --check`, and `tools/preflight.py` on 3.9 / 3.11 / 3.13.

🤖 Generated with [Claude Code](https://claude.com/claude-code)