### PR TITLE
Make super-research manual invocation only

### DIFF
--- a/.claude/skills/super-research/SKILL.md
+++ b/.claude/skills/super-research/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: super-research
 description: Use for keyless read-only acquisition of public records: Reddit, X, Bluesky, YouTube, HN, GitHub, LinkedIn, Stocktwits, markets, open web.
+disable-model-invocation: true
 ---
 @../../../.orchflows/skills/super-research/SKILL.md
 

--- a/.orchflows/skills/super-research/SKILL.md
+++ b/.orchflows/skills/super-research/SKILL.md
@@ -2,6 +2,7 @@
 name: super-research
 description: Use for keyless read-only acquisition of public records: Reddit, X, Bluesky, YouTube, HN, GitHub, LinkedIn, Stocktwits, markets, open web.
 role: worker
+disable-model-invocation: true
 ---
 
 Require: one bounded question naming the platforms it reaches, a frozen `as_of`

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,7 +14,7 @@ command is `python scripts/friction.py "<what happened>" "<what was
 expected or missing>"`, same sink, same flags. `orch-off` suspends
 routing for the session on request.
 
-- Project-scope custom item: `super-research` — keyless read-only acquisition from public surfaces — at `.orchflows/skills/super-research/SKILL.md`.
+- Project-scope custom item: `super-research` — manual invocation only; keyless read-only acquisition from public surfaces — at `.orchflows/skills/super-research/SKILL.md`.
 
 ## Required checks
 


### PR DESCRIPTION
## What changed

- set `disable-model-invocation: true` on the project-scoped `super-research` skill
- mirror the setting on its Claude adapter
- mark the Codex routing entry as manual invocation only

## Why

`super-research` should run only when explicitly invoked, not through model-selected routing.

## Impact

The acquisition implementation is unchanged. Only invocation policy and host routing metadata change.

## Validation

- `uv run --no-project python tools/validate.py`
- `uv run --no-project python tools/run_tests.py` — 2,110 tests passed, 17 skipped
- `uv run --no-project python -m unittest discover -s tests -v` — 2,110 tests passed, 17 skipped
- `uv run --no-project python install.py --dry-run`
- `git diff --check`