### PR TITLE
The decomposer cuts for atoms and the shortest critical path

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -45,7 +45,9 @@ dependencies point. Terms: `docs/vocabulary.md`.
 - `scripts/` — repository-root scripts — stdlib Python 3, Windows and
   POSIX, no network at run time — one owner each:
   `scripts/cutcheck.py` owns cut-defect detection over an issued ticket
-  set, run by `orch-decompose` and read by its cut lens;
+  set, run by `orch-decompose` and read by its cut lens, and beside the
+  defects it reads that set's graph — the critical path and each level's
+  width — as a reading and never as a finding;
   `scripts/doclint.py` owns grading any repository's markdown — every
   relative link resolves, every paragraph has one home — and with it the
   one near-duplicate method, which `tools/validate.py` calls rather than

--- a/docs/vocabulary.md
+++ b/docs/vocabulary.md
@@ -98,6 +98,11 @@ that needs a different meaning needs a different word.
   ⊕ completion test ⊕ lifecycle ⊕ graph position, per
   `contracts/work-item.md`; on disk, a markdown ticket the executor writes
   to. The two words name the same thing; ticket is the on-disk view.
+- **atom** — a work item at the finest lawful cut: one observable end
+  state, a completion test discriminating it alone, a closed write
+  scope, oracles reading nothing a sibling writes, an instruction
+  inside the stub ceiling. Law, and what lies either side of it, in
+  `rules/topology.md` §3.
 - **root ticket** — a ticket whose executor is `orch-decompose`; its
   subtree is `<id>.NN` unit tickets plus `<id>.gate.*`, checked before
   its first unit is promoted; it completes when
@@ -222,6 +227,11 @@ composition).
 - **frontier** — the set of work items dispatchable now — every dependency
   `complete` — recomputed by `orch-frontier` on every event and dispatched
   as it forms, never batched.
+- **critical path** — the longest `depends_on` chain over a run's issued
+  items, gate stubs excluded; what decomposition minimizes subject to
+  every item an atom. Read with each level's width from
+  `scripts/cutcheck.py`'s `graph` block (classes `critical-path`,
+  `level-width`).
 - **lane** — any independent parallel branch whose write scope and
   whose workspace are both disjoint from every other's (sharing =
   writing the same artifact or slot, not returning same-named fields).

--- a/packs/orch-code-pack/references/slicing.md
+++ b/packs/orch-code-pack/references/slicing.md
@@ -1,8 +1,9 @@
-# Code slicing: tracer-bullet tickets
+# Code slicing: acceptance-first tickets
 
-Cut the spec into tracer tickets: each crosses the system end to end
-at one thin point, proving the seams early, then widens; the first
-frontier carries the riskiest seam's tracer.
+Every seam the spec's acceptance already checks is its own item on the
+first frontier. Cut a tracer — one thin end-to-end crossing, taken
+first and widened after — only for the riskiest seam the spec leaves
+unproven.
 
 - Each ticket: one observable behavior, provable by runnable checks from
   the spec's acceptance; dependency edges only where one ticket's seam

--- a/packs/orch-design-pack/references/slicing.md
+++ b/packs/orch-design-pack/references/slicing.md
@@ -1,8 +1,9 @@
 # Design slicing: token-first view tickets
 
-Cut the spec into view tickets: the token set plus one core view
-first — proving the design language end to end and exempt from the
-one-view rule below — then widen to the remaining views.
+The token set is the first item. Views the acceptance already
+enumerates by breakpoint and state each open the first frontier
+alongside it; pair the tokens with one core view, exempt from the
+one-view rule below, only while the design language stays unproven.
 
 - Each ticket is one view with its full identity set (the spec's
   breakpoints × its enumerated states), provable by capture and the

--- a/packs/orch-design-pack/references/slicing.md
+++ b/packs/orch-design-pack/references/slicing.md
@@ -1,9 +1,12 @@
 # Design slicing: token-first view tickets
 
-The token set is the first item. Views the acceptance already
-enumerates by breakpoint and state each open the first frontier
-alongside it; pair the tokens with one core view, exempt from the
-one-view rule below, only while the design language stays unproven.
+The token set alone opens the first frontier. Every view's capture
+samples rendered values against the tokens, so each view the
+acceptance enumerates by breakpoint and state depends on that item
+under [rules/topology.md](../../../rules/topology.md) §3's edge rule
+and takes the frontier behind it. Pair the tokens with one core view,
+exempt from the one-view rule below, only while the design language
+stays unproven.
 
 - Each ticket is one view with its full identity set (the spec's
   breakpoints × its enumerated states), provable by capture and the

--- a/rules/token-economy.md
+++ b/rules/token-economy.md
@@ -55,8 +55,12 @@
     return fields; never its fixed inputs) 300, a pack's craft as
     [contracts/pack-signature.md](../contracts/pack-signature.md)
     mandates; every-run units widest — engine and workflow bodies 450,
-    a template manifest 250. Counted by `tools/validate.py` in words
-    with link targets stripped. What degrades adherence is the count of
+    a template manifest 250. Counted in words with link targets
+    stripped: the stub's instruction by `scripts/tickets.py`, which
+    also enforces it — `new` and `amend` refuse an issued unit over the
+    ceiling, a root ticket and a `.gate.` stub exempt — and every other
+    surface here by `tools/validate.py`, template stubs included,
+    through that same counter. What degrades adherence is the count of
     standing demands and tension between them, not length at a fixed
     count — so a surface earns each demand by §1 and carries no two in
     tension, and complexity buys structure, never width: more stubs and

--- a/rules/topology.md
+++ b/rules/topology.md
@@ -17,14 +17,31 @@
    and engines. One-off routing stays inside rule 1's operators and the
    delegation boundary.
 3. Decomposition emits [work items](../contracts/work-item.md); domains
-   extend the item, never replace it. One item is a lawful cut: a cut
-   is forced only by parallelism, disjoint write scopes, isolation, or
-   resumption — never made to look thorough. A decomposition that
+   extend the item, never replace it. The lawful set is the finest cut
+   in which every item is an atom: one observable end state; a
+   completion test discriminating it alone (`scripts/cutcheck.py`
+   family 1); a closed write scope (family 3); oracles reading nothing
+   a sibling writes (family 4); an instruction inside the stub ceiling
+   ([token-economy.md](token-economy.md) §11). A coarser item is a
+   compound item
+   ([cut-lens.md](../skills/kernel/orch-decompose/references/cut-lens.md)),
+   never a safe default; below the atom is padding — an item no oracle
+   discriminates from a sibling — which is where cutting finer stops.
+   Count is unbounded above; width past the host profile is the
+   frontier's queue, not the cut's. A decomposition that
    cannot cover most acceptance criteria under the stamped slicing
-   returns a decision gap, never a forced slicing. A cut's write scope
+   returns a decision gap, never a forced slicing. An edge exists only
+   where the dependent's oracle reads what the predecessor writes or
+   its `## Fixed inputs` cite the predecessor's result identity — never
+   for ordering preference. A cut's write scope
    covers every artifact its own objective and completion test name,
    resolved against the workspace before issue; a cut that cannot cover
-   them is widened or re-cut, never issued. Observing is not naming: an
+   them is widened or re-cut, never issued. An artifact more than one
+   item would write is given to exactly one item — one on the first
+   frontier the rest depend on, or a closing item depending on them —
+   never shared; the recurring ones are `ARCHITECTURE.md`, a `SKILL.md`
+   roster, a fixture copying a source, `tests/pins.json`, and a test
+   module pinning several owners. Observing is not naming: an
    artifact a test only observes — asserting that it is unchanged
    included — stays outside the write scope, which covers only what the
    item changes. Reads are scope all the same: an item whose completion
@@ -33,7 +50,9 @@
    move the verdict it observes, in the workspace where it observes it —
    isolation keeping a sibling's in-flight change out of that workspace
    qualifies as squarely as disjointness does. A sibling's write counts
-   as material until shown immaterial.
+   as material until shown immaterial. An ad-hoc set is a cut like any
+   other: every clause here binds it, and `scripts/cutcheck.py` reads
+   it before its first dispatch.
 4. At most one terminal assembly item per run, depending on every unit
    item. Assembly rewrites its inputs, so unit verification upstream of
    it is invalidated at the join; the final gate re-verifies the

--- a/rules/topology.md
+++ b/rules/topology.md
@@ -30,10 +30,10 @@
    Count is unbounded above; width past the host profile is the
    frontier's queue, not the cut's. A decomposition that
    cannot cover most acceptance criteria under the stamped slicing
-   returns a decision gap, never a forced slicing. An edge exists only
-   where the dependent's oracle reads what the predecessor writes or
-   its `## Fixed inputs` cite the predecessor's result identity — never
-   for ordering preference. A cut's write scope
+   returns a decision gap, never a forced slicing. An edge exists
+   only where the dependent's oracle reads what the predecessor
+   writes or its `## Fixed inputs` cite the predecessor's result
+   identity — never for ordering preference. A cut's write scope
    covers every artifact its own objective and completion test name,
    resolved against the workspace before issue; a cut that cannot cover
    them is widened or re-cut, never issued. An artifact more than one

--- a/scripts/cutcheck.py
+++ b/scripts/cutcheck.py
@@ -292,8 +292,14 @@ BYTECODE_REPAIR = "the interpreter's own cache; spell this oracle with `-B`"
 # summary line may carry any of those, nor the path of a script: a summary a
 # filter selects is a finding line to everything downstream. That is why the
 # shape's heading names neither of the two readings standing under it.
+#
+# The shape's heading also has to read nothing like the advisory's. What sends
+# a fresh cut checker at a set is an agent reading "cutcheck reported an
+# advisory" off this report, and a heading that echoed the advisory's wording
+# would fire that checker on every set ever graded. So it says outright what it
+# is, and borrows none of the advisory's phrasing to say it.
 ADVISORY_HEADING = "cutcheck: advisory -- reported, and never setting the exit status:"
-GRAPH_HEADING = "cutcheck: the shape of this cut -- read, and never setting the exit status:"
+GRAPH_HEADING = "cutcheck: the shape of this cut -- how long and how wide it is, and no finding of any kind:"
 NO_FINDING_OUTSIDE = "cutcheck: no finding outside the advisory set"
 SCRATCH_NOT_REMOVED = "cutcheck: scratch root not removed"
 NO_SCRATCH_ROOT = "cutcheck: no scratch root could be placed for"

--- a/scripts/cutcheck.py
+++ b/scripts/cutcheck.py
@@ -106,6 +106,18 @@ criteria in prose, and a gap that failed the run would turn every clean
 set red. Gaps are for the decomposer to read, not for the exit code to
 decide.
 
+Below both blocks stands a third, and it holds no finding of any kind. It
+is a reading of the cut's shape -- how long the longest ``depends_on``
+chain through the issued items is, and how many items stand on each level
+of them -- printed for every set this tool resolves, clean or not. A cut
+is not defective for being deep or for being narrow, and this tool grades
+defects, so the shape is reported and nothing more: it is what the
+decomposer minimizes and what the frontier's queue is shaped by, and both
+of them were reading it off the tickets by hand. Its two classes carry a
+marker of their own, sit outside the advisory set because they are not
+advisory findings but not findings, and are built apart from the finding
+list so that no path exists by which they could move the exit status.
+
 The copy is checked as well as the spans run in it. A tree entry carrying
 git's ``120000`` mode is the one route out that argv cannot see, so the copy
 is cloned with ``core.symlinks=false`` -- which makes such an entry a file
@@ -178,6 +190,7 @@ FAMILY_4 = "family 4"
 FAMILY_5 = "family 5"
 FAMILY_6 = "family 6"
 READING = "reading"
+GRAPH = "graph"
 ALREADY_PASSES = "already-passes"
 NO_HITS_BOTH_REVISIONS = "no-hits-both-revisions"
 FAILS_BOTH_REVISIONS = "fails-both-revisions"
@@ -203,6 +216,8 @@ ILLEGAL_EXECUTOR = "illegal-executor"
 SYMLINK_IN_TREE = "symlink-in-tree"
 BYTECODE_WRITTEN = "bytecode-written"
 UNREAD_HALF = "unread-half"
+CRITICAL_PATH = "critical-path"
+LEVEL_WIDTH = "level-width"
 FAMILY_OF = {
     ALREADY_PASSES: FAMILY,
     NO_HITS_BOTH_REVISIONS: FAMILY,
@@ -239,6 +254,12 @@ FAMILY_OF = {
     # marker of its own so a reader filters it the way every other line is
     # filtered, and so no family's line count silently gains a member.
     UNREAD_HALF: READING,
+    # No family either, and for the nearer half of the same reason: the shape
+    # of a cut is not a defect of one. A family here would put two lines that
+    # grade nothing into a family's count, and the marker keeps them selectable
+    # by the one filter every other line answers to.
+    CRITICAL_PATH: GRAPH,
+    LEVEL_WIDTH: GRAPH,
 }
 # Advisory classes are printed and never set the exit status. A map that is
 # not there is a fact about the run, not a defect of the cut; a committed
@@ -254,17 +275,25 @@ ADVISORY = frozenset(
         UNREAD_HALF,
     }
 )
+# The shape reading's classes, which are in neither set. An advisory is a
+# finding the exit status forgives; these are not findings, so they are held
+# out of the finding list altogether rather than forgiven inside it. Naming
+# them here is what lets a reader ask the question directly instead of
+# inferring the answer from two absences.
+GRAPH_CLASSES = frozenset({CRITICAL_PATH, LEVEL_WIDTH})
 # The one thing a python oracle writes into the copy by importing anything,
 # and the flag that stops it. Reported in words because the repair is a
 # spelling of the oracle and is stated nowhere else -- not in the pack's
 # oracle policy, not in the decomposer's skill, not in this report until now.
 BYTECODE_RE = re.compile(r"(?:^|/)__pycache__/|\.py[co]$")
 BYTECODE_REPAIR = "the interpreter's own cache; spell this oracle with `-B`"
-# The report's two summary lines. A reader selects finding lines by filtering
-# stdout on a family, a class name, a criterion number or a ticket id, so
-# neither summary line may carry any of those, nor the path of a script: a
-# summary a filter selects is a finding line to everything downstream.
+# The report's three summary lines. A reader selects finding lines by filtering
+# stdout on a family, a class name, a criterion number or a ticket id, so no
+# summary line may carry any of those, nor the path of a script: a summary a
+# filter selects is a finding line to everything downstream. That is why the
+# shape's heading names neither of the two readings standing under it.
 ADVISORY_HEADING = "cutcheck: advisory -- reported, and never setting the exit status:"
+GRAPH_HEADING = "cutcheck: the shape of this cut -- read, and never setting the exit status:"
 NO_FINDING_OUTSIDE = "cutcheck: no finding outside the advisory set"
 SCRATCH_NOT_REMOVED = "cutcheck: scratch root not removed"
 NO_SCRATCH_ROOT = "cutcheck: no scratch root could be placed for"
@@ -1904,6 +1933,93 @@ def _pairwise(siblings, reads):
     return findings
 
 
+def _levels(siblings, ids):
+    """Each issued item's level, and the ids no level resolves for.
+
+    Level 1 is an item depending on nothing inside the set; every other item's
+    level is one past the greatest level among its ``depends_on`` here. Only
+    edges inside the set count, because an id naming something this cut does
+    not hold orders nothing in it.
+
+    An item whose dependencies never all resolve is inside a ``depends_on``
+    cycle or behind one. It is returned unresolved and named in the reading
+    rather than raised: a cut this tool cannot order is a fact about the cut,
+    and a reader who asked for a shape gets the shape and the reason the rest
+    of it is missing. Raising would take the whole report -- findings included
+    -- down with the one set that most needs reading.
+    """
+
+    deps = {item: [d for d in _listed(siblings[item], "depends_on") if d in ids]
+            for item in ids}
+    level = {}
+    pending = list(ids)
+    while pending:
+        ready = [item for item in pending if all(d in level for d in deps[item])]
+        if not ready:
+            break
+        for item in ready:
+            level[item] = 1 + max([level[d] for d in deps[item]] or [0])
+        pending = [item for item in pending if item not in level]
+    return level, deps, sorted(pending)
+
+
+def _critical_path(level, deps):
+    """The longest ``depends_on`` chain, read back from its deepest item.
+
+    Every dependency of a levelled item is levelled, and an item's level is one
+    past the greatest of theirs, so stepping to the deepest dependency at each
+    hop walks a chain as long as the level says it is. Ties are broken on the
+    id so that one cut reads the same twice: the chain is a reading a decomposer
+    compares between revisions, and an arbitrary tie would make it move on its
+    own.
+    """
+
+    if not level:
+        return []
+    node = max(sorted(level), key=lambda item: level[item])
+    chain = [node]
+    while deps[node]:
+        node = max(sorted(deps[node]), key=lambda item: level[item])
+        chain.append(node)
+    chain.reverse()
+    return chain
+
+
+def _graph_reading(run, siblings):
+    """The cut's shape: how deep it is, and how wide at each level.
+
+    Against the run rather than any ticket, because neither reading is a
+    property of one item -- the chain is the run's length in dispatches and the
+    widths are what each frontier asks of the host at once. Over the issued
+    items alone, for the reason `_issued_items` gives: a root does not run
+    beside its own subtree and a gate runs behind all of it, so counting either
+    would report a shape no frontier ever executes.
+
+    A set with no issued item is read as nothing at all rather than as a shape
+    of zero: there is no cut there to have one.
+    """
+
+    ids = _issued_items(siblings, _root_ids(siblings))
+    if not ids:
+        return []
+    level, deps, cycled = _levels(siblings, ids)
+    chain = _critical_path(level, deps)
+    detail = "{}: {}".format(len(chain), " > ".join(chain)) if chain else "0"
+    if cycled:
+        detail += "; cycle: {}".format(", ".join(cycled))
+    deepest = max(level.values()) if level else 0
+    widths = [
+        sum(1 for item in level if level[item] == depth)
+        for depth in range(1, deepest + 1)
+    ]
+    return [
+        (run, 0, CRITICAL_PATH, detail),
+        # `0` where nothing resolved: every item is in a cycle or behind one,
+        # and the chain's line names which.
+        (run, 0, LEVEL_WIDTH, " ".join(str(width) for width in widths) or "0"),
+    ]
+
+
 def _coverage_path(run_dir, name=COVERAGE_FILE):
     """Where the acceptance-coverage map lives for a resolved ticket root.
 
@@ -2394,6 +2510,16 @@ def main(argv=None):
         print(ADVISORY_HEADING)
         for finding in advisory:
             print(_finding_line(*finding))
+    # Read from the same `siblings` the findings were, and printed whatever
+    # they said. It stands after the advisory block so that everything the exit
+    # status answers for is above it and read first, and it is built outside
+    # `findings` rather than added to them and excused: a class in that list is
+    # a class the status has an opinion about, and this one must not be.
+    shape = _graph_reading(args.run, siblings)
+    if shape:
+        print(GRAPH_HEADING)
+        for reading in shape:
+            print(_finding_line(*reading))
     if outside:
         return REPORTED
     # Zero bytes reads the same as a run that never happened. A set whose only

--- a/scripts/tickets.py
+++ b/scripts/tickets.py
@@ -2312,6 +2312,11 @@ def _cmd_amend(rest):
             "error": f"the amended ticket {run}/{ticket_id} would be off contract "
             f"(contracts/work-item.md): " + "; ".join(defects)
         }
+    over = _ceiling_error(
+        f"the amended ticket {run}/{ticket_id}", ticket_id, rendered
+    )
+    if over is not None:
+        return over
     try:
         ticket_path.write_text(rendered, encoding="utf-8")
     except OSError as error:

--- a/scripts/tickets.py
+++ b/scripts/tickets.py
@@ -263,6 +263,10 @@ ITERATION_ID_RE = re.compile(r"^.+\.iter\.\d+$")
 # The gate's last stub. A ticket depending on it is scope queued behind the
 # whole root subtree rather than work inside it.
 GATE_VERIFY_SUFFIX = ".gate.verify"
+# What every gate stub's id carries, `<root>.gate.<lane>`. `gate` renders
+# them from the root's own acceptance, so they are the root's carriage, not
+# unit packets a cutter wrote.
+GATE_ID_MARKER = ".gate."
 # The heading that closes a run's notes. Written only by `--terminal`, so
 # the file carries no terminal placeholder until it closes and the marker
 # means what it says: while it is absent the run is open.
@@ -2328,8 +2332,17 @@ def _ceiling_error(subject: str, ticket_id: str, text: str):
     Applied where the cutter still holds the flag that was wrong. An
     objective enumerating (1)...(5) cannot fit inside the ceiling, which is
     the point: the ticket that does not fit is two tickets.
+
+    The ceiling is a unit's. A root ticket states a whole run, and each
+    `.gate.` stub carries the root's `## Completion test` verbatim -- `gate`
+    renders them from it -- so grading either against the unit ceiling would
+    refuse what this script itself writes.
     """
 
+    if GATE_ID_MARKER in str(ticket_id or ""):
+        return None
+    if _executor_of(_parse_frontmatter(text)) == ROOT_EXECUTOR:
+        return None
     count = instruction_words(text)
     if count <= INSTRUCTION_BUDGET:
         return None

--- a/scripts/tickets.py
+++ b/scripts/tickets.py
@@ -173,6 +173,16 @@ EXECUTOR_SECTIONS_BY_KEY = {name.lower(): name for name in EXECUTOR_SECTIONS}
 # executor is the moving target rules/verification.md §3 forbids.
 CUT_SECTIONS = ("Objective", "Fixed inputs", "Completion test", "Return fields")
 CUT_SECTIONS_BY_KEY = {name.lower(): name for name in CUT_SECTIONS}
+# rules/token-economy.md §11: a stub's instruction is an every-dispatch unit
+# of 300 words -- the sections below plus the frontmatter `excluded_actions`,
+# never `## Fixed inputs`, which are identities. Words, not lines: a line
+# count is met by widening lines. Markdown link targets are stripped first so
+# a citation costs its label, not its path. `tools/validate.py` graded the
+# template stubs by a counter of its own; the ceiling belongs beside the rest
+# of ticket shape, and the compiler reads it from here.
+INSTRUCTION_BUDGET = 300
+INSTRUCTION_SECTIONS = ("Objective", "Completion test", "Return fields")
+LINK_TARGET_RE = re.compile(r"\]\([^)]*\)")
 # contracts/work-item.md states the sections in this order; a created section
 # takes its place in it, never the end of the file.
 SECTION_ORDER = (
@@ -1047,6 +1057,21 @@ def _sections(text: str) -> dict:
     if heading is not None:
         sections[heading] = "\n".join(body).strip()
     return sections
+
+
+def instruction_words(text: str) -> int:
+    """One ticket's instruction in words, markdown link targets stripped.
+
+    The objective, the completion test, the return fields and the
+    frontmatter `excluded_actions` -- what a child loads on every dispatch.
+    Never `## Fixed inputs`: those are identities, and counting them would
+    charge a cutter for supplying evidence (rules/token-economy.md §11).
+    """
+
+    sections = _sections(text)
+    parts = [str(item) for item in _parse_frontmatter(text).get("excluded_actions") or []]
+    parts += [sections.get(name, "") for name in INSTRUCTION_SECTIONS]
+    return sum(len(LINK_TARGET_RE.sub("]", part).split()) for part in parts)
 
 
 def _frontmatter_end(lines) -> int:
@@ -2297,6 +2322,26 @@ def _cmd_amend(rest):
     }
 
 
+def _ceiling_error(subject: str, ticket_id: str, text: str):
+    """The refusal a ticket over the instruction ceiling gets, or ``None``.
+
+    Applied where the cutter still holds the flag that was wrong. An
+    objective enumerating (1)...(5) cannot fit inside the ceiling, which is
+    the point: the ticket that does not fit is two tickets.
+    """
+
+    count = instruction_words(text)
+    if count <= INSTRUCTION_BUDGET:
+        return None
+    return {
+        "error": f"{subject} has a {count}-word instruction, over the "
+        f"{INSTRUCTION_BUDGET}-word ceiling (rules/token-economy.md §11): the "
+        "objective, completion test, excluded actions and return fields a "
+        "child loads every dispatch, never its fixed inputs. A compound "
+        "objective is two items, not one longer ticket"
+    }
+
+
 def _issue_ticket(run: str, ticket_id: str, text: str):
     """Grade one rendered ticket, then write it — in that order.
 
@@ -2310,6 +2355,9 @@ def _issue_ticket(run: str, ticket_id: str, text: str):
             "error": f"ticket {run}/{ticket_id} is off contract "
             f"(contracts/work-item.md): " + "; ".join(defects)
         }
+    over = _ceiling_error(f"ticket {run}/{ticket_id}", ticket_id, text)
+    if over is not None:
+        return over
     tickets_root = _tickets_root()
     if tickets_root is None:
         return {"error": NO_SINK_ERROR}

--- a/scripts/tickets.py
+++ b/scripts/tickets.py
@@ -2348,7 +2348,8 @@ def _ceiling_error(subject: str, ticket_id: str, text: str):
         return None
     return {
         "error": f"{subject} has a {count}-word instruction, over the "
-        f"{INSTRUCTION_BUDGET}-word ceiling (rules/token-economy.md §11): the "
+        f"{INSTRUCTION_BUDGET}-word ceiling (rules/token-economy.md, section "
+        "11): the "
         "objective, completion test, excluded actions and return fields a "
         "child loads every dispatch, never its fixed inputs. A compound "
         "objective is two items, not one longer ticket"

--- a/skills/kernel/orch-decompose/SKILL.md
+++ b/skills/kernel/orch-decompose/SKILL.md
@@ -9,16 +9,23 @@ Require: a root
 pack's slicing reference and oracle_policy. Reject a root missing any
 part that contract names, naming it.
 
+Goal: minimize the run's critical path subject to every item an atom
+([rules/topology.md](../../../rules/topology.md) §3). Count is
+unbounded above; width beyond the host profile is the frontier's
+queue, not the cut's.
+
 Cut the root ticket into [work items](../../../contracts/work-item.md)
-under the slicing — cut count per
-[rules/topology.md](../../../rules/topology.md) §3 — issued as
-`<root>.NN` into the root's own run directory through `tickets.py new`.
-Each item takes `isolation: required` when the pack's workspace cell
-names a mechanism and the item's write scope lies inside it, a write
-scope overlapping only siblings it is dependency-ordered with, a bound,
-its edges, and a completion test whose criteria name oracles from the
-pack's oracle policy, each with its provenance; `independence: gate`
-when a `judged` criterion there rides the final gate.
+under the slicing, issued as `<root>.NN` into the root's own run
+directory through `tickets.py new`. Each item takes a write scope
+overlapping only siblings it is dependency-ordered with,
+`isolation: required` when the pack's workspace cell names a mechanism
+covering that scope, a bound, its edges, and a completion test whose
+criteria name oracles from the pack's oracle policy, each with its
+provenance; `independence: gate` when a `judged` criterion there rides
+the final gate. Per §3: draw an edge only where the dependent's oracle
+reads what the predecessor writes or its fixed inputs cite the
+predecessor's result identity; and give an artifact more than one item
+would write to exactly one of them, never shared.
 Emit the assembly item the pack's cell names, on §4's terms.
 
 Then run `cutcheck.py` against the revision the set was cut from,
@@ -34,5 +41,6 @@ remainder at `<state-root>/runs/<run>/<root>.coverage.md`.
 Never: edit the root ticket's frozen statement.
 
 Return: status; result — the ticket directory; verification — the
-cutcheck result; then item ids with edges, uncovered remainder (`[]`
-when none), and decision_gap (`[]` when coverable).
+cutcheck result; then item ids with edges, the critical-path length and
+per-level width from cutcheck's `graph` block, uncovered remainder (`[]` when
+none), and decision_gap (`[]` when coverable).

--- a/skills/kernel/orch-decompose/SKILL.md
+++ b/skills/kernel/orch-decompose/SKILL.md
@@ -9,10 +9,10 @@ Require: a root
 pack's slicing reference and oracle_policy. Reject a root missing any
 part that contract names, naming it.
 
-Goal: minimize the run's critical path subject to every item an atom
-([rules/topology.md](../../../rules/topology.md) §3). Count is
-unbounded above; width beyond the host profile is the frontier's
-queue, not the cut's.
+Goal: minimize the run's critical path subject to every item an atom.
+The atom test, and where a cut's count and its width are settled, are
+[rules/topology.md](../../../rules/topology.md) §3's; read it before
+the first item.
 
 Cut the root ticket into [work items](../../../contracts/work-item.md)
 under the slicing, issued as `<root>.NN` into the root's own run
@@ -22,10 +22,9 @@ overlapping only siblings it is dependency-ordered with,
 covering that scope, a bound, its edges, and a completion test whose
 criteria name oracles from the pack's oracle policy, each with its
 provenance; `independence: gate` when a `judged` criterion there rides
-the final gate. Per §3: draw an edge only where the dependent's oracle
-reads what the predecessor writes or its fixed inputs cite the
-predecessor's result identity; and give an artifact more than one item
-would write to exactly one of them, never shared.
+the final gate. Draw each edge under §3's edge rule and place each
+artifact two items would write under its sole-owner rule, at the point
+you decide one.
 Emit the assembly item the pack's cell names, on §4's terms.
 
 Then run `cutcheck.py` against the revision the set was cut from,

--- a/skills/kernel/orch-decompose/SKILL.md
+++ b/skills/kernel/orch-decompose/SKILL.md
@@ -40,6 +40,6 @@ remainder at `<state-root>/runs/<run>/<root>.coverage.md`.
 Never: edit the root ticket's frozen statement.
 
 Return: status; result — the ticket directory; verification — the
-cutcheck result; then item ids with edges, the critical-path length and
-per-level width from cutcheck's `graph` block, uncovered remainder (`[]` when
-none), and decision_gap (`[]` when coverable).
+cutcheck result; then item ids with edges, the critical-path length
+and per-level width from cutcheck's `graph` block, uncovered
+remainder (`[]` when none), and decision_gap (`[]` when coverable).

--- a/skills/kernel/orch-decompose/references/cut-lens.md
+++ b/skills/kernel/orch-decompose/references/cut-lens.md
@@ -25,6 +25,10 @@ the unclaimed items, `tickets.py new` for one the cut is missing, and
 - Slicing fidelity: the cut is the shape the stamped pack's `slicing`
   cell prescribes, terminal assembly item included
   ([contracts/pack-signature.md](../../../../contracts/pack-signature.md)).
+- false edge: an edge no oracle-read or cited result identity
+  justifies; without it a level widens at no cost. Read it from
+  `cutcheck.py`'s `graph` block — `critical-path` and `level-width` —
+  beside each item's oracles and `## Fixed inputs`.
 
 ## Proving a copy
 

--- a/skills/kernel/orch-decompose/references/cut-lens.md
+++ b/skills/kernel/orch-decompose/references/cut-lens.md
@@ -29,6 +29,10 @@ the unclaimed items, `tickets.py new` for one the cut is missing, and
   justifies; without it a level widens at no cost. Read it from
   `cutcheck.py`'s `graph` block — `critical-path` and `level-width` —
   beside each item's oracles and `## Fixed inputs`.
+- compound item: an item whose criteria partition into subsets with
+  disjoint write scopes, each subset still discriminating — two atoms
+  issued as one. The instruction ceiling `tickets.py new` enforces is
+  this judgment's mechanical half, never the whole of it.
 
 ## Proving a copy
 

--- a/skills/kernel/orch-integrate/SKILL.md
+++ b/skills/kernel/orch-integrate/SKILL.md
@@ -37,7 +37,11 @@ vantage error, not a verdict.
 Classify by blame per the
 [work-item contract](../../../contracts/work-item.md#dispatch) and
 record the class through `tickets.py run-state --note`. The join alone
-writes terminal status (`tickets.py set-status`).
+writes terminal status (`tickets.py set-status`). At a critique join,
+an accepted defect set of `[]` across every critique the
+`<root>.gate.repair` depends on completes that repair here — empty
+disposition filed through `tickets.py result`, then
+`set-status complete` — with no dispatch.
 
 Never: trust out-of-scope output; re-run a covered oracle; repair the
 result yourself.

--- a/tests/fixtures/cutcheck/cutcheck-graph/01-alpha.md
+++ b/tests/fixtures/cutcheck/cutcheck-graph/01-alpha.md
@@ -1,0 +1,32 @@
+---
+id: 01-alpha
+run: cutcheck-graph
+status: issued
+executor: orch-tdd
+pack: orch-code-pack
+independence: gate
+depends_on: []
+bound: 20 tool calls
+write_scope:
+  - docs/vocabulary.md
+excluded_actions:
+  - editing scripts/tickets.py
+---
+## Objective
+
+Fixture set for the shape reading: this item depends on nothing in the set, so
+it sits on the first level, and the chain the reading names starts here.
+
+## Fixed inputs
+
+- Baseline: the revision cutcheck is invoked with.
+
+## Completion test
+
+1. **Installed under its bare name.** `grep -n "cutcheck.py" install.py` returns
+   the SCRIPT_NAMES line. oracle_class: deterministic. provenance:
+   pre-existing.
+
+## Result
+
+[]

--- a/tests/fixtures/cutcheck/cutcheck-graph/02-beta.md
+++ b/tests/fixtures/cutcheck/cutcheck-graph/02-beta.md
@@ -1,0 +1,32 @@
+---
+id: 02-beta
+run: cutcheck-graph
+status: issued
+executor: orch-tdd
+pack: orch-code-pack
+independence: gate
+depends_on: []
+bound: 20 tool calls
+write_scope:
+  - rules/topology.md
+excluded_actions:
+  - editing scripts/tickets.py
+---
+## Objective
+
+Fixture set for the shape reading: a second item on the first level, and one
+the last level's item depends on without lengthening the chain.
+
+## Fixed inputs
+
+- Baseline: the revision cutcheck is invoked with.
+
+## Completion test
+
+1. **Installed under its bare name.** `grep -n "cutcheck.py" install.py` returns
+   the SCRIPT_NAMES line. oracle_class: deterministic. provenance:
+   pre-existing.
+
+## Result
+
+[]

--- a/tests/fixtures/cutcheck/cutcheck-graph/03-gamma.md
+++ b/tests/fixtures/cutcheck/cutcheck-graph/03-gamma.md
@@ -1,0 +1,32 @@
+---
+id: 03-gamma
+run: cutcheck-graph
+status: issued
+executor: orch-tdd
+pack: orch-code-pack
+independence: gate
+depends_on: []
+bound: 20 tool calls
+write_scope:
+  - packs/orch-code-pack/SKILL.md
+excluded_actions:
+  - editing scripts/tickets.py
+---
+## Objective
+
+Fixture set for the shape reading: a third item on the first level, on no
+chain at all, so the first level's width is three where the chain is one.
+
+## Fixed inputs
+
+- Baseline: the revision cutcheck is invoked with.
+
+## Completion test
+
+1. **Installed under its bare name.** `grep -n "cutcheck.py" install.py` returns
+   the SCRIPT_NAMES line. oracle_class: deterministic. provenance:
+   pre-existing.
+
+## Result
+
+[]

--- a/tests/fixtures/cutcheck/cutcheck-graph/04-delta.md
+++ b/tests/fixtures/cutcheck/cutcheck-graph/04-delta.md
@@ -1,0 +1,33 @@
+---
+id: 04-delta
+run: cutcheck-graph
+status: issued
+executor: orch-tdd
+pack: orch-code-pack
+independence: gate
+depends_on:
+  - 01-alpha
+bound: 20 tool calls
+write_scope:
+  - README.md
+excluded_actions:
+  - editing scripts/tickets.py
+---
+## Objective
+
+Fixture set for the shape reading: one first-level item stands behind this one,
+so it is the second level and the second link of the chain.
+
+## Fixed inputs
+
+- Baseline: the revision cutcheck is invoked with.
+
+## Completion test
+
+1. **Installed under its bare name.** `grep -n "cutcheck.py" install.py` returns
+   the SCRIPT_NAMES line. oracle_class: deterministic. provenance:
+   pre-existing.
+
+## Result
+
+[]

--- a/tests/fixtures/cutcheck/cutcheck-graph/05-epsilon.md
+++ b/tests/fixtures/cutcheck/cutcheck-graph/05-epsilon.md
@@ -1,0 +1,34 @@
+---
+id: 05-epsilon
+run: cutcheck-graph
+status: issued
+executor: orch-tdd
+pack: orch-code-pack
+independence: gate
+depends_on:
+  - 04-delta
+  - 02-beta
+bound: 20 tool calls
+write_scope:
+  - AGENTS.md
+excluded_actions:
+  - editing scripts/tickets.py
+---
+## Objective
+
+Fixture set for the shape reading: two items stand behind this one, one on each
+of the levels below, so the greater of them decides the level and the chain.
+
+## Fixed inputs
+
+- Baseline: the revision cutcheck is invoked with.
+
+## Completion test
+
+1. **Installed under its bare name.** `grep -n "cutcheck.py" install.py` returns
+   the SCRIPT_NAMES line. oracle_class: deterministic. provenance:
+   pre-existing.
+
+## Result
+
+[]

--- a/tests/fixtures/cutcheck/cutcheck-graph/coverage.md
+++ b/tests/fixtures/cutcheck/cutcheck-graph/coverage.md
@@ -1,0 +1,9 @@
+# Acceptance coverage — cutcheck-graph
+
+| criterion | owner |
+| --- | --- |
+| 1 | 01-alpha |
+| 2 | 02-beta |
+| 3 | 03-gamma |
+| 4 | 04-delta |
+| 5 | 05-epsilon |

--- a/tests/fixtures/cutcheck/verdicts.json
+++ b/tests/fixtures/cutcheck/verdicts.json
@@ -5,7 +5,7 @@
    "cutcheck: advisory -- reported, and never setting the exit status:",
    "01-barenoun: family 1: extraction-gap: criterion 2: **A mention standing alone is an extraction gap.** The only command head this criterion states is `p | oracle_class: deterministic",
    "cutcheck-barenoun: family 5: coverage-map-absent: tests/fixtures/cutcheck/cutcheck-barenoun/coverage.md",
-   "cutcheck: the shape of this cut -- read, and never setting the exit status:",
+   "cutcheck: the shape of this cut -- how long and how wide it is, and no finding of any kind:",
    "cutcheck-barenoun: graph: critical-path: 1: 01-barenoun",
    "cutcheck-barenoun: graph: level-width: 1",
    "cutcheck: no finding outside the advisory set"
@@ -14,7 +14,7 @@
  "cutcheck-carveouts": {
   "exit": 0,
   "lines": [
-   "cutcheck: the shape of this cut -- read, and never setting the exit status:",
+   "cutcheck: the shape of this cut -- how long and how wide it is, and no finding of any kind:",
    "cutcheck-carveouts: graph: critical-path: 2: 01-reads-only > 02-depends",
    "cutcheck-carveouts: graph: level-width: 1 2",
    "cutcheck: no finding outside the advisory set"
@@ -23,7 +23,7 @@
  "cutcheck-clean": {
   "exit": 0,
   "lines": [
-   "cutcheck: the shape of this cut -- read, and never setting the exit status:",
+   "cutcheck: the shape of this cut -- how long and how wide it is, and no finding of any kind:",
    "cutcheck-clean: graph: critical-path: 1: 01-clean-oracles",
    "cutcheck-clean: graph: level-width: 1",
    "cutcheck: no finding outside the advisory set"
@@ -36,7 +36,7 @@
    "01-quoted: family 1: extraction-gap: criterion 2: **A span quoted as what the guard refuses is no oracle.** The confinement gate refuses `git log --ou | oracle_class: deterministic",
    "01-quoted: family 1: extraction-gap: criterion 3: **A span quoted as what CI runs is no oracle.** A whole-module invocation such as `python3 -m unitte | oracle_class: deterministic",
    "cutcheck-command-mention: family 5: coverage-map-absent: tests/fixtures/cutcheck/cutcheck-command-mention/coverage.md",
-   "cutcheck: the shape of this cut -- read, and never setting the exit status:",
+   "cutcheck: the shape of this cut -- how long and how wide it is, and no finding of any kind:",
    "cutcheck-command-mention: graph: critical-path: 1: 01-quoted",
    "cutcheck-command-mention: graph: level-width: 1",
    "cutcheck: no finding outside the advisory set"
@@ -48,7 +48,7 @@
    "cutcheck: advisory -- reported, and never setting the exit status:",
    "01-evalhead: family 1: extraction-gap: criterion 1: **An interpreter evaluating its argument is never executed.** `python3 -c \"import pathlib;pathlib.Pa | oracle_class: deterministic",
    "cutcheck-evalhead: family 5: coverage-map-absent: tests/fixtures/cutcheck/cutcheck-evalhead/coverage.md",
-   "cutcheck: the shape of this cut -- read, and never setting the exit status:",
+   "cutcheck: the shape of this cut -- how long and how wide it is, and no finding of any kind:",
    "cutcheck-evalhead: graph: critical-path: 1: 01-evalhead",
    "cutcheck-evalhead: graph: level-width: 1",
    "cutcheck: no finding outside the advisory set"
@@ -60,7 +60,7 @@
    "01-cuttime: family 1: no-hits-both-revisions: criterion 1: grep -rn \"zzqq-cuttime-token\" install.py",
    "cutcheck: advisory -- reported, and never setting the exit status:",
    "cutcheck-f1-cuttime: family 5: coverage-map-absent: tests/fixtures/cutcheck/cutcheck-f1-cuttime/coverage.md",
-   "cutcheck: the shape of this cut -- read, and never setting the exit status:",
+   "cutcheck: the shape of this cut -- how long and how wide it is, and no finding of any kind:",
    "cutcheck-f1-cuttime: graph: critical-path: 1: 01-cuttime",
    "cutcheck-f1-cuttime: graph: level-width: 1"
   ]
@@ -73,7 +73,7 @@
    "01-discrimination: family 1: fails-both-revisions: criterion 3: python3 -B -m unittest tests.test_installer.NoSuchClass.test_absent",
    "cutcheck: advisory -- reported, and never setting the exit status:",
    "cutcheck-f1-discrimination: family 5: coverage-map-absent: tests/fixtures/cutcheck/cutcheck-f1-discrimination/coverage.md",
-   "cutcheck: the shape of this cut -- read, and never setting the exit status:",
+   "cutcheck: the shape of this cut -- how long and how wide it is, and no finding of any kind:",
    "cutcheck-f1-discrimination: graph: critical-path: 1: 01-discrimination",
    "cutcheck-f1-discrimination: graph: level-width: 1"
   ]
@@ -84,7 +84,7 @@
    "cutcheck: advisory -- reported, and never setting the exit status:",
    "01-extraction-gap: family 1: extraction-gap: criterion 1: **The boundary reads clearly to a first reader.** A reviewer who has not seen this ticket can name,  | oracle_class: judgment",
    "cutcheck-f1-extraction-gap: family 5: coverage-map-absent: tests/fixtures/cutcheck/cutcheck-f1-extraction-gap/coverage.md",
-   "cutcheck: the shape of this cut -- read, and never setting the exit status:",
+   "cutcheck: the shape of this cut -- how long and how wide it is, and no finding of any kind:",
    "cutcheck-f1-extraction-gap: graph: critical-path: 1: 01-extraction-gap",
    "cutcheck-f1-extraction-gap: graph: level-width: 1",
    "cutcheck: no finding outside the advisory set"
@@ -95,7 +95,7 @@
   "lines": [
    "cutcheck: advisory -- reported, and never setting the exit status:",
    "cutcheck-f1-phantom: family 5: coverage-map-absent: tests/fixtures/cutcheck/cutcheck-f1-phantom/coverage.md",
-   "cutcheck: the shape of this cut -- read, and never setting the exit status:",
+   "cutcheck: the shape of this cut -- how long and how wide it is, and no finding of any kind:",
    "cutcheck-f1-phantom: graph: critical-path: 2: 01-phantom > 02-nested-list",
    "cutcheck-f1-phantom: graph: level-width: 1 1",
    "cutcheck: no finding outside the advisory set"
@@ -108,7 +108,7 @@
    "01-shape: family 1: cumulative-range: criterion 2: git diff --name-only ac8791a..HEAD",
    "cutcheck: advisory -- reported, and never setting the exit status:",
    "cutcheck-f1-shape: family 5: coverage-map-absent: tests/fixtures/cutcheck/cutcheck-f1-shape/coverage.md",
-   "cutcheck: the shape of this cut -- read, and never setting the exit status:",
+   "cutcheck: the shape of this cut -- how long and how wide it is, and no finding of any kind:",
    "cutcheck-f1-shape: graph: critical-path: 1: 01-shape",
    "cutcheck-f1-shape: graph: level-width: 1"
   ]
@@ -119,7 +119,7 @@
    "cutcheck: advisory -- reported, and never setting the exit status:",
    "01-truncated: family 1: extraction-gap: criterion 2: **The criterion after the interruption.** A reviewer names, from the module docstring alone, every f | oracle_class: judgment",
    "cutcheck-f1-truncated: family 5: coverage-map-absent: tests/fixtures/cutcheck/cutcheck-f1-truncated/coverage.md",
-   "cutcheck: the shape of this cut -- read, and never setting the exit status:",
+   "cutcheck: the shape of this cut -- how long and how wide it is, and no finding of any kind:",
    "cutcheck-f1-truncated: graph: critical-path: 1: 01-truncated",
    "cutcheck-f1-truncated: graph: level-width: 1",
    "cutcheck: no finding outside the advisory set"
@@ -131,7 +131,7 @@
    "01-f2-paths: family 2: missing-path: criterion 1: .orch/evidence/f2-missing/: grep -rn \"verdict\" .orch/evidence/f2-missing/",
    "01-f2-paths: family 2: unresolved-citation: criterion 2: install.py:99999",
    "01-f2-paths: family 2: quote-not-at-citation: criterion 3: \"no line reads this way\" not at install.py:1",
-   "cutcheck: the shape of this cut -- read, and never setting the exit status:",
+   "cutcheck: the shape of this cut -- how long and how wide it is, and no finding of any kind:",
    "cutcheck-f2-paths: graph: critical-path: 1: 01-f2-paths",
    "cutcheck-f2-paths: graph: level-width: 1"
   ]
@@ -145,7 +145,7 @@
    "01-unscoped: family 4: staged-invalidation: with 02-contradiction: install.py",
    "cutcheck: advisory -- reported, and never setting the exit status:",
    "cutcheck-f3-scope: family 5: coverage-map-absent: tests/fixtures/cutcheck/cutcheck-f3-scope/coverage.md",
-   "cutcheck: the shape of this cut -- read, and never setting the exit status:",
+   "cutcheck: the shape of this cut -- how long and how wide it is, and no finding of any kind:",
    "cutcheck-f3-scope: graph: critical-path: 1: 01-unscoped",
    "cutcheck-f3-scope: graph: level-width: 2"
   ]
@@ -155,7 +155,7 @@
   "lines": [
    "cutcheck: advisory -- reported, and never setting the exit status:",
    "cutcheck-f4-ordered: family 5: coverage-map-absent: tests/fixtures/cutcheck/cutcheck-f4-ordered/coverage.md",
-   "cutcheck: the shape of this cut -- read, and never setting the exit status:",
+   "cutcheck: the shape of this cut -- how long and how wide it is, and no finding of any kind:",
    "cutcheck-f4-ordered: graph: critical-path: 2: 01-reader > 02-rewriter",
    "cutcheck-f4-ordered: graph: level-width: 1 1",
    "cutcheck: no finding outside the advisory set"
@@ -170,7 +170,7 @@
    "03-alpha: family 1: extraction-gap: criterion 1: **The shared scope is the whole defect.** The two scopes intersect, which the report names without r | oracle_class: deterministic",
    "04-beta: family 1: extraction-gap: criterion 1: **The shared scope is the whole defect.** The two scopes intersect, which the report names without r | oracle_class: deterministic",
    "cutcheck-f4-pairs: family 5: coverage-map-absent: tests/fixtures/cutcheck/cutcheck-f4-pairs/coverage.md",
-   "cutcheck: the shape of this cut -- read, and never setting the exit status:",
+   "cutcheck: the shape of this cut -- how long and how wide it is, and no finding of any kind:",
    "cutcheck-f4-pairs: graph: critical-path: 1: 01-reader",
    "cutcheck-f4-pairs: graph: level-width: 4"
   ]
@@ -180,7 +180,7 @@
   "lines": [
    "cutcheck: advisory -- reported, and never setting the exit status:",
    "cutcheck-f4-transitive: family 5: coverage-map-absent: tests/fixtures/cutcheck/cutcheck-f4-transitive/coverage.md",
-   "cutcheck: the shape of this cut -- read, and never setting the exit status:",
+   "cutcheck: the shape of this cut -- how long and how wide it is, and no finding of any kind:",
    "cutcheck-f4-transitive: graph: critical-path: 3: 01-first > 02-middle > 03-third",
    "cutcheck-f4-transitive: graph: level-width: 1 1 1",
    "cutcheck: no finding outside the advisory set"
@@ -191,7 +191,7 @@
   "lines": [
    "cutcheck-f5-coverage: family 5: orphan-criterion: criterion 3: 03-absent",
    "02-orphan-item: family 5: orphan-item: named by no criterion in coverage.md",
-   "cutcheck: the shape of this cut -- read, and never setting the exit status:",
+   "cutcheck: the shape of this cut -- how long and how wide it is, and no finding of any kind:",
    "cutcheck-f5-coverage: graph: critical-path: 1: 01-covered",
    "cutcheck-f5-coverage: graph: level-width: 2"
   ]
@@ -201,7 +201,7 @@
   "lines": [
    "cutcheck: advisory -- reported, and never setting the exit status:",
    "cutcheck-f5-nomap: family 5: coverage-map-absent: tests/fixtures/cutcheck/cutcheck-f5-nomap/coverage.md",
-   "cutcheck: the shape of this cut -- read, and never setting the exit status:",
+   "cutcheck: the shape of this cut -- how long and how wide it is, and no finding of any kind:",
    "cutcheck-f5-nomap: graph: critical-path: 1: 01-lonely",
    "cutcheck-f5-nomap: graph: level-width: 1",
    "cutcheck: no finding outside the advisory set"
@@ -212,7 +212,7 @@
   "lines": [
    "cutcheck: advisory -- reported, and never setting the exit status:",
    "02-materialize: family 5: coverage-map-absent: tests/fixtures/cutcheck/cutcheck-f5-template/02-materialize.coverage.md",
-   "cutcheck: the shape of this cut -- read, and never setting the exit status:",
+   "cutcheck: the shape of this cut -- how long and how wide it is, and no finding of any kind:",
    "cutcheck-f5-template: graph: critical-path: 1: 00-acquire.01",
    "cutcheck-f5-template: graph: level-width: 2",
    "cutcheck: no finding outside the advisory set"
@@ -224,7 +224,7 @@
    "03-alien: family 6: illegal-executor: orch-render is neither orch-code-pack's executor cell nor its assembly cell",
    "cutcheck: advisory -- reported, and never setting the exit status:",
    "cutcheck-f6-executor: family 5: coverage-map-absent: tests/fixtures/cutcheck/cutcheck-f6-executor/coverage.md",
-   "cutcheck: the shape of this cut -- read, and never setting the exit status:",
+   "cutcheck: the shape of this cut -- how long and how wide it is, and no finding of any kind:",
    "cutcheck-f6-executor: graph: critical-path: 1: 02-legal",
    "cutcheck-f6-executor: graph: level-width: 2"
   ]
@@ -236,7 +236,7 @@
    "01-git-graded: family 1: already-passes: criterion 2: git diff ac8791a -- install.py",
    "cutcheck: advisory -- reported, and never setting the exit status:",
    "cutcheck-git-graded: family 5: coverage-map-absent: tests/fixtures/cutcheck/cutcheck-git-graded/coverage.md",
-   "cutcheck: the shape of this cut -- read, and never setting the exit status:",
+   "cutcheck: the shape of this cut -- how long and how wide it is, and no finding of any kind:",
    "cutcheck-git-graded: graph: critical-path: 1: 01-git-graded",
    "cutcheck-git-graded: graph: level-width: 1"
   ]
@@ -248,7 +248,7 @@
    "01-gitescape: family 1: unconfined-oracle: criterion 2: git log --output=/tmp/cutcheck-gitescape-wrote",
    "cutcheck: advisory -- reported, and never setting the exit status:",
    "cutcheck-gitescape: family 5: coverage-map-absent: tests/fixtures/cutcheck/cutcheck-gitescape/coverage.md",
-   "cutcheck: the shape of this cut -- read, and never setting the exit status:",
+   "cutcheck: the shape of this cut -- how long and how wide it is, and no finding of any kind:",
    "cutcheck-gitescape: graph: critical-path: 1: 01-gitescape",
    "cutcheck-gitescape: graph: level-width: 1"
   ]
@@ -256,7 +256,7 @@
  "cutcheck-graph": {
   "exit": 0,
   "lines": [
-   "cutcheck: the shape of this cut -- read, and never setting the exit status:",
+   "cutcheck: the shape of this cut -- how long and how wide it is, and no finding of any kind:",
    "cutcheck-graph: graph: critical-path: 3: 01-alpha > 04-delta > 05-epsilon",
    "cutcheck-graph: graph: level-width: 3 1 1",
    "cutcheck: no finding outside the advisory set"
@@ -268,7 +268,7 @@
    "01-mention: family 3: unscoped-write: .orch/evidence/mention/verdict.txt",
    "cutcheck: advisory -- reported, and never setting the exit status:",
    "cutcheck-mention: family 5: coverage-map-absent: tests/fixtures/cutcheck/cutcheck-mention/coverage.md",
-   "cutcheck: the shape of this cut -- read, and never setting the exit status:",
+   "cutcheck: the shape of this cut -- how long and how wide it is, and no finding of any kind:",
    "cutcheck-mention: graph: critical-path: 1: 01-mention",
    "cutcheck-mention: graph: level-width: 1"
   ]
@@ -281,7 +281,7 @@
    "cutcheck: advisory -- reported, and never setting the exit status:",
    "01-pre-existing: family 1: verdict-in-output: criterion 3: grep -c \"SCRIPT_NAMES\" install.py",
    "cutcheck-provenance: family 5: coverage-map-absent: tests/fixtures/cutcheck/cutcheck-provenance/coverage.md",
-   "cutcheck: the shape of this cut -- read, and never setting the exit status:",
+   "cutcheck: the shape of this cut -- how long and how wide it is, and no finding of any kind:",
    "cutcheck-provenance: graph: critical-path: 2: 01-pre-existing > 02-authored-here",
    "cutcheck-provenance: graph: level-width: 1 1"
   ]
@@ -293,7 +293,7 @@
    "01-mentioned: family 1: already-passes: criterion 2: grep -n \"friction.py\" install.py",
    "cutcheck: advisory -- reported, and never setting the exit status:",
    "cutcheck-provenance-mention: family 5: coverage-map-absent: tests/fixtures/cutcheck/cutcheck-provenance-mention/coverage.md",
-   "cutcheck: the shape of this cut -- read, and never setting the exit status:",
+   "cutcheck: the shape of this cut -- how long and how wide it is, and no finding of any kind:",
    "cutcheck-provenance-mention: graph: critical-path: 2: 01-mentioned > 02-stamped",
    "cutcheck-provenance-mention: graph: level-width: 1 1"
   ]
@@ -304,7 +304,7 @@
    "01-quotes: family 2: quote-not-at-citation: \"no line of this file reads this way\" not at install.py:1",
    "cutcheck: advisory -- reported, and never setting the exit status:",
    "cutcheck-quote-precision: family 5: coverage-map-absent: tests/fixtures/cutcheck/cutcheck-quote-precision/coverage.md",
-   "cutcheck: the shape of this cut -- read, and never setting the exit status:",
+   "cutcheck: the shape of this cut -- how long and how wide it is, and no finding of any kind:",
    "cutcheck-quote-precision: graph: critical-path: 1: 01-quotes",
    "cutcheck-quote-precision: graph: level-width: 1"
   ]
@@ -316,7 +316,7 @@
    "00-root.gate.critique.code: family 1: extraction-gap: criterion 1: every finding names the artifact identity it was found at and the evidence that shows it | oracle: t | oracle_class: judged",
    "00-root.gate.critique.code: family 1: extraction-gap: criterion 2: every `## Result` named in the fixed inputs was read | oracle: this ticket's `## Result` against tha | oracle_class: deterministic",
    "00-root.gate.repair: family 1: extraction-gap: criterion 1: every accepted finding is repaired or declined with a stated reason | oracle: the critique tickets'  | oracle_class: deterministic",
-   "cutcheck: the shape of this cut -- read, and never setting the exit status:",
+   "cutcheck: the shape of this cut -- how long and how wide it is, and no finding of any kind:",
    "cutcheck-root-gate: graph: critical-path: 1: 00-root.01",
    "cutcheck-root-gate: graph: level-width: 1",
    "cutcheck: no finding outside the advisory set"
@@ -336,7 +336,7 @@
    "02-carried: family 1: extraction-gap: criterion 1: **Nothing in the tree still spells the two names.** A reviewer reads the tree and finds each name go | oracle_class: judged",
    "cutcheck-scope-open: family 5: coverage-map-absent: tests/fixtures/cutcheck/cutcheck-scope-open/coverage.md",
    "cutcheck-scope-open: reading: unread-half: docs/banner.png: past PIN_SIZE_LIMIT, not read for pins",
-   "cutcheck: the shape of this cut -- read, and never setting the exit status:",
+   "cutcheck: the shape of this cut -- how long and how wide it is, and no finding of any kind:",
    "cutcheck-scope-open: graph: critical-path: 2: 01-open > 02-carried",
    "cutcheck-scope-open: graph: level-width: 1 1"
   ]
@@ -347,7 +347,7 @@
    "cutcheck: advisory -- reported, and never setting the exit status:",
    "01-shellhead: family 1: extraction-gap: criterion 1: **A shell span is never executed.** `bash -lc 'touch /tmp/cutcheck-shellhead-ran'` is the span; thro | oracle_class: deterministic",
    "cutcheck-shellhead: family 5: coverage-map-absent: tests/fixtures/cutcheck/cutcheck-shellhead/coverage.md",
-   "cutcheck: the shape of this cut -- read, and never setting the exit status:",
+   "cutcheck: the shape of this cut -- how long and how wide it is, and no finding of any kind:",
    "cutcheck-shellhead: graph: critical-path: 1: 01-shellhead",
    "cutcheck-shellhead: graph: level-width: 1",
    "cutcheck: no finding outside the advisory set"
@@ -360,7 +360,7 @@
    "01-verdict: family 1: verdict-in-output: criterion 1: grep -c \"SCRIPT_NAMES\" install.py",
    "01-verdict: family 1: verdict-in-output: criterion 2: git rev-list --count HEAD",
    "cutcheck-verdict-in-output: family 5: coverage-map-absent: tests/fixtures/cutcheck/cutcheck-verdict-in-output/coverage.md",
-   "cutcheck: the shape of this cut -- read, and never setting the exit status:",
+   "cutcheck: the shape of this cut -- how long and how wide it is, and no finding of any kind:",
    "cutcheck-verdict-in-output: graph: critical-path: 1: 01-verdict",
    "cutcheck-verdict-in-output: graph: level-width: 1",
    "cutcheck: no finding outside the advisory set"

--- a/tests/fixtures/cutcheck/verdicts.json
+++ b/tests/fixtures/cutcheck/verdicts.json
@@ -5,18 +5,27 @@
    "cutcheck: advisory -- reported, and never setting the exit status:",
    "01-barenoun: family 1: extraction-gap: criterion 2: **A mention standing alone is an extraction gap.** The only command head this criterion states is `p | oracle_class: deterministic",
    "cutcheck-barenoun: family 5: coverage-map-absent: tests/fixtures/cutcheck/cutcheck-barenoun/coverage.md",
+   "cutcheck: the shape of this cut -- read, and never setting the exit status:",
+   "cutcheck-barenoun: graph: critical-path: 1: 01-barenoun",
+   "cutcheck-barenoun: graph: level-width: 1",
    "cutcheck: no finding outside the advisory set"
   ]
  },
  "cutcheck-carveouts": {
   "exit": 0,
   "lines": [
+   "cutcheck: the shape of this cut -- read, and never setting the exit status:",
+   "cutcheck-carveouts: graph: critical-path: 2: 01-reads-only > 02-depends",
+   "cutcheck-carveouts: graph: level-width: 1 2",
    "cutcheck: no finding outside the advisory set"
   ]
  },
  "cutcheck-clean": {
   "exit": 0,
   "lines": [
+   "cutcheck: the shape of this cut -- read, and never setting the exit status:",
+   "cutcheck-clean: graph: critical-path: 1: 01-clean-oracles",
+   "cutcheck-clean: graph: level-width: 1",
    "cutcheck: no finding outside the advisory set"
   ]
  },
@@ -27,6 +36,9 @@
    "01-quoted: family 1: extraction-gap: criterion 2: **A span quoted as what the guard refuses is no oracle.** The confinement gate refuses `git log --ou | oracle_class: deterministic",
    "01-quoted: family 1: extraction-gap: criterion 3: **A span quoted as what CI runs is no oracle.** A whole-module invocation such as `python3 -m unitte | oracle_class: deterministic",
    "cutcheck-command-mention: family 5: coverage-map-absent: tests/fixtures/cutcheck/cutcheck-command-mention/coverage.md",
+   "cutcheck: the shape of this cut -- read, and never setting the exit status:",
+   "cutcheck-command-mention: graph: critical-path: 1: 01-quoted",
+   "cutcheck-command-mention: graph: level-width: 1",
    "cutcheck: no finding outside the advisory set"
   ]
  },
@@ -36,6 +48,9 @@
    "cutcheck: advisory -- reported, and never setting the exit status:",
    "01-evalhead: family 1: extraction-gap: criterion 1: **An interpreter evaluating its argument is never executed.** `python3 -c \"import pathlib;pathlib.Pa | oracle_class: deterministic",
    "cutcheck-evalhead: family 5: coverage-map-absent: tests/fixtures/cutcheck/cutcheck-evalhead/coverage.md",
+   "cutcheck: the shape of this cut -- read, and never setting the exit status:",
+   "cutcheck-evalhead: graph: critical-path: 1: 01-evalhead",
+   "cutcheck-evalhead: graph: level-width: 1",
    "cutcheck: no finding outside the advisory set"
   ]
  },
@@ -44,7 +59,10 @@
   "lines": [
    "01-cuttime: family 1: no-hits-both-revisions: criterion 1: grep -rn \"zzqq-cuttime-token\" install.py",
    "cutcheck: advisory -- reported, and never setting the exit status:",
-   "cutcheck-f1-cuttime: family 5: coverage-map-absent: tests/fixtures/cutcheck/cutcheck-f1-cuttime/coverage.md"
+   "cutcheck-f1-cuttime: family 5: coverage-map-absent: tests/fixtures/cutcheck/cutcheck-f1-cuttime/coverage.md",
+   "cutcheck: the shape of this cut -- read, and never setting the exit status:",
+   "cutcheck-f1-cuttime: graph: critical-path: 1: 01-cuttime",
+   "cutcheck-f1-cuttime: graph: level-width: 1"
   ]
  },
  "cutcheck-f1-discrimination": {
@@ -54,7 +72,10 @@
    "01-discrimination: family 1: no-hits-both-revisions: criterion 2: grep -rn \"zzqq-token-never-written\" install.py",
    "01-discrimination: family 1: fails-both-revisions: criterion 3: python3 -B -m unittest tests.test_installer.NoSuchClass.test_absent",
    "cutcheck: advisory -- reported, and never setting the exit status:",
-   "cutcheck-f1-discrimination: family 5: coverage-map-absent: tests/fixtures/cutcheck/cutcheck-f1-discrimination/coverage.md"
+   "cutcheck-f1-discrimination: family 5: coverage-map-absent: tests/fixtures/cutcheck/cutcheck-f1-discrimination/coverage.md",
+   "cutcheck: the shape of this cut -- read, and never setting the exit status:",
+   "cutcheck-f1-discrimination: graph: critical-path: 1: 01-discrimination",
+   "cutcheck-f1-discrimination: graph: level-width: 1"
   ]
  },
  "cutcheck-f1-extraction-gap": {
@@ -63,6 +84,9 @@
    "cutcheck: advisory -- reported, and never setting the exit status:",
    "01-extraction-gap: family 1: extraction-gap: criterion 1: **The boundary reads clearly to a first reader.** A reviewer who has not seen this ticket can name,  | oracle_class: judgment",
    "cutcheck-f1-extraction-gap: family 5: coverage-map-absent: tests/fixtures/cutcheck/cutcheck-f1-extraction-gap/coverage.md",
+   "cutcheck: the shape of this cut -- read, and never setting the exit status:",
+   "cutcheck-f1-extraction-gap: graph: critical-path: 1: 01-extraction-gap",
+   "cutcheck-f1-extraction-gap: graph: level-width: 1",
    "cutcheck: no finding outside the advisory set"
   ]
  },
@@ -71,6 +95,9 @@
   "lines": [
    "cutcheck: advisory -- reported, and never setting the exit status:",
    "cutcheck-f1-phantom: family 5: coverage-map-absent: tests/fixtures/cutcheck/cutcheck-f1-phantom/coverage.md",
+   "cutcheck: the shape of this cut -- read, and never setting the exit status:",
+   "cutcheck-f1-phantom: graph: critical-path: 2: 01-phantom > 02-nested-list",
+   "cutcheck-f1-phantom: graph: level-width: 1 1",
    "cutcheck: no finding outside the advisory set"
   ]
  },
@@ -80,7 +107,10 @@
    "01-shape: family 1: swallowed-exit: criterion 1: python3 -m unittest discover -s tests | tail -5",
    "01-shape: family 1: cumulative-range: criterion 2: git diff --name-only ac8791a..HEAD",
    "cutcheck: advisory -- reported, and never setting the exit status:",
-   "cutcheck-f1-shape: family 5: coverage-map-absent: tests/fixtures/cutcheck/cutcheck-f1-shape/coverage.md"
+   "cutcheck-f1-shape: family 5: coverage-map-absent: tests/fixtures/cutcheck/cutcheck-f1-shape/coverage.md",
+   "cutcheck: the shape of this cut -- read, and never setting the exit status:",
+   "cutcheck-f1-shape: graph: critical-path: 1: 01-shape",
+   "cutcheck-f1-shape: graph: level-width: 1"
   ]
  },
  "cutcheck-f1-truncated": {
@@ -89,6 +119,9 @@
    "cutcheck: advisory -- reported, and never setting the exit status:",
    "01-truncated: family 1: extraction-gap: criterion 2: **The criterion after the interruption.** A reviewer names, from the module docstring alone, every f | oracle_class: judgment",
    "cutcheck-f1-truncated: family 5: coverage-map-absent: tests/fixtures/cutcheck/cutcheck-f1-truncated/coverage.md",
+   "cutcheck: the shape of this cut -- read, and never setting the exit status:",
+   "cutcheck-f1-truncated: graph: critical-path: 1: 01-truncated",
+   "cutcheck-f1-truncated: graph: level-width: 1",
    "cutcheck: no finding outside the advisory set"
   ]
  },
@@ -97,7 +130,10 @@
   "lines": [
    "01-f2-paths: family 2: missing-path: criterion 1: .orch/evidence/f2-missing/: grep -rn \"verdict\" .orch/evidence/f2-missing/",
    "01-f2-paths: family 2: unresolved-citation: criterion 2: install.py:99999",
-   "01-f2-paths: family 2: quote-not-at-citation: criterion 3: \"no line reads this way\" not at install.py:1"
+   "01-f2-paths: family 2: quote-not-at-citation: criterion 3: \"no line reads this way\" not at install.py:1",
+   "cutcheck: the shape of this cut -- read, and never setting the exit status:",
+   "cutcheck-f2-paths: graph: critical-path: 1: 01-f2-paths",
+   "cutcheck-f2-paths: graph: level-width: 1"
   ]
  },
  "cutcheck-f3-scope": {
@@ -108,7 +144,10 @@
    "01-unscoped: family 4: scope-collision: with 02-contradiction: install.py",
    "01-unscoped: family 4: staged-invalidation: with 02-contradiction: install.py",
    "cutcheck: advisory -- reported, and never setting the exit status:",
-   "cutcheck-f3-scope: family 5: coverage-map-absent: tests/fixtures/cutcheck/cutcheck-f3-scope/coverage.md"
+   "cutcheck-f3-scope: family 5: coverage-map-absent: tests/fixtures/cutcheck/cutcheck-f3-scope/coverage.md",
+   "cutcheck: the shape of this cut -- read, and never setting the exit status:",
+   "cutcheck-f3-scope: graph: critical-path: 1: 01-unscoped",
+   "cutcheck-f3-scope: graph: level-width: 2"
   ]
  },
  "cutcheck-f4-ordered": {
@@ -116,6 +155,9 @@
   "lines": [
    "cutcheck: advisory -- reported, and never setting the exit status:",
    "cutcheck-f4-ordered: family 5: coverage-map-absent: tests/fixtures/cutcheck/cutcheck-f4-ordered/coverage.md",
+   "cutcheck: the shape of this cut -- read, and never setting the exit status:",
+   "cutcheck-f4-ordered: graph: critical-path: 2: 01-reader > 02-rewriter",
+   "cutcheck-f4-ordered: graph: level-width: 1 1",
    "cutcheck: no finding outside the advisory set"
   ]
  },
@@ -127,7 +169,10 @@
    "cutcheck: advisory -- reported, and never setting the exit status:",
    "03-alpha: family 1: extraction-gap: criterion 1: **The shared scope is the whole defect.** The two scopes intersect, which the report names without r | oracle_class: deterministic",
    "04-beta: family 1: extraction-gap: criterion 1: **The shared scope is the whole defect.** The two scopes intersect, which the report names without r | oracle_class: deterministic",
-   "cutcheck-f4-pairs: family 5: coverage-map-absent: tests/fixtures/cutcheck/cutcheck-f4-pairs/coverage.md"
+   "cutcheck-f4-pairs: family 5: coverage-map-absent: tests/fixtures/cutcheck/cutcheck-f4-pairs/coverage.md",
+   "cutcheck: the shape of this cut -- read, and never setting the exit status:",
+   "cutcheck-f4-pairs: graph: critical-path: 1: 01-reader",
+   "cutcheck-f4-pairs: graph: level-width: 4"
   ]
  },
  "cutcheck-f4-transitive": {
@@ -135,6 +180,9 @@
   "lines": [
    "cutcheck: advisory -- reported, and never setting the exit status:",
    "cutcheck-f4-transitive: family 5: coverage-map-absent: tests/fixtures/cutcheck/cutcheck-f4-transitive/coverage.md",
+   "cutcheck: the shape of this cut -- read, and never setting the exit status:",
+   "cutcheck-f4-transitive: graph: critical-path: 3: 01-first > 02-middle > 03-third",
+   "cutcheck-f4-transitive: graph: level-width: 1 1 1",
    "cutcheck: no finding outside the advisory set"
   ]
  },
@@ -142,7 +190,10 @@
   "exit": 1,
   "lines": [
    "cutcheck-f5-coverage: family 5: orphan-criterion: criterion 3: 03-absent",
-   "02-orphan-item: family 5: orphan-item: named by no criterion in coverage.md"
+   "02-orphan-item: family 5: orphan-item: named by no criterion in coverage.md",
+   "cutcheck: the shape of this cut -- read, and never setting the exit status:",
+   "cutcheck-f5-coverage: graph: critical-path: 1: 01-covered",
+   "cutcheck-f5-coverage: graph: level-width: 2"
   ]
  },
  "cutcheck-f5-nomap": {
@@ -150,6 +201,9 @@
   "lines": [
    "cutcheck: advisory -- reported, and never setting the exit status:",
    "cutcheck-f5-nomap: family 5: coverage-map-absent: tests/fixtures/cutcheck/cutcheck-f5-nomap/coverage.md",
+   "cutcheck: the shape of this cut -- read, and never setting the exit status:",
+   "cutcheck-f5-nomap: graph: critical-path: 1: 01-lonely",
+   "cutcheck-f5-nomap: graph: level-width: 1",
    "cutcheck: no finding outside the advisory set"
   ]
  },
@@ -158,6 +212,9 @@
   "lines": [
    "cutcheck: advisory -- reported, and never setting the exit status:",
    "02-materialize: family 5: coverage-map-absent: tests/fixtures/cutcheck/cutcheck-f5-template/02-materialize.coverage.md",
+   "cutcheck: the shape of this cut -- read, and never setting the exit status:",
+   "cutcheck-f5-template: graph: critical-path: 1: 00-acquire.01",
+   "cutcheck-f5-template: graph: level-width: 2",
    "cutcheck: no finding outside the advisory set"
   ]
  },
@@ -166,7 +223,10 @@
   "lines": [
    "03-alien: family 6: illegal-executor: orch-render is neither orch-code-pack's executor cell nor its assembly cell",
    "cutcheck: advisory -- reported, and never setting the exit status:",
-   "cutcheck-f6-executor: family 5: coverage-map-absent: tests/fixtures/cutcheck/cutcheck-f6-executor/coverage.md"
+   "cutcheck-f6-executor: family 5: coverage-map-absent: tests/fixtures/cutcheck/cutcheck-f6-executor/coverage.md",
+   "cutcheck: the shape of this cut -- read, and never setting the exit status:",
+   "cutcheck-f6-executor: graph: critical-path: 1: 02-legal",
+   "cutcheck-f6-executor: graph: level-width: 2"
   ]
  },
  "cutcheck-git-graded": {
@@ -175,7 +235,10 @@
    "01-git-graded: family 1: already-passes: criterion 1: git log -1 --format=%H",
    "01-git-graded: family 1: already-passes: criterion 2: git diff ac8791a -- install.py",
    "cutcheck: advisory -- reported, and never setting the exit status:",
-   "cutcheck-git-graded: family 5: coverage-map-absent: tests/fixtures/cutcheck/cutcheck-git-graded/coverage.md"
+   "cutcheck-git-graded: family 5: coverage-map-absent: tests/fixtures/cutcheck/cutcheck-git-graded/coverage.md",
+   "cutcheck: the shape of this cut -- read, and never setting the exit status:",
+   "cutcheck-git-graded: graph: critical-path: 1: 01-git-graded",
+   "cutcheck-git-graded: graph: level-width: 1"
   ]
  },
  "cutcheck-gitescape": {
@@ -184,7 +247,19 @@
    "01-gitescape: family 1: unconfined-oracle: criterion 1: git -c alias.pwn='!touch /tmp/cutcheck-gitescape-ran' pwn",
    "01-gitescape: family 1: unconfined-oracle: criterion 2: git log --output=/tmp/cutcheck-gitescape-wrote",
    "cutcheck: advisory -- reported, and never setting the exit status:",
-   "cutcheck-gitescape: family 5: coverage-map-absent: tests/fixtures/cutcheck/cutcheck-gitescape/coverage.md"
+   "cutcheck-gitescape: family 5: coverage-map-absent: tests/fixtures/cutcheck/cutcheck-gitescape/coverage.md",
+   "cutcheck: the shape of this cut -- read, and never setting the exit status:",
+   "cutcheck-gitescape: graph: critical-path: 1: 01-gitescape",
+   "cutcheck-gitescape: graph: level-width: 1"
+  ]
+ },
+ "cutcheck-graph": {
+  "exit": 0,
+  "lines": [
+   "cutcheck: the shape of this cut -- read, and never setting the exit status:",
+   "cutcheck-graph: graph: critical-path: 3: 01-alpha > 04-delta > 05-epsilon",
+   "cutcheck-graph: graph: level-width: 3 1 1",
+   "cutcheck: no finding outside the advisory set"
   ]
  },
  "cutcheck-mention": {
@@ -192,7 +267,10 @@
   "lines": [
    "01-mention: family 3: unscoped-write: .orch/evidence/mention/verdict.txt",
    "cutcheck: advisory -- reported, and never setting the exit status:",
-   "cutcheck-mention: family 5: coverage-map-absent: tests/fixtures/cutcheck/cutcheck-mention/coverage.md"
+   "cutcheck-mention: family 5: coverage-map-absent: tests/fixtures/cutcheck/cutcheck-mention/coverage.md",
+   "cutcheck: the shape of this cut -- read, and never setting the exit status:",
+   "cutcheck-mention: graph: critical-path: 1: 01-mention",
+   "cutcheck-mention: graph: level-width: 1"
   ]
  },
  "cutcheck-provenance": {
@@ -202,7 +280,10 @@
    "02-authored-here: family 1: already-passes: criterion 1: grep -n \"SCRIPT_NAMES\" install.py",
    "cutcheck: advisory -- reported, and never setting the exit status:",
    "01-pre-existing: family 1: verdict-in-output: criterion 3: grep -c \"SCRIPT_NAMES\" install.py",
-   "cutcheck-provenance: family 5: coverage-map-absent: tests/fixtures/cutcheck/cutcheck-provenance/coverage.md"
+   "cutcheck-provenance: family 5: coverage-map-absent: tests/fixtures/cutcheck/cutcheck-provenance/coverage.md",
+   "cutcheck: the shape of this cut -- read, and never setting the exit status:",
+   "cutcheck-provenance: graph: critical-path: 2: 01-pre-existing > 02-authored-here",
+   "cutcheck-provenance: graph: level-width: 1 1"
   ]
  },
  "cutcheck-provenance-mention": {
@@ -211,7 +292,10 @@
    "01-mentioned: family 1: already-passes: criterion 1: grep -n \"SCRIPT_NAMES\" install.py",
    "01-mentioned: family 1: already-passes: criterion 2: grep -n \"friction.py\" install.py",
    "cutcheck: advisory -- reported, and never setting the exit status:",
-   "cutcheck-provenance-mention: family 5: coverage-map-absent: tests/fixtures/cutcheck/cutcheck-provenance-mention/coverage.md"
+   "cutcheck-provenance-mention: family 5: coverage-map-absent: tests/fixtures/cutcheck/cutcheck-provenance-mention/coverage.md",
+   "cutcheck: the shape of this cut -- read, and never setting the exit status:",
+   "cutcheck-provenance-mention: graph: critical-path: 2: 01-mentioned > 02-stamped",
+   "cutcheck-provenance-mention: graph: level-width: 1 1"
   ]
  },
  "cutcheck-quote-precision": {
@@ -219,7 +303,10 @@
   "lines": [
    "01-quotes: family 2: quote-not-at-citation: \"no line of this file reads this way\" not at install.py:1",
    "cutcheck: advisory -- reported, and never setting the exit status:",
-   "cutcheck-quote-precision: family 5: coverage-map-absent: tests/fixtures/cutcheck/cutcheck-quote-precision/coverage.md"
+   "cutcheck-quote-precision: family 5: coverage-map-absent: tests/fixtures/cutcheck/cutcheck-quote-precision/coverage.md",
+   "cutcheck: the shape of this cut -- read, and never setting the exit status:",
+   "cutcheck-quote-precision: graph: critical-path: 1: 01-quotes",
+   "cutcheck-quote-precision: graph: level-width: 1"
   ]
  },
  "cutcheck-root-gate": {
@@ -229,6 +316,9 @@
    "00-root.gate.critique.code: family 1: extraction-gap: criterion 1: every finding names the artifact identity it was found at and the evidence that shows it | oracle: t | oracle_class: judged",
    "00-root.gate.critique.code: family 1: extraction-gap: criterion 2: every `## Result` named in the fixed inputs was read | oracle: this ticket's `## Result` against tha | oracle_class: deterministic",
    "00-root.gate.repair: family 1: extraction-gap: criterion 1: every accepted finding is repaired or declined with a stated reason | oracle: the critique tickets'  | oracle_class: deterministic",
+   "cutcheck: the shape of this cut -- read, and never setting the exit status:",
+   "cutcheck-root-gate: graph: critical-path: 1: 00-root.01",
+   "cutcheck-root-gate: graph: level-width: 1",
    "cutcheck: no finding outside the advisory set"
   ]
  },
@@ -245,7 +335,10 @@
    "01-open: family 1: extraction-gap: criterion 1: **Nothing in the tree still spells the two names.** A reviewer reads the tree and finds each name go | oracle_class: judged",
    "02-carried: family 1: extraction-gap: criterion 1: **Nothing in the tree still spells the two names.** A reviewer reads the tree and finds each name go | oracle_class: judged",
    "cutcheck-scope-open: family 5: coverage-map-absent: tests/fixtures/cutcheck/cutcheck-scope-open/coverage.md",
-   "cutcheck-scope-open: reading: unread-half: docs/banner.png: past PIN_SIZE_LIMIT, not read for pins"
+   "cutcheck-scope-open: reading: unread-half: docs/banner.png: past PIN_SIZE_LIMIT, not read for pins",
+   "cutcheck: the shape of this cut -- read, and never setting the exit status:",
+   "cutcheck-scope-open: graph: critical-path: 2: 01-open > 02-carried",
+   "cutcheck-scope-open: graph: level-width: 1 1"
   ]
  },
  "cutcheck-shellhead": {
@@ -254,6 +347,9 @@
    "cutcheck: advisory -- reported, and never setting the exit status:",
    "01-shellhead: family 1: extraction-gap: criterion 1: **A shell span is never executed.** `bash -lc 'touch /tmp/cutcheck-shellhead-ran'` is the span; thro | oracle_class: deterministic",
    "cutcheck-shellhead: family 5: coverage-map-absent: tests/fixtures/cutcheck/cutcheck-shellhead/coverage.md",
+   "cutcheck: the shape of this cut -- read, and never setting the exit status:",
+   "cutcheck-shellhead: graph: critical-path: 1: 01-shellhead",
+   "cutcheck-shellhead: graph: level-width: 1",
    "cutcheck: no finding outside the advisory set"
   ]
  },
@@ -264,6 +360,9 @@
    "01-verdict: family 1: verdict-in-output: criterion 1: grep -c \"SCRIPT_NAMES\" install.py",
    "01-verdict: family 1: verdict-in-output: criterion 2: git rev-list --count HEAD",
    "cutcheck-verdict-in-output: family 5: coverage-map-absent: tests/fixtures/cutcheck/cutcheck-verdict-in-output/coverage.md",
+   "cutcheck: the shape of this cut -- read, and never setting the exit status:",
+   "cutcheck-verdict-in-output: graph: critical-path: 1: 01-verdict",
+   "cutcheck-verdict-in-output: graph: level-width: 1",
    "cutcheck: no finding outside the advisory set"
   ]
  }

--- a/tests/test_contracts.py
+++ b/tests/test_contracts.py
@@ -1,10 +1,16 @@
 """Freezes the load-bearing shape of the T0 contracts and the
 description budget every skill must respect."""
 import re
+import sys
 import unittest
 from pathlib import Path
 
 ROOT = Path(__file__).resolve().parent.parent
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+import scripts.cutcheck as cutcheck  # noqa: E402  topology §3 cites its families
+
 CONTRACTS = ROOT / "contracts"
 SKILLS = ROOT / "skills"
 
@@ -570,6 +576,44 @@ class TopologyAtomTest(unittest.TestCase):
         ):
             with self.subTest(token=token):
                 self.assertIn(token, text, f"topology.md §3 {why}")
+
+    def test_section_3_family_cites_answer_to_the_checker(self):
+        """§3 states three of `scripts/cutcheck.py`'s family numbers as law.
+        The test above asserts only that the literals appear in the clause, so
+        a renumbering in `FAMILY_OF` would leave the rule false with every
+        check in the tree green. This reads the checker's own table instead:
+        for each conjunct of the atom, the classes that decide it must sit in
+        the family §3 sends a reader to. `tests/test_cut_lens.py`
+        `FamilyCorrespondenceTest` holds the cut lens to the same constants;
+        this is the rule's half of it."""
+        text = self.section()
+        for family, classes, conjunct in (
+            (cutcheck.FAMILY,
+             (cutcheck.ALREADY_PASSES, cutcheck.NO_HITS_BOTH_REVISIONS,
+              cutcheck.FAILS_BOTH_REVISIONS, cutcheck.UNCONFINED_ORACLE,
+              cutcheck.WHOLE_SUITE_ORACLE, cutcheck.UNRUNNABLE_ORACLE),
+             "a completion test discriminating the item alone"),
+            (cutcheck.FAMILY_3,
+             (cutcheck.UNSCOPED_WRITE, cutcheck.SCOPE_CONTRADICTION,
+              cutcheck.SCOPE_OPEN),
+             "a closed write scope"),
+            (cutcheck.FAMILY_4,
+             (cutcheck.SCOPE_COLLISION, cutcheck.STAGED_INVALIDATION),
+             "oracles reading nothing a sibling writes"),
+        ):
+            with self.subTest(family=family):
+                self.assertIn(
+                    family, text,
+                    f"topology.md §3 no longer cites {family!r}, the checker "
+                    f"family that reports {conjunct}",
+                )
+                for name in classes:
+                    self.assertEqual(
+                        cutcheck.FAMILY_OF[name], family,
+                        f"cutcheck grades {name!r} under "
+                        f"{cutcheck.FAMILY_OF[name]!r}, while topology.md §3 "
+                        f"sends a reader of {conjunct} to {family!r}",
+                    )
 
     def test_section_3_bounds_the_cut_below_and_binds_an_ad_hoc_set(self):
         text = self.section()

--- a/tests/test_contracts.py
+++ b/tests/test_contracts.py
@@ -515,6 +515,145 @@ class TestWorkItemCitationLaws(unittest.TestCase):
                 self.assertIn(token, text, why)
 
 
+class TopologyAtomTest(unittest.TestCase):
+    """`rules/topology.md` §3 owns the cut law the decomposer and every
+    ad-hoc cut read: what an atom is, when an edge exists, and who owns an
+    artifact more than one item would write. Read from clause 3 alone, so
+    a sentence landing in a neighbouring clause cannot satisfy it, and
+    pinned by anchor — a term, a backticked name, a checker family —
+    never by a sentence, which a lawful reword would break."""
+
+    def section(self):
+        return read_clause_flat("rules/topology.md", 3)
+
+    def test_section_3_states_the_atom_the_edge_rule_and_the_shared_surface_rule(self):
+        text = self.section()
+        self.assertRegex(
+            text, r"\batom\b",
+            "topology.md §3 does not name the atom, the unit the lawful set "
+            "is cut into",
+        )
+        for token, why in (
+            ("finest",
+             "does not make the lawful set the finest cut, so it states no "
+             "polarity and a coarser cut stays a safe default"),
+            ("family 1",
+             "does not tie the discriminating completion test to the checker "
+             "family that reports its absence"),
+            ("family 3",
+             "does not tie the closed write scope to its checker family"),
+            ("family 4",
+             "does not tie the sibling-read prohibition to its checker family"),
+            ("`scripts/cutcheck.py`",
+             "names checker families without naming the checker that owns "
+             "them"),
+            ("compound item",
+             "does not name what an item coarser than an atom is"),
+            ("`## Fixed inputs`",
+             "'s edge rule does not name the cited-identity half, so an edge "
+             "carrying no oracle read has no other justification"),
+            ("result identity",
+             "'s edge rule does not say what a fixed input cites to earn an "
+             "edge"),
+            ("ordering preference",
+             "does not refuse the edge drawn for ordering preference"),
+            ("exactly one item",
+             "does not give an artifact more than one item would write to "
+             "exactly one item"),
+            ("`ARCHITECTURE.md`",
+             "'s shared-surface rule names no recurring surface, so a cutter "
+             "rediscovers them"),
+            ("`SKILL.md`",
+             "'s shared-surface rule does not name the roster case"),
+            ("`tests/pins.json`",
+             "'s shared-surface rule does not name the pin-file case"),
+        ):
+            with self.subTest(token=token):
+                self.assertIn(token, text, f"topology.md §3 {why}")
+
+    def test_section_3_bounds_the_cut_below_and_binds_an_ad_hoc_set(self):
+        text = self.section()
+        for token, why in (
+            ("padding",
+             "does not name what lies below the atom, so the finest-cut "
+             "polarity has no floor"),
+            ("unbounded",
+             "does not leave the item count unbounded above"),
+            ("frontier's queue",
+             "does not send width past the host profile to the frontier's "
+             "queue instead of back into the cut"),
+            ("ad-hoc set",
+             "does not bind the ad-hoc set, the form every wide cut in the "
+             "sink was made in"),
+            ("first dispatch",
+             "does not order the cut check before an ad-hoc set's first "
+             "dispatch"),
+        ):
+            with self.subTest(token=token):
+                self.assertIn(token, text, f"topology.md §3 {why}")
+        self.assertNotIn(
+            "look thorough", text,
+            "topology.md §3 still forces a cut only under parallelism, "
+            "disjoint scopes, isolation or resumption — the clause the atom "
+            "bound replaces",
+        )
+
+
+class VocabularyCutTermsTest(unittest.TestCase):
+    """`docs/vocabulary.md` owns the two terms topology §3 and the
+    decomposer's goal are stated in. Each is asserted as an entry —
+    defined once, under the section a reader of its neighbours reaches it
+    from — never as a corpus count of the word."""
+
+    def entry(self, term):
+        flat = read_at_flat("docs/vocabulary.md")
+        self.assertEqual(
+            flat.count(term), 1,
+            f"docs/vocabulary.md must carry the {term} entry exactly once",
+        )
+        return flat.split(term, 1)[1].split(" - **", 1)[0]
+
+    def under(self, heading, next_heading):
+        flat = read_at_flat("docs/vocabulary.md")
+        return flat.split(heading, 1)[1].split(next_heading, 1)[0]
+
+    def test_atom_and_critical_path_are_defined_once(self):
+        atom = self.entry("**atom**")
+        for token, why in (
+            ("end state", "does not name the one observable end state"),
+            ("completion test", "does not name the discriminating completion test"),
+            ("write scope", "does not name the closed write scope"),
+            ("sibling", "does not name the sibling-read bound"),
+            ("ceiling", "does not name the instruction ceiling, the atom's "
+                        "mechanical bound"),
+            ("`rules/topology.md`", "does not name the owner of the law it "
+                                    "summarises"),
+        ):
+            with self.subTest(term="atom", token=token):
+                self.assertIn(token, atom, f"the atom entry {why}")
+        path = self.entry("**critical path**")
+        for token, why in (
+            ("`depends_on`", "does not name the edge the chain runs over"),
+            ("gate", "does not exclude the gate stubs from the chain"),
+            ("`scripts/cutcheck.py`", "does not name what reports it"),
+            ("`critical-path`", "does not name the class carrying the length"),
+            ("`level-width`", "does not name the class carrying each level's "
+                              "width"),
+        ):
+            with self.subTest(term="critical path", token=token):
+                self.assertIn(token, path, f"the critical path entry {why}")
+        self.assertIn(
+            "**atom**", self.under("## Work", "## Verification"),
+            "the atom entry must sit under ## Work, beside the work item it "
+            "is a property of",
+        )
+        self.assertIn(
+            "**critical path**", self.under("## Iteration", "## Improvement"),
+            "the critical path entry must sit under ## Iteration, beside the "
+            "frontier it is measured over",
+        )
+
+
 class TestSkillDescriptions(unittest.TestCase):
     def test_every_skill_description_is_at_most_140_chars(self):
         skill_files = sorted(SKILLS.glob("*/*/SKILL.md"))

--- a/tests/test_cut_lens.py
+++ b/tests/test_cut_lens.py
@@ -72,8 +72,9 @@ def correspondence(lens, source):
 # the checker block a false edge is read from -- a block name, not a family
 # label, so naming it here cannot widen the correspondence.
 FALSE_EDGE = "false edge"
+COMPOUND_ITEM = "compound item"
 GRAPH_BLOCK = "graph"
-KEPT_JUDGMENTS = (FALSE_EDGE,)
+KEPT_JUDGMENTS = (FALSE_EDGE, COMPOUND_ITEM)
 ABSENT = "the kept half names no {} judgment"
 UNREAD = "the {} judgment names no `{}` block to read it from"
 

--- a/tests/test_cut_lens.py
+++ b/tests/test_cut_lens.py
@@ -68,6 +68,67 @@ def correspondence(lens, source):
     ]
 
 
+# The judgments the kept half owes beyond the correspondence above. `graph` is
+# the checker block a false edge is read from -- a block name, not a family
+# label, so naming it here cannot widen the correspondence.
+FALSE_EDGE = "false edge"
+GRAPH_BLOCK = "graph"
+KEPT_JUDGMENTS = (FALSE_EDGE,)
+ABSENT = "the kept half names no {} judgment"
+UNREAD = "the {} judgment names no `{}` block to read it from"
+
+
+def kept_judgments(kept):
+    """Each judgment the kept half states, by name, with its body joined.
+
+    A bullet runs to the first line that is neither its own nor a continuation
+    of it, so the copy recipe standing under its own heading below is never
+    read as one.
+    """
+
+    judgments = {}
+    name = None
+    for line in kept.splitlines():
+        if line.startswith("- "):
+            name, _, body = line[2:].partition(":")
+            name = name.strip()
+            judgments[name] = body.strip()
+        elif name and line.startswith("  ") and line.strip():
+            judgments[name] = "{} {}".format(judgments[name], line.strip())
+        else:
+            name = None
+    return judgments
+
+
+def missing_judgments(lens):
+    """Every judgment the kept half owes and does not state."""
+
+    division = lens_division(lens)
+    if division is None:
+        return [NO_DIVISION]
+    judgments = kept_judgments(division[1])
+    missing = [
+        ABSENT.format(name) for name in KEPT_JUDGMENTS if name not in judgments
+    ]
+    edge = judgments.get(FALSE_EDGE)
+    if edge is not None and "`{}`".format(GRAPH_BLOCK) not in edge:
+        missing.append(UNREAD.format(FALSE_EDGE, GRAPH_BLOCK))
+    return missing
+
+
+def without_judgment(lens, name):
+    """The lens with one kept judgment dropped -- bullet and continuations.
+
+    The wrong result each pin fails against drops the judgment, never only the
+    name it is anchored on: a lens still stating the judgment under a renamed
+    anchor would prove the search, not the fact.
+    """
+
+    return re.sub(
+        r"^- {}:.*\n(?:  \S.*\n)*".format(re.escape(name)), "", lens, flags=re.M
+    )
+
+
 class FamilyCorrespondenceTest(unittest.TestCase):
     def setUp(self):
         self.lens = LENS.read_text(encoding="utf-8")
@@ -128,6 +189,38 @@ class DelegationStatedTest(unittest.TestCase):
         source = CHECKER.read_text(encoding="utf-8")
         self.assertEqual(
             [NO_DIVISION], correspondence(self.lens.replace(DELEGATED, ""), source)
+        )
+
+
+class GraphJudgmentsTest(unittest.TestCase):
+    """The kept half names the judgments no checker report reaches.
+
+    The checker decides its families over fields each item states about
+    itself. An edge nothing justifies is not one of them -- it is read across
+    the set, from the checker's own `graph` block beside each item's oracles
+    and fixed inputs -- and neither is an item that is two atoms, which every
+    field it states is consistent with.
+    """
+
+    def setUp(self):
+        self.lens = LENS.read_text(encoding="utf-8")
+
+    def test_the_kept_half_names_the_false_edge_and_the_compound_item(self):
+        self.assertEqual([], missing_judgments(self.lens))
+
+    def test_a_judgment_the_lens_drops_is_reported(self):
+        for name in KEPT_JUDGMENTS:
+            with self.subTest(judgment=name):
+                dropped = without_judgment(self.lens, name)
+                self.assertNotEqual(self.lens, dropped, "nothing was dropped")
+                self.assertEqual([ABSENT.format(name)], missing_judgments(dropped))
+
+    def test_a_false_edge_with_no_block_behind_it_is_reported(self):
+        unread = without_judgment(self.lens, FALSE_EDGE).replace(
+            KEPT, "{}\n\n- {}: an edge nothing justifies.".format(KEPT, FALSE_EDGE)
+        )
+        self.assertEqual(
+            [UNREAD.format(FALSE_EDGE, GRAPH_BLOCK)], missing_judgments(unread)
         )
 
 

--- a/tests/test_cutcheck.py
+++ b/tests/test_cutcheck.py
@@ -74,6 +74,20 @@ def graph_block(result):
     return block
 
 
+def finding_lines(result):
+    """Every finding line the report holds, and nothing else.
+
+    Both blocks, neither summary line, and never the shape reading. A caller
+    asking what was found about an item is asking about findings, and the
+    chain the shape names carries ticket ids -- a reading of those items, not
+    a finding against them, and a filter that took it for one would convict a
+    clean set of whatever its longest chain happened to run through.
+    """
+
+    violations, advisories, _ = report(result)
+    return violations + advisories
+
+
 def fixture_criteria(run, name):
     path = ROOT / "tests" / "fixtures" / "cutcheck" / run / name
     section = tickets._sections(path.read_text(encoding="utf-8"))
@@ -102,8 +116,12 @@ class AffirmativeSummaryTest(unittest.TestCase):
         self.assertEqual(
             self.spawned.returncode, 0, self.spawned.stdout + self.spawned.stderr
         )
+        # Nothing found, and the line saying so is the report's last: the
+        # shape reading stands above it and is a reading of this set, never a
+        # finding against it.
+        self.assertEqual(finding_lines(self.spawned), [], self.spawned.stdout)
         self.assertEqual(
-            self.spawned.stdout.splitlines(), [cutcheck.NO_FINDING_OUTSIDE]
+            self.spawned.stdout.splitlines()[-1], cutcheck.NO_FINDING_OUTSIDE
         )
 
     def test_the_in_process_grading_reads_the_same_as_the_spawned_one(self):
@@ -228,6 +246,34 @@ class GraphReadingTest(unittest.TestCase):
         for klass in sorted(cutcheck.GRAPH_CLASSES):
             self.assertEqual(cutcheck.FAMILY_OF[klass], cutcheck.GRAPH)
             self.assertNotIn(klass, cutcheck.ADVISORY)
+
+    def _details(self, run, siblings):
+        return {
+            klass: detail
+            for _, _, klass, detail in cutcheck._graph_reading(run, siblings)
+        }
+
+    def test_a_cycle_is_named_in_the_reading_rather_than_raised(self):
+        """A set no ordering exists for is still read, and says which part is not.
+
+        Asked of the reading directly rather than through a fixture: a cyclic
+        set is one `tickets.py` never issues, so pinning one as a fixture would
+        pin a corpus the tool cannot meet, and re-record its verdict beside the
+        real ones. What has to hold is that the levelling terminates on a graph
+        with no order, reports the part that does have one, and names the rest
+        -- three claims about this function and none about the report's shape.
+        """
+
+        details = self._details("cycled", {
+            "01-a": {"id": "01-a", "depends_on": []},
+            "02-b": {"id": "02-b", "depends_on": ["03-c"]},
+            "03-c": {"id": "03-c", "depends_on": ["02-b"]},
+        })
+        self.assertEqual(details[cutcheck.CRITICAL_PATH], "1: 01-a; cycle: 02-b, 03-c")
+        self.assertEqual(details[cutcheck.LEVEL_WIDTH], "1")
+
+    def test_a_set_with_no_issued_item_has_no_shape_to_read(self):
+        self.assertEqual(cutcheck._graph_reading("empty", {}), [])
 
 
 EXIT_ENTRY_RE = re.compile(r"^ {2}(\d+) {2}(\S.*)$")
@@ -472,7 +518,7 @@ class PathRealityTest(unittest.TestCase):
             self.assertIn(cutcheck.FAMILY_2, line)
 
     def test_exactly_three_violations_one_per_case(self):
-        self.assertEqual(len(self.result.stdout.splitlines()), 3, self.result.stdout)
+        self.assertEqual(len(finding_lines(self.result)), 3, self.result.stdout)
         self.assertEqual(len(self.lines), 3, self.result.stdout)
 
     def test_each_path_class_is_reported_once(self):
@@ -498,18 +544,21 @@ class CarveOutTest(unittest.TestCase):
 
     def test_the_set_is_reported_clean(self):
         self.assertEqual(self.result.returncode, 0, self.result.stdout + self.result.stderr)
-        # The whole report, not a line of it: nothing was found here but the
-        # affirmative line that says so.
-        self.assertEqual(self.result.stdout.splitlines(), [cutcheck.NO_FINDING_OUTSIDE])
+        # Every finding line, not a line of it: nothing was found here, and
+        # the affirmative line closes the report the shape reading precedes.
+        self.assertEqual(finding_lines(self.result), [], self.result.stdout)
+        self.assertEqual(
+            self.result.stdout.splitlines()[-1], cutcheck.NO_FINDING_OUTSIDE
+        )
 
     def test_a_path_the_item_only_reads_is_no_scope_defect(self):
-        self.assertNotIn("01-reads-only", self.result.stdout)
+        self.assertNotIn("01-reads-only", "\n".join(finding_lines(self.result)))
 
     def test_a_path_a_depends_on_ancestor_makes_is_present(self):
-        self.assertNotIn("02-depends", self.result.stdout)
+        self.assertNotIn("02-depends", "\n".join(finding_lines(self.result)))
 
     def test_a_quote_resolves_at_the_baseline_not_the_workspace(self):
-        self.assertNotIn("03-baseline-quote", self.result.stdout)
+        self.assertNotIn("03-baseline-quote", "\n".join(finding_lines(self.result)))
 
 
 class ScopeClosureTest(unittest.TestCase):
@@ -785,7 +834,7 @@ class ExecutorLegalityTest(unittest.TestCase):
         self.assertIn("orch-code-pack", lines[0])
 
     def test_the_packs_own_executor_cell_is_not_reported(self):
-        self.assertNotIn("02-legal", self.result.stdout)
+        self.assertNotIn("02-legal", "\n".join(finding_lines(self.result)))
 
     def test_the_surviving_engines_are_lawful_executors(self):
         """P4-3 deleted the engine prohibition with the two engines it named.
@@ -1076,7 +1125,7 @@ class ShellHeadTest(unittest.TestCase):
             self.assertFalse(mark.exists(), "{}\n{}".format(mark, findings))
 
     def test_the_span_is_reported_rather_than_run(self):
-        lines = [line for line in self.result.stdout.splitlines() if "01-shellhead" in line]
+        lines = [line for line in finding_lines(self.result) if "01-shellhead" in line]
         self.assertEqual(len(lines), 1, self.result.stdout)
         self.assertIn(cutcheck.EXTRACTION_GAP, lines[0])
 
@@ -1097,7 +1146,7 @@ class EvalHeadTest(unittest.TestCase):
             self.assertFalse(mark.exists(), "{}\n{}".format(mark, findings))
 
     def test_the_span_is_reported_rather_than_run(self):
-        lines = [line for line in self.result.stdout.splitlines() if "01-evalhead" in line]
+        lines = [line for line in finding_lines(self.result) if "01-evalhead" in line]
         self.assertEqual(len(lines), 1, self.result.stdout)
         self.assertIn(cutcheck.EXTRACTION_GAP, lines[0])
 
@@ -1199,7 +1248,7 @@ class GitEscapeTest(unittest.TestCase):
 
     def test_the_span_is_reported_rather_than_run(self):
         lines = [
-            line for line in self.result.stdout.splitlines() if "01-gitescape" in line
+            line for line in finding_lines(self.result) if "01-gitescape" in line
         ]
         self.assertEqual(len(lines), 2, self.result.stdout)
         for line in lines:
@@ -2032,7 +2081,7 @@ class VerdictInOutputTest(unittest.TestCase):
     def setUp(self):
         self.result = run_cutcheck("cutcheck-verdict-in-output")
         self.lines = [
-            line for line in self.result.stdout.splitlines() if "01-verdict" in line
+            line for line in finding_lines(self.result) if "01-verdict" in line
         ]
 
     def test_the_text_count_is_reported_for_what_it_prints(self):

--- a/tests/test_cutcheck.py
+++ b/tests/test_cutcheck.py
@@ -37,20 +37,41 @@ def reported(result, family=cutcheck.FAMILY):
 
 
 def report(result):
-    """The report split where its own two summary lines split it.
+    """The report split where its own summary lines split it.
 
     Findings outside the advisory set first, then the advisory findings under
-    the heading, then whether the affirmative line closed the report.
+    the heading, then whether the affirmative line closed the report. The shape
+    reading is split off and returned by none of the three: it is a reading of
+    the cut and not a finding of it, so a caller counting findings must never
+    have to subtract it.
     """
 
     lines = result.stdout.splitlines()
     affirmed = bool(lines) and lines[-1] == cutcheck.NO_FINDING_OUTSIDE
     if affirmed:
         lines = lines[:-1]
+    if cutcheck.GRAPH_HEADING in lines:
+        lines = lines[:lines.index(cutcheck.GRAPH_HEADING)]
     if cutcheck.ADVISORY_HEADING in lines:
         cut = lines.index(cutcheck.ADVISORY_HEADING)
         return lines[:cut], lines[cut + 1:], affirmed
     return lines, [], affirmed
+
+
+def graph_block(result):
+    """The shape reading's own lines, under its own heading.
+
+    The half `report` drops. Nothing but the affirmative line follows the
+    block, so the block is what stands between its heading and that line.
+    """
+
+    lines = result.stdout.splitlines()
+    if cutcheck.GRAPH_HEADING not in lines:
+        return []
+    block = lines[lines.index(cutcheck.GRAPH_HEADING) + 1:]
+    if block and block[-1] == cutcheck.NO_FINDING_OUTSIDE:
+        block = block[:-1]
+    return block
 
 
 def fixture_criteria(run, name):
@@ -133,7 +154,11 @@ class AdvisoryMarkingTest(unittest.TestCase):
     def test_neither_summary_line_can_be_read_as_a_finding(self):
         markers = sorted(cutcheck.FAMILY_OF) + sorted(set(cutcheck.FAMILY_OF.values()))
         markers += ["criterion ", "scripts/cutcheck.py"]
-        for line in (cutcheck.ADVISORY_HEADING, cutcheck.NO_FINDING_OUTSIDE):
+        for line in (
+            cutcheck.ADVISORY_HEADING,
+            cutcheck.GRAPH_HEADING,
+            cutcheck.NO_FINDING_OUTSIDE,
+        ):
             for marker in markers:
                 self.assertNotIn(marker, line)
 
@@ -148,6 +173,61 @@ class AdvisoryExitZeroTest(unittest.TestCase):
         self.assertEqual(violations, [], result.stdout)
         self.assertTrue(advisories, result.stdout)
         self.assertTrue(affirmed, result.stdout)
+
+
+class GraphReadingTest(unittest.TestCase):
+    """The cut's shape is read from the issued set, and it decides nothing.
+
+    The fixture is five items in the one arrangement that separates the two
+    readings from each other: three items depending on nothing, one behind one
+    of those, and one behind that one and a second first-level item. Depth and
+    breadth disagree there -- the chain is three long where the widest level
+    holds three -- so a reading that counted levels as a chain, or took the
+    longest chain to be the item count, is wrong by a different number in each
+    line rather than right by coincidence.
+
+    The set is otherwise clean, which is what makes the second node an
+    assertion rather than a hope: the graph classes lie outside the advisory
+    set, so were they findings at all they would be findings outside it, and
+    this set would exit 1 with two violations instead of 0 with none.
+    """
+
+    RUN = "cutcheck-graph"
+
+    @classmethod
+    def setUpClass(cls):
+        cls.result = run_cutcheck(cls.RUN)
+
+    def _detail(self, klass):
+        prefix = "{}: {}: {}: ".format(self.RUN, cutcheck.GRAPH, klass)
+        found = [
+            line[len(prefix):]
+            for line in graph_block(self.result)
+            if line.startswith(prefix)
+        ]
+        self.assertEqual(len(found), 1, self.result.stdout)
+        return found[0]
+
+    def test_the_critical_path_and_level_widths_are_reported(self):
+        self.assertEqual(
+            self._detail(cutcheck.CRITICAL_PATH),
+            "3: 01-alpha > 04-delta > 05-epsilon",
+            self.result.stdout,
+        )
+        self.assertEqual(
+            self._detail(cutcheck.LEVEL_WIDTH), "3 1 1", self.result.stdout
+        )
+
+    def test_the_graph_block_stands_outside_the_advisory_set_and_the_exit_status(self):
+        violations, advisories, affirmed = report(self.result)
+        self.assertTrue(graph_block(self.result), self.result.stdout)
+        self.assertEqual(self.result.returncode, cutcheck.CLEAN, self.result.stdout)
+        self.assertEqual(violations, [], self.result.stdout)
+        self.assertEqual(advisories, [], self.result.stdout)
+        self.assertTrue(affirmed, self.result.stdout)
+        for klass in sorted(cutcheck.GRAPH_CLASSES):
+            self.assertEqual(cutcheck.FAMILY_OF[klass], cutcheck.GRAPH)
+            self.assertNotIn(klass, cutcheck.ADVISORY)
 
 
 EXIT_ENTRY_RE = re.compile(r"^ {2}(\d+) {2}(\S.*)$")

--- a/tests/test_static_tree_invariants.py
+++ b/tests/test_static_tree_invariants.py
@@ -33,6 +33,10 @@ OVERLAP_ANCHORS = ("write scope", "dependency-ordered")
 # the Goal minimizes, the per-item constraint it minimizes under, and the
 # cutcheck block whose numbers the Return reports it against.
 CUT_GOAL_ANCHORS = ("critical path", "atom", "graph")
+INTEGRATE = ROOT / "skills" / "kernel" / "orch-integrate" / "SKILL.md"
+# The empty-set skip by its anchors: the gate item the join completes itself,
+# spelled as the owner spells it, and the set whose emptiness is the trigger.
+EMPTY_SET_SKIP_ANCHORS = ("gate.repair", "accepted defect set")
 
 COMPOSITIONS = ROOT / "compositions"
 EVAL_DESIGN = ROOT / "skills" / "workflows" / "orch-eval-design" / "SKILL.md"
@@ -372,6 +376,17 @@ class TestCutGoalAnchors(unittest.TestCase):
                 "longer told to minimize the critical path subject to every "
                 "item an atom, or no longer returns the graph block whose "
                 "numbers that goal is measured by",
+            )
+
+    def test_the_join_skips_the_repair_on_an_empty_accepted_set(self):
+        text = read_flat(INTEGRATE)
+        for anchor in EMPTY_SET_SKIP_ANCHORS:
+            self.assertIn(
+                anchor, text,
+                f"orch-integrate does not name {anchor!r}, so the join no "
+                "longer completes the gate's repair itself on an empty "
+                "accepted defect set and every clean run pays for a no-op "
+                "dispatch on its critical path",
             )
 
 

--- a/tests/test_static_tree_invariants.py
+++ b/tests/test_static_tree_invariants.py
@@ -29,6 +29,10 @@ DESIGN_SLICING = ROOT / "packs" / "orch-design-pack" / "references" / "slicing.m
 # The rule by its anchors, never by its sentence: the field the rule scopes,
 # as the owner's prose spells it, and the ordering term that scopes it.
 OVERLAP_ANCHORS = ("write scope", "dependency-ordered")
+# What a cut optimizes, by the three terms orch-decompose spells: the quantity
+# the Goal minimizes, the per-item constraint it minimizes under, and the
+# cutcheck block whose numbers the Return reports it against.
+CUT_GOAL_ANCHORS = ("critical path", "atom", "graph")
 
 COMPOSITIONS = ROOT / "compositions"
 EVAL_DESIGN = ROOT / "skills" / "workflows" / "orch-eval-design" / "SKILL.md"
@@ -335,6 +339,39 @@ class TestDependencyOrderedOverlap(unittest.TestCase):
                 anchor, text,
                 f"code pack slicing does not name {anchor!r}, so it does not "
                 "put the riskiest seam's tracer in the first frontier",
+            )
+
+
+class TestCutGoalAnchors(unittest.TestCase):
+    """Three facts about what a cut is for, each landed in a prose owner and
+    each read here by that owner's own anchors rather than by the sentence
+    carrying them: the decomposer states what a cut optimizes, the join
+    completes an empty repair instead of dispatching a no-op, and both slicing
+    cells open the first frontier with what the acceptance already proves.
+
+    Nothing else in the tree reads these clauses, so before this class any of
+    the three could be reworded away silently. The pin is an anchor and not a
+    sentence for the reason craft.md (Shape) gives, which is load-bearing
+    here: the two kernel bodies sit two and seven words inside the 300-word
+    ceiling and get recompressed to pay for the next clause, and the
+    cross-pack cell linter forbids the two slicing cells from stating their
+    shared fact in one shared sentence -- so the slicing pin is the two words
+    literal in both, asserted per cell.
+
+    Each anchor is also load-bearing rather than incidental: deleting the
+    clause that carries it from a copy of its owner reds this class. An
+    anchor that survived that deletion would only prove the grep.
+    """
+
+    def test_the_decomposer_states_the_goal_by_anchor(self):
+        text = read_flat(DECOMPOSE)
+        for anchor in CUT_GOAL_ANCHORS:
+            self.assertIn(
+                anchor, text,
+                f"orch-decompose does not name {anchor!r}, so the cut is no "
+                "longer told to minimize the critical path subject to every "
+                "item an atom, or no longer returns the graph block whose "
+                "numbers that goal is measured by",
             )
 
 

--- a/tests/test_static_tree_invariants.py
+++ b/tests/test_static_tree_invariants.py
@@ -37,6 +37,11 @@ INTEGRATE = ROOT / "skills" / "kernel" / "orch-integrate" / "SKILL.md"
 # The empty-set skip by its anchors: the gate item the join completes itself,
 # spelled as the owner spells it, and the set whose emptiness is the trigger.
 EMPTY_SET_SKIP_ANCHORS = ("gate.repair", "accepted defect set")
+# The one fact both cells state, by the only two words literal in both: the
+# frontier the proven work opens, and the state that earns the exception.
+# tools/validate.py's cross-pack cell linter forbids the shared sentence, so
+# the cells word the rest apart on purpose and there is nothing else to pin.
+PROVEN_SEAM_ANCHORS = ("first frontier", "unproven")
 
 COMPOSITIONS = ROOT / "compositions"
 EVAL_DESIGN = ROOT / "skills" / "workflows" / "orch-eval-design" / "SKILL.md"
@@ -388,6 +393,22 @@ class TestCutGoalAnchors(unittest.TestCase):
                 "accepted defect set and every clean run pays for a no-op "
                 "dispatch on its critical path",
             )
+
+    def test_the_slicing_cells_put_proven_seams_on_the_first_frontier(self):
+        for label, path in (
+            ("code pack slicing", CODE_SLICING),
+            ("design pack slicing", DESIGN_SLICING),
+        ):
+            text = read_flat(path)
+            for anchor in PROVEN_SEAM_ANCHORS:
+                with self.subTest(cell=label, anchor=anchor):
+                    self.assertIn(
+                        anchor, text,
+                        f"{label} does not name {anchor!r}, so it no longer "
+                        "opens the first frontier with the work the "
+                        "acceptance already proves and reserves the tracer "
+                        "for what the spec leaves unproven",
+                    )
 
 
 class TestCompositionLinks(unittest.TestCase):

--- a/tests/test_static_tree_invariants.py
+++ b/tests/test_static_tree_invariants.py
@@ -32,7 +32,10 @@ OVERLAP_ANCHORS = ("write scope", "dependency-ordered")
 # What a cut optimizes, by the three terms orch-decompose spells: the quantity
 # the Goal minimizes, the per-item constraint it minimizes under, and the
 # cutcheck block whose numbers the Return reports it against.
-CUT_GOAL_ANCHORS = ("critical path", "atom", "graph")
+# The constraint anchor carries the two words before the term because the body
+# names the atom twice -- in the Goal and in the pointer to its test -- so the
+# bare term survives deleting the constraint clause and pins nothing.
+CUT_GOAL_ANCHORS = ("critical path", "item an atom", "graph")
 INTEGRATE = ROOT / "skills" / "kernel" / "orch-integrate" / "SKILL.md"
 # The empty-set skip by its anchors: the gate item the join completes itself,
 # spelled as the owner spells it, and the set whose emptiness is the trigger.
@@ -341,13 +344,15 @@ class TestDependencyOrderedOverlap(unittest.TestCase):
                 "different frontiers can be concurrently in flight and collide",
             )
 
-    def test_the_code_cut_puts_the_riskiest_seam_first(self):
+    def test_the_code_cut_reserves_the_tracer_for_the_unproven_seam(self):
         text = read_flat(CODE_SLICING)
         for anchor in ("first frontier", "riskiest", "tracer"):
             self.assertIn(
                 anchor, text,
-                f"code pack slicing does not name {anchor!r}, so it does not "
-                "put the riskiest seam's tracer in the first frontier",
+                f"code pack slicing does not name {anchor!r}, so it no longer "
+                "opens the first frontier with the seams the acceptance "
+                "already checks and reserves the tracer for the riskiest "
+                "seam the spec leaves unproven",
             )
 
 

--- a/tests/test_templates.py
+++ b/tests/test_templates.py
@@ -496,6 +496,28 @@ class TestTemplateBudgets(_TemplateTree):
     every-dispatch and every-run units with word ceilings; a stub's fixed
     inputs are identities and never count."""
 
+    EXCLUDED_ACTIONS = (
+        "excluded_actions:\n  - adding a third-party dependency\n"
+        "  - editing a T0 contract\n"
+    )
+
+    def stub_at(self, words):
+        """One stub carrying excluded actions, its objective padded until
+        `tickets.instruction_words` reads exactly `words`.
+
+        Measured against the owner rather than recomputed here: what the
+        caller pins is that the compiler reaches the same number, which it
+        can only do by asking the owner.
+        """
+
+        def render(objective):
+            text = stub_md("repair", depends="[diagnose]")
+            text = text.replace("bound:", self.EXCLUDED_ACTIONS + "bound:")
+            return text.replace("one repaired tree at {{target}}.", objective)
+
+        spent = tickets.instruction_words(render("word")) - 1
+        return render(" ".join(["word"] * (words - spent)))
+
     def test_a_stub_whose_instruction_exceeds_the_budget_is_one_error(self):
         fat = "- " + " ".join(["criterion"] * 320) + " | oracle: x | oracle_class: deterministic\n"
         stubs = dict(GOOD_STUBS)
@@ -503,7 +525,21 @@ class TestTemplateBudgets(_TemplateTree):
         self.write_template("demo", stubs=stubs)
         error = self.assert_one_error("repair.md")
         self.assertIn("stub instruction has", error)
-        self.assertIn(f"budget of {validate.STUB_INSTRUCTION_BUDGET}", error)
+        self.assertIn(f"budget of {tickets.INSTRUCTION_BUDGET}", error)
+
+    def test_the_compiler_puts_the_boundary_where_the_ticket_owner_puts_it(self):
+        """A stub is a ticket before it is issued, and rules/token-economy.md
+        §11 is one ceiling: the compiler grading the template and the script
+        refusing the issued ticket have to put the boundary in the same
+        place. This compiler kept a counter of its own, and that one charged
+        an excluded action a word for its list marker -- so a stub the sink
+        accepts at the ceiling was two words over here."""
+
+        stubs = dict(GOOD_STUBS)
+        stubs["repair"] = self.stub_at(tickets.INSTRUCTION_BUDGET)
+        self.write_template("demo", stubs=stubs)
+        result, errors = self.diagnostics()
+        self.assertEqual([], errors, result.stdout)
 
     def test_fixed_inputs_do_not_count_toward_the_stub_budget(self):
         stubs = dict(GOOD_STUBS)

--- a/tests/test_tickets_issue.py
+++ b/tests/test_tickets_issue.py
@@ -529,6 +529,29 @@ class InstructionCeilingTest(unittest.TestCase):
                 at, tickets_mod.instruction_words(path.read_text(encoding="utf-8"))
             )
 
+    def test_a_root_ticket_is_exempt(self):
+        """A root states a whole run, and the `.gate.` stubs `gate` renders
+        carry that root's `## Completion test` verbatim. Neither is a unit
+        packet, and holding them to the unit ceiling would refuse what this
+        script itself writes."""
+
+        over = tickets_mod.INSTRUCTION_BUDGET + 100
+        exempt = (
+            ("00-root", tickets_mod.ROOT_EXECUTOR),
+            ("00-root.gate.critique.code", "orch-critique"),
+            ("00-root.gate.verify", "orch-verify"),
+        )
+        for ticket_id, executor in exempt:
+            with self.subTest(ticket_id), tempfile.TemporaryDirectory() as tmp:
+                tmp = Path(tmp)
+                payload, path = self.place(
+                    tmp,
+                    ceiling_ticket(over, executor=executor, ticket_id=ticket_id),
+                    ticket_id=ticket_id,
+                )
+                self.assertNotIn("error", payload)
+                self.assertTrue(path.is_file())
+
 
 class CriterionNestingTest(unittest.TestCase):
     """Indentation, in the one owner of criterion parsing.

--- a/tests/test_tickets_issue.py
+++ b/tests/test_tickets_issue.py
@@ -386,6 +386,150 @@ class AmendTest(unittest.TestCase):
             self.assertIn("T9", payload["error"])
 
 
+# A ticket whose instruction is padded to an exact word count. Every part
+# the counter reads is a slot here, so this module can spend the budget with
+# `str.split` -- its own arithmetic, not the owner's -- and the two have to
+# agree on the number the refusal states.
+CEILING_EXCLUDED = ("adding a third-party dependency", "editing a T0 contract")
+CEILING_RETURNS = "status; result; verification."
+CEILING_TICKET = """---
+id: {ticket_id}
+run: testrun
+status: ready
+executor: {executor}
+depends_on: []
+write_scope: [scratch/t1.txt]
+excluded_actions:
+  - {excluded_one}
+  - {excluded_two}
+bound: 30m
+claimed_by:
+claimed_at:
+---
+
+## Objective
+
+{objective}
+
+## Fixed inputs
+
+{inputs}
+
+## Completion test
+
+- {criterion}
+
+## Return fields
+
+{returns}
+
+## Result
+
+## Verification
+
+## Feedback
+
+[]
+
+## Risks
+
+[]
+"""
+
+
+def ceiling_ticket(total, inputs="None.", executor="orch-tdd", ticket_id="T1"):
+    """One ticket whose instruction is exactly ``total`` words.
+
+    The objective takes whatever the excluded actions, the criterion and the
+    return fields have not already spent; `## Fixed inputs` is free of the
+    count by law, so a caller pads it to prove exactly that.
+    """
+
+    spent = sum(
+        len(part.split())
+        for part in (*CEILING_EXCLUDED, "- " + GOOD_CRITERION, CEILING_RETURNS)
+    )
+    return CEILING_TICKET.format(
+        ticket_id=ticket_id,
+        executor=executor,
+        excluded_one=CEILING_EXCLUDED[0],
+        excluded_two=CEILING_EXCLUDED[1],
+        objective=" ".join(["word"] * (total - spent)),
+        inputs=inputs,
+        criterion=GOOD_CRITERION,
+        returns=CEILING_RETURNS,
+    )
+
+
+class InstructionCeilingTest(unittest.TestCase):
+    """rules/token-economy.md §11: a unit ticket's instruction -- its
+    objective, completion test, excluded actions and return fields, never
+    its fixed inputs -- is 300 words, and the two subcommands that write
+    cut-time content refuse one over it before it lands.
+
+    The ceiling was enforced only on `compositions/*/` stubs, where no
+    dispatched ticket ever comes from: every wide ad-hoc set in the sink ran
+    at a median instruction of 500-800 words, objectives enumerating (1)...(5)
+    -- two atoms issued as one. The refusal is where the cutter still holds
+    the flag that was wrong.
+    """
+
+    def place(self, tmp: Path, text: str, ticket_id: str = "T1"):
+        """`new --file` for one already-written ticket; the sink is the
+        test's own."""
+
+        sink = use_sink(tmp)
+        source = tmp / f"{ticket_id}.md"
+        source.write_text(text, encoding="utf-8")
+        payload = run_cmd("new", "testrun", "--file", str(source))
+        return payload, sink / "tickets" / "testrun" / f"{ticket_id}.md"
+
+    def assert_names_the_ceiling(self, error, count):
+        for expected in (str(count), str(tickets_mod.INSTRUCTION_BUDGET),
+                         "rules/token-economy.md", "two items"):
+            with self.subTest(expected):
+                self.assertIn(expected, error)
+
+    def test_new_refuses_an_instruction_over_the_ceiling(self):
+        over = tickets_mod.INSTRUCTION_BUDGET + 1
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp = Path(tmp)
+            payload, path = self.place(tmp, ceiling_ticket(over))
+            self.assertIn("error", payload)
+            self.assert_names_the_ceiling(payload["error"], over)
+            self.assertFalse(path.exists(), "a refused cut wrote")
+            # The flag form renders its own text and lands in the same
+            # grade, so a cutter cannot spell its way past the ceiling.
+            flagged = run_cmd(
+                "new", "testrun", "T2", "--executor", "orch-tdd",
+                "--objective", " ".join(["word"] * (over + 20)),
+                "--criterion", GOOD_CRITERION,
+            )
+            self.assertIn("error", flagged)
+            self.assert_names_the_ceiling(
+                flagged["error"], tickets_mod.INSTRUCTION_BUDGET
+            )
+            self.assertFalse(
+                (path.parent / "T2.md").exists(), "a refused cut wrote"
+            )
+
+    def test_new_issues_an_instruction_at_the_ceiling(self):
+        at = tickets_mod.INSTRUCTION_BUDGET
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp = Path(tmp)
+            # The fixed inputs are identities, not instruction: four hundred
+            # words of them do not move the count.
+            payload, path = self.place(
+                tmp,
+                ceiling_ticket(at, inputs="- " + " ".join(["identity"] * 400)),
+            )
+            self.assertNotIn("error", payload)
+            self.assertTrue(path.is_file())
+            self.assertEqual(
+                at, tickets_mod.instruction_words(path.read_text(encoding="utf-8"))
+            )
+
+
 class CriterionNestingTest(unittest.TestCase):
     """Indentation, in the one owner of criterion parsing.
 

--- a/tests/test_tickets_issue.py
+++ b/tests/test_tickets_issue.py
@@ -1512,7 +1512,13 @@ class RefusalTextTest(unittest.TestCase):
                 ),
             )
             directory = make_template(tmp, three_stubs())
+            fat = tmp / "F1.md"
+            fat.write_text(
+                ceiling_ticket(tickets_mod.INSTRUCTION_BUDGET + 1, ticket_id="F1"),
+                encoding="utf-8",
+            )
             return [
+                run_cmd("new", "testrun", "--file", str(fat)),
                 run_cmd("new", "testrun", "T1", "--executor", "orch-verify",
                         "--objective", "o", "--criterion", "x"),
                 run_cmd("new", "testrun", "T1", "--executor", "orch-verify",

--- a/tests/test_tickets_issue.py
+++ b/tests/test_tickets_issue.py
@@ -529,6 +529,39 @@ class InstructionCeilingTest(unittest.TestCase):
                 at, tickets_mod.instruction_words(path.read_text(encoding="utf-8"))
             )
 
+    def test_amend_refuses_an_instruction_over_the_ceiling(self):
+        """`amend` is the one write path around the refusals `new` applies
+        to the same bytes; a cutter could otherwise widen a ticket past the
+        ceiling one section at a time."""
+
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp = Path(tmp)
+            payload, path = self.place(
+                tmp, ceiling_ticket(tickets_mod.INSTRUCTION_BUDGET)
+            )
+            self.assertNotIn("error", payload)
+            before = path.read_text(encoding="utf-8")
+            refused = run_cmd(
+                "amend", "testrun", "T1", "--section", "Objective",
+                "--text", " ".join(["word"] * tickets_mod.INSTRUCTION_BUDGET),
+            )
+            self.assertIn("error", refused)
+            self.assert_names_the_ceiling(
+                refused["error"], tickets_mod.INSTRUCTION_BUDGET
+            )
+            self.assertEqual(before, path.read_text(encoding="utf-8"))
+            # The section that is never instruction stays amendable at any
+            # length, and a repair that brings the ticket down lands.
+            for section, body in (
+                ("Fixed inputs", "- " + " ".join(["identity"] * 400)),
+                ("Objective", "cut the run"),
+            ):
+                with self.subTest(section):
+                    self.assertNotIn("error", run_cmd(
+                        "amend", "testrun", "T1", "--section", section,
+                        "--text", body,
+                    ))
+
     def test_a_root_ticket_is_exempt(self):
         """A root states a whole run, and the `.gate.` stubs `gate` renders
         carry that root's `## Completion test` verbatim. Neither is a unit

--- a/tools/validate.py
+++ b/tools/validate.py
@@ -50,11 +50,13 @@ LINK_TARGET_RE = re.compile(r"\]\([^)]*\)")
 # rules/token-economy.md §11: every-turn surfaces tightest, every-dispatch
 # units next, every-run units widest. Ceilings only fall.
 SURFACE_BUDGET = {"templates/host-block.md": 400, "AGENTS.md": 300}
-STUB_INSTRUCTION_BUDGET = 300   # objective + completion test + excluded actions + return fields
 MANIFEST_BUDGET = 250
-STUB_INSTRUCTION_SECTIONS = ("Objective", "Completion test", "Return fields")
-STUB_SECTION_SPLIT_RE = re.compile(r"^## (.+)$", re.MULTILINE)
-EXCLUDED_ACTIONS_RE = re.compile(r"^excluded_actions:\n((?:[ \t]+- .*\n)*)", re.MULTILINE)
+# A stub's instruction ceiling is not here: a stub is a ticket before it is
+# issued, and `scripts/tickets.py` refuses an issued one over the same
+# number. `_ticket_law()` reads `INSTRUCTION_BUDGET` and `instruction_words`
+# from there, so the compiler and the sink cannot put the boundary in two
+# places -- this file's own counter charged an excluded action a word for
+# its list marker, and did.
 DESCRIPTION_BUDGET = 140
 ALLOWED_FRONTMATTER_KEYS = {"name", "description", "disable-model-invocation", "role"}
 ROLE_PROFILES = {"orch-planner", "orch-worker"}
@@ -758,18 +760,6 @@ def body_words(body: str) -> int:
 def _split_frontmatter(text: str):
     parts = text.split("---", 2)
     return (parts[1], parts[2]) if len(parts) > 2 else ("", text)
-
-
-def stub_instruction_words(text: str) -> int:
-    """A stub's instruction: its excluded actions plus the Objective,
-    Completion test and Return fields sections — never its Fixed inputs,
-    which are identities (rules/token-economy.md §11)."""
-    front, body = _split_frontmatter(text)
-    excluded = EXCLUDED_ACTIONS_RE.search(front)
-    total = body_words(excluded.group(1)) if excluded else 0
-    parts = STUB_SECTION_SPLIT_RE.split(body)
-    sections = {parts[i].strip(): parts[i + 1] for i in range(1, len(parts) - 1, 2)}
-    return total + sum(body_words(sections.get(name, "")) for name in STUB_INSTRUCTION_SECTIONS)
 
 
 def validate_surface_budgets(diag: Diagnostics) -> None:
@@ -1520,9 +1510,9 @@ def validate_templates(diag: Diagnostics) -> None:
             if path.name == manifest_name:
                 continue
             text = _read_source(path)
-            n = stub_instruction_words(text)
-            if n > STUB_INSTRUCTION_BUDGET:
-                diag.error(rel(path), f"stub instruction has {n} words, exceeds the budget of {STUB_INSTRUCTION_BUDGET}")
+            n = tickets.instruction_words(text)
+            if n > tickets.INSTRUCTION_BUDGET:
+                diag.error(rel(path), f"stub instruction has {n} words, exceeds the budget of {tickets.INSTRUCTION_BUDGET}")
             stub_used = set(tickets.PLACEHOLDER_RE.findall(text))
             used |= stub_used
             executor = tickets._parse_frontmatter(text).get("executor")


### PR DESCRIPTION
Implements the decomposer's cutting goals — small atoms, minimal critical path — from the handoff `20260817T133916Z-decomposer-cut-goals`, as structure rather than exhortation: the goal and the atom's bounds in the law and the decomposer, the asymmetric defect families in the critiquer, and every measurement in a script.

Run `20260817T135914Z-decomposer-cut-goals`, root `00-root`, pack `orch-code-pack`. Nine units, one gate. Critical path 2, level widths 8 1 — read from the tool this run built.

## What lands

**Law.** `rules/topology.md` §3: the lawful set is the finest cut in which every item is an **atom** — one observable end state; a completion test discriminating it alone (cutcheck family 1); a closed write scope (family 3); oracles reading nothing a sibling writes (family 4); an instruction inside the ceiling. A coarser item is a *compound item*, never a safe default; below the atom is *padding*. Count unbounded above, width past the host profile the frontier's queue. An **edge** exists only where the dependent's oracle reads what the predecessor writes or its `## Fixed inputs` cite the predecessor's result identity — never for ordering preference. An artifact more than one item would write goes to **exactly one item**, the recurring surfaces named. An ad-hoc set is a cut like any other and cutcheck reads it before its first dispatch. The superseded "a cut is forced only by…never made to look thorough" sentence is gone; its anti-padding intent is re-sited as the atom's floor. `docs/vocabulary.md` defines **atom** and **critical path**.

**Mechanism.** `scripts/tickets.py` owns the instruction ceiling: `INSTRUCTION_BUDGET = 300` and `instruction_words()`; `new` (both forms) and `amend` refuse a unit over it, a root ticket and its `.gate.` stubs exempt. `tools/validate.py` lost its five private names and reads the owner. A compound objective enumerating (1)…(5) no longer fits.

**Measurement.** `scripts/cutcheck.py` prints a third block — the cut's shape, `critical-path` and `level-width` — under its own marker, outside the advisory set, never exit-setting. Its heading deliberately borrows nothing from the advisory heading, so no reader fires the fresh cut checker on it.

**Surfaces.** `orch-decompose` opens its cut with the goal and returns the graph numbers, citing §3 rather than restating it. The cut lens keeps two new judgments: **false edge** and **compound item**. `orch-integrate` completes a `<root>.gate.repair` itself on an empty accepted defect set, with no dispatch — the small-task lever the `stats-root` run paid for. Both slicing cells put acceptance-proven seams on the first frontier and reserve the tracer for the unproven seam; the design cell keeps the token item's edge, which its views' captures read.

**Pins.** Every fact by anchor, never by sentence (`craft.md` Shape): topology and vocabulary in `test_contracts.py` (with a family-correspondence pin read off `cutcheck.FAMILY_OF`, so a renumbering can no longer falsify §3 silently), the lens in `test_cut_lens.py`, the three prose owners in `test_static_tree_invariants.py`, the scripts by behaviour tests.

## How it was run

The design was practiced on itself. Eight atoms on the first frontier plus one closing item for the shared test module — the sole-owner rule applied to the run that writes it. `cutcheck` exit 0 before dispatch after six repair classes; a fresh cut checker (Opus 5) amended three sections before any unit was promoted.

Two things only the wider vantage could see, both repaired:

- The batch tip check caught a **red the lanes' own oracles could not**: the decomposer body restated §3 at 0.93 similarity, tripping the cross-tier near-duplicate ratchet. Blame recorded as the caller's — the lane ran exactly the oracles its ticket named. Repaired by `00-root.09` (7 → 4 WARNs).
- The gate critique caught a **pin that went vacuous between commits**: `00-root.08` demonstrated its `atom` mutant red, and `00-root.09` then added a second occurrence of the word one commit later, so deleting the whole finest-cut clause left the pin green. Repaired by re-deriving the anchor to `item an atom` and re-showing the mutant red at the merged tip.

Five accepted defects at the gate, all repaired, none declined; one candidate rejected on evidence. Root criterion 7 (judged) went NOT MET at the critique and PASS at verify once the design cell's polarity was fixed.

## Checks

At `b0e943d`: `validate.py` 0 ERROR / 8 WARN (baseline's own count), `run_tests.py` 2036 tests 0 failures, serial `discover` 2036 OK, `install.py --dry-run` 0, `git diff --check` clean, `git status --porcelain` empty. `preflight.py` green on 3.9 / 3.11 / 3.12; 3.13 and the two non-Windows OS cells stay CI's.

## Queued, not in scope

Promote the can-fail mutant harness and the anchor-occurrence screen to `tools/` and run them at the join — two runs have now hand-built them. `tests/test_contracts.py` imports `scripts/cutcheck.py` at module scope. The cell near-duplicate linter sits at its ceiling with no headroom. Two open uncertainties the critique named: whether `orch-frontier` could dispatch a ready `gate.repair` before the join closes it, and `_ceiling_error`'s `.gate.` marker matching any id containing it. `suite_check.py`'s stripped-PATH arm still strips git (carried from PR #61).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
