### PR TITLE
installer: add private runtime

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -44,7 +44,17 @@ dependencies point. Terms: `docs/vocabulary.md`.
   `tests/pins.json` is where `validate.py` reads them from.
 - `install.sh` / `install.cmd` + `install.py` — setup and teardown; what
   each scope writes, detects and removes is `install.py`'s docstring's.
-- `scripts/` — repository-root scripts — stdlib Python 3, Windows and
+  `install.py` is the compatibility facade; `installer/` owns the static
+  support modules, including the private-runtime lifecycle in
+  `installer/runtime.py`. User scope owns one private runtime at
+  `~/.orchflows/runtime`; project scope verifies and borrows it, renders
+  caller-local paths, and never creates an environment in a repository.
+  Runtime replacement is staged and probed before an installer-owned prior
+  generation is moved.
+- `requirements-runtime.txt` — the installed runtime's dependency contract.
+  `pyproject.toml` mirrors its current empty dependency set for repository
+  tooling; this revision installs no third-party package.
+- `scripts/` — repository-root scripts — Python 3.9+, Windows and
   POSIX, no network at run time — one owner each. The unprefixed family
   module is the public CLI and import compatibility facade; implementation
   dependencies point from that facade into its static `<name>_*` helpers,

--- a/README.md
+++ b/README.md
@@ -16,6 +16,13 @@ picks the right workflow.
 Works with Claude Code and Codex, on Windows, macOS, and Linux. It
 configures whichever CLI it finds. To update: `git pull`, rerun.
 
+User installs create or reuse `~/.orchflows/runtime`, a private Python
+environment used by installed commands even when installation starts from
+an active project environment. Runtime dependencies are declared in
+`requirements-runtime.txt`; the current declaration is intentionally empty.
+Project installs never create an environment in the project, dry runs create
+nothing, and uninstall retains the private runtime for explicit manual cleanup.
+
 ## Use
 
 Ask for things like you normally would. There are no skill names to
@@ -73,10 +80,13 @@ Runs survive session death: every ticket is a file in one per-user
 state sink outside every repository, so a fresh context — in any
 checkout — resumes mid-flight.
 
-Team setup: `python install.py --project PATH` writes a committable
-routing block for a repo. Uninstall: `python install.py --user
+Team setup: after each teammate has run the user install, `python install.py
+--project PATH` verifies that user's healthy private runtime and writes a
+committable routing block whose `~/.orchflows` paths resolve locally. It
+refuses before writing when that prerequisite is missing. Uninstall: `python install.py --user
 --uninstall` removes only what it generated; `--dry-run` previews
-either. `--claude-adapters {all,four}` chooses how much of the library
+either, including whether runtime apply will create, reuse, or repair.
+`--claude-adapters {all,four}` chooses how much of the library
 Claude gets first-class adapters for — `all` (the default) mints one per
 package and template, `four` mints only `orch-spec`, `orch-frontier`,
 `fix` and `orch-build` and leaves every other name to resolve at

--- a/install.py
+++ b/install.py
@@ -1,13 +1,13 @@
 #!/usr/bin/env python3
 """Install orchflows for Claude Code and/or Codex from a git clone.
 
-Stdlib-only, cross-platform (Windows + POSIX), pathlib throughout, never
+Cross-platform (Windows + POSIX), pathlib throughout, never
 symlinks. User scope is primary and auto-detects which host(s) to
 configure: the Claude half runs only when a Claude CLI is on ``PATH``, and
 the Codex half only when a Codex CLI is on ``PATH``. If neither is found,
 the installer warns and exits successfully without writing anything.
 
-- ``~/.orchflows/`` (library, scripts, receipt, the rendered
+- ``~/.orchflows/`` (private Python runtime, library, scripts, receipt, the rendered
   ``host-block.md``). The library also carries a flat, host-agnostic
   ``lib/by-name/<orch-name>/SKILL.md`` index: one deterministic path per
   canonical package (every skill tier plus packs), each a redirect pointer
@@ -48,7 +48,10 @@ names (``docs/vocabulary.md``, ``ARCHITECTURE.md``) where the project holds
 none — a document already there is left byte-identical, and the receipt says
 which of the two the installer wrote — plus a minimal receipt. Both blocks stay
 inline marker blocks (never an import) since a project is committable and
-must stay self-contained for teammates without the same ``~/.orchflows``.
+must resolve each teammate's own ``~/.orchflows`` rather than freezing the
+installer's absolute home or operating-system runtime path. Project apply
+requires that user install and refuses before writing when its private runtime
+is absent or unhealthy.
 Durable state is user-scope in either scope: an install seeds the one sink
 ``_state_sink`` names and never a project runtime tree, so a record carries
 the project it arose in as a field rather than by its location. Of
@@ -61,6 +64,7 @@ prints the drift, and a null commit says on stderr which read came up empty.
 A receipt that will not read is refused, never overwritten as if absent.
 
 ``--dry-run`` builds and prints the exact same plan an install would apply,
+including whether the private runtime would be created, reused or repaired,
 without writing anything. ``--uninstall`` removes only unchanged generated
 skill entrypoints. It prints manual cleanup for every other path in the
 scope's ``receipt.json`` (gracefully, even for a receipt from an older, full
@@ -133,6 +137,8 @@ def discover_script_names(scripts_dir: Path) -> tuple[str, ...]:
 
 from installer import planning as _planning
 from installer import presentation as _presentation
+from installer import application as _application
+from installer import runtime as _runtime
 from installer.application import (
     _diverged_role_agents,
     _installed_file,
@@ -243,6 +249,31 @@ from installer import packages as _packages
 _discover_packages_impl = discover_packages
 _detect_hosts_impl = detect_hosts
 
+RUNTIME_METADATA_FILENAME = _runtime.RUNTIME_METADATA_FILENAME
+RUNTIME_REQUIREMENTS = _runtime.RUNTIME_REQUIREMENTS
+_dependency_environment = _runtime._dependency_environment
+_read_runtime_metadata = _runtime._read_runtime_metadata
+_runtime_metadata = _runtime._runtime_metadata
+_runtime_requirement_lines = _runtime._runtime_requirement_lines
+private_runtime_action = _runtime.private_runtime_action
+private_runtime_home = _runtime.private_runtime_home
+private_runtime_is_healthy = _runtime.private_runtime_is_healthy
+private_runtime_is_owned = _runtime.private_runtime_is_owned
+private_runtime_python = _runtime.private_runtime_python
+venv = _runtime.venv
+
+_build_private_runtime_impl = _runtime._build_private_runtime
+_create_private_runtime_impl = _runtime._create_private_runtime
+
+
+def _build_private_runtime(runtime_home: Path) -> Path:
+    return _build_private_runtime_impl(runtime_home)
+
+
+def _create_private_runtime() -> Path:
+    _runtime._build_private_runtime = _build_private_runtime
+    return _create_private_runtime_impl()
+
 
 def _sync_installer_seams() -> None:
     for module in (_foundation, _models, _packages, _planning):
@@ -250,6 +281,13 @@ def _sync_installer_seams() -> None:
             module.REPO_ROOT = REPO_ROOT
     _managed_text.CODEX_MAX_THREADS = CODEX_MAX_THREADS
     _planning.detect_hosts = detect_hosts
+    _planning.private_runtime_action = private_runtime_action
+    _planning.private_runtime_is_healthy = private_runtime_is_healthy
+    _models.private_runtime_python = private_runtime_python
+    _runtime.RUNTIME_REQUIREMENTS = RUNTIME_REQUIREMENTS
+    _runtime._build_private_runtime = _build_private_runtime
+    _application._create_private_runtime = _create_private_runtime
+    _application.private_runtime_is_healthy = private_runtime_is_healthy
 
 
 def discover_packages():
@@ -291,6 +329,7 @@ def print_plan(plan: Plan) -> None:
 
 
 def apply_plan(plan: Plan, keep_role_agents: bool | None = None) -> dict:
+    _sync_installer_seams()
     return _apply_plan(plan, resolve_source_commit(), keep_role_agents)
 
 
@@ -402,6 +441,13 @@ def main(argv=None) -> int:
     # like a run that had planned the whole install.
     if args.dry_run:
         print_plan(plan)
+        if plan.runtime_action == "refuse":
+            print(
+                f"error: refusing install because {private_runtime_home()} is "
+                "not a healthy installer-owned runtime",
+                file=sys.stderr,
+            )
+            return 1
         if (plan.claude_enabled or plan.codex_enabled) and plan_entry_count(plan) == 0:
             print(
                 "error: a host is enabled but the plan is empty; nothing would be installed",

--- a/installer/application.py
+++ b/installer/application.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import hashlib
 import json
 import shutil
+import tempfile
 from datetime import datetime, timezone
 from pathlib import Path
 
@@ -20,6 +21,12 @@ from .foundation import (
 )
 from .managed_text import upsert_import_line, upsert_marked_block
 from .models import Plan
+from .runtime import (
+    _create_private_runtime,
+    private_runtime_home,
+    private_runtime_is_healthy,
+    private_runtime_python,
+)
 
 # --- apply -----------------------------------------------------------------
 
@@ -36,6 +43,53 @@ def _load_json(path: Path):
         return json.loads(path.read_text(encoding="utf-8"))
     except (OSError, json.JSONDecodeError) as error:
         raise ValueError(f"{path} is unreadable ({error}); move it aside and rerun") from error
+
+
+def _write_json(path: Path, value: dict) -> None:
+    """Atomically replace one installer-owned JSON document."""
+
+    path.parent.mkdir(parents=True, exist_ok=True)
+    handle = tempfile.NamedTemporaryFile(
+        mode="w",
+        encoding="utf-8",
+        dir=path.parent,
+        prefix=f".{path.name}.",
+        suffix=".tmp",
+        delete=False,
+    )
+    temporary = Path(handle.name)
+    try:
+        with handle:
+            json.dump(value, handle, indent=2, ensure_ascii=False)
+            handle.write("\n")
+        temporary.replace(path)
+    finally:
+        if temporary.exists():
+            temporary.unlink()
+
+
+def _record_runtime_intent(plan: Plan, old_receipt: dict | None) -> None:
+    """Make a first or interrupted runtime install discoverable by uninstall."""
+
+    receipt = dict(old_receipt or {})
+    receipt.update(
+        {
+            "version": 4,
+            "scope": "user",
+            "project_root": None,
+            "lib_home": str(plan.lib_home),
+            "bin_dir": str(plan.bin_dir),
+            "install_in_progress": True,
+            "runtime": {
+                "home": str(private_runtime_home()),
+                "python": str(private_runtime_python()),
+                "uninstall": "retained",
+            },
+        }
+    )
+    for key in ("files", "blocks", "imports", "dirs"):
+        receipt.setdefault(key, [])
+    _write_json(plan.receipt_path, receipt)
 
 
 def _sha256_file(path: Path) -> str:
@@ -156,6 +210,15 @@ def apply_plan(
     plan: Plan, source_commit: str | None, keep_role_agents: bool | None = None
 ) -> dict:
     old_receipt = _load_json(plan.receipt_path)
+    if (
+        plan.scope == "project"
+        and plan.runtime_action is not None
+        and not private_runtime_is_healthy()
+    ):
+        raise RuntimeError(
+            "project install requires a healthy user runtime at "
+            f"{private_runtime_home()}; run install.py --user first"
+        )
     diverged = _diverged_role_agents(plan, old_receipt)
     # A kept agent stays in the plan so ``_remove_stale`` still counts it as
     # wanted; only its write is skipped. Dropping it from the plan would
@@ -179,6 +242,12 @@ def apply_plan(
     def install_details(path: Path, kind: str, details: dict) -> dict:
         old_entry = old_entries.get((str(path), kind), {})
         return old_entry.get("details") or details
+
+    if plan.scope == "user" and plan.runtime_action is not None:
+        # This lands before the first runtime mutation. If anything below
+        # fails, uninstall can still discover the retained runtime.
+        _record_runtime_intent(plan, old_receipt)
+        _create_private_runtime()
 
     # Library tree: fully installer-owned, replaced wholesale. Thin project
     # plans carry no lib_copies and never touch a project's ``.orchflows/lib``.
@@ -348,9 +417,17 @@ def apply_plan(
         "blocks": written_blocks,
         "imports": written_imports,
         "dirs": list(dict.fromkeys([str(d) for d in plan.runtime_dirs] + extra_dirs)),
+        "runtime": (
+            {
+                "home": str(private_runtime_home()),
+                "python": str(private_runtime_python()),
+                "uninstall": "retained",
+            }
+            if plan.scope == "user"
+            else None
+        ),
     }
-    plan.receipt_path.parent.mkdir(parents=True, exist_ok=True)
-    plan.receipt_path.write_text(json.dumps(receipt, indent=2, ensure_ascii=False) + "\n", encoding="utf-8")
+    _write_json(plan.receipt_path, receipt)
     return receipt
 
 
@@ -365,6 +442,7 @@ def print_summary(plan: Plan) -> None:
     if plan.scope == "user":
         print(f"  detected Claude Code CLI: {'yes' if plan.claude_enabled else 'no'}")
         print(f"  detected Codex CLI: {'yes' if plan.codex_enabled else 'no'}")
+        print(f"  private runtime: {private_runtime_home()}")
     print(f"  library:     {plan.lib_home}  ({len(plan.lib_copies)} files)")
     if plan.by_name:
         print(f"  flat index:  {plan.lib_home / 'by-name'}  ({len(plan.by_name)} names)")

--- a/installer/managed_text.py
+++ b/installer/managed_text.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import os
 from pathlib import PurePath
 
 from .foundation import (
@@ -26,13 +27,48 @@ def render_host_block(
     skills_dir: PurePath,
     lib_dir: PurePath,
     python_interpreter: str,
+    portable: bool = False,
 ) -> str:
+    if portable:
+        friction_commands = (
+            '    PowerShell: & "$HOME\\.orchflows\\runtime\\Scripts\\python.exe" '
+            '"$HOME\\.orchflows\\bin\\friction.py" "<what happened>" '
+            '"<what was expected or missing>"\n'
+            '    POSIX: "$HOME/.orchflows/runtime/bin/python" '
+            '"$HOME/.orchflows/bin/friction.py" "<what happened>" '
+            '"<what was expected or missing>"'
+        )
+    elif os.name == "nt":
+        def powershell_token(value: object) -> str:
+            return "'" + str(value).replace("'", "''") + "'"
+
+        friction_commands = "    PowerShell: & " + " ".join(
+            powershell_token(value)
+            for value in (
+                python_interpreter,
+                bin_dir / "friction.py",
+                "<what happened>",
+                "<what was expected or missing>",
+            )
+        )
+    else:
+        import shlex
+
+        friction_commands = "    POSIX: " + shlex.join(
+            [
+                python_interpreter,
+                str(PurePath(bin_dir) / "friction.py"),
+                "<what happened>",
+                "<what was expected or missing>",
+            ]
+        )
     return (
         template_text.replace("{{ORCH_BIN}}", str(bin_dir))
         .replace("{{ORCH_DOCS}}", str(docs_dir))
         .replace("{{ORCH_SKILLS}}", str(skills_dir))
         .replace("{{ORCH_LIB}}", str(lib_dir))
         .replace("{{PYTHON}}", python_interpreter)
+        .replace("{{FRICTION_COMMANDS}}", friction_commands)
     )
 
 

--- a/installer/models.py
+++ b/installer/models.py
@@ -3,11 +3,12 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from pathlib import Path
+from pathlib import Path, PurePosixPath
 
 from .foundation import HOST_BLOCK_TEMPLATE, _bin_dir, _lib_home
 from .managed_text import render_host_block
-from .packages import resolved_python_interpreter, template_markers
+from .packages import template_markers
+from .runtime import private_runtime_python
 
 # --- plan -----------------------------------------------------------------
 
@@ -76,6 +77,7 @@ class Plan:
     manage_host_surfaces: bool = True                    # False for thin project plans
     claude_enabled: bool = True                          # user scope: a Claude CLI was detected
     codex_enabled: bool = True                           # user scope: a Codex CLI was detected
+    runtime_action: str | None = None                    # create, reuse, repair or refuse
 
 
 _BUILD_ARTIFACT_SUFFIXES = (".pyc", ".pyo")
@@ -90,17 +92,23 @@ def _is_build_artifact(path: Path) -> bool:
     return any(part in _BUILD_ARTIFACT_DIR_NAMES for part in path.parts)
 
 
-def _host_block_content() -> tuple[str, str, str]:
+def _host_block_content(portable: bool = False) -> tuple[str, str, str]:
     """Render the instruction block against the *user* library paths
     (``~/.orchflows/...``). Both scopes point here: project installs carry
     no library of their own and read the user install instead."""
 
-    lib_home = _lib_home("user", None)
-    bin_dir = _bin_dir("user", None)
+    lib_home = PurePosixPath("~/.orchflows/lib") if portable else _lib_home("user", None)
+    bin_dir = PurePosixPath("~/.orchflows/bin") if portable else _bin_dir("user", None)
     template_text = HOST_BLOCK_TEMPLATE.read_text(encoding="utf-8")
     start_marker, end_marker = template_markers(template_text)
     content = render_host_block(
-        template_text, bin_dir, lib_home / "docs", lib_home / "skills", lib_home, resolved_python_interpreter()
+        template_text,
+        bin_dir,
+        lib_home / "docs",
+        lib_home / "skills",
+        lib_home,
+        str(private_runtime_python()),
+        portable=portable,
     )
     return content, start_marker, end_marker
 
@@ -148,7 +156,7 @@ def _day_zero_documents(project_root: Path) -> list:
     no library of its own to point at.
     """
 
-    docs_dir = _lib_home("user", None) / "docs"
+    docs_dir = PurePosixPath("~/.orchflows/lib/docs")
     return [
         DayZeroPlan(
             project_root / "docs" / "vocabulary.md",

--- a/installer/planning.py
+++ b/installer/planning.py
@@ -51,13 +51,14 @@ from .packages import (
     split_frontmatter,
     template_adapter_body,
 )
+from .runtime import private_runtime_action, private_runtime_is_healthy
 
 def _build_project_plan(project_root: Path) -> Plan:
     """Thin stub: only the two managed instruction blocks plus a minimal
     receipt. No lib copy, no runtime dirs, no ``.claude``/``.codex`` writes —
     a project install borrows the user install for everything else."""
 
-    host_block, start_marker, end_marker = _host_block_content()
+    host_block, start_marker, end_marker = _host_block_content(portable=True)
     blocks = [
         BlockPlan(
             _claude_md_path("project", project_root),
@@ -85,6 +86,7 @@ def _build_project_plan(project_root: Path) -> Plan:
         day_zero=_day_zero_documents(project_root),
         receipt_path=scope_home / "receipt.json",
         manage_host_surfaces=False,
+        runtime_action="reuse" if private_runtime_is_healthy() else "refuse",
     )
 
 
@@ -141,6 +143,7 @@ def _build_user_plan(
             ],
             claude_enabled=False,
             codex_enabled=False,
+            runtime_action=None,
         )
 
     lib_copies = []
@@ -334,6 +337,7 @@ def _build_user_plan(
         warnings=warnings,
         claude_enabled=claude_enabled,
         codex_enabled=codex_enabled,
+        runtime_action=private_runtime_action(),
     )
 
 
@@ -376,4 +380,9 @@ def plan_entry_count(plan: Plan) -> int:
         + len(plan.day_zero)
         + (1 if plan.host_block is not None else 0)
         + (1 if plan.claude_import is not None else 0)
+        + (
+            1
+            if plan.scope == "user" and plan.runtime_action in ("create", "repair")
+            else 0
+        )
     )

--- a/installer/presentation.py
+++ b/installer/presentation.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from .models import Plan
 from .planning import plan_entry_count
+from .runtime import private_runtime_home
 
 def print_plan(plan: Plan, source_commit: str | None) -> None:
     print(f"scope: {plan.scope}")
@@ -15,6 +16,18 @@ def print_plan(plan: Plan, source_commit: str | None) -> None:
     print(f"source commit: {source_commit or 'unknown'}")
     print(f"library home: {plan.lib_home}")
     print(f"bin dir: {plan.bin_dir}")
+    if plan.scope == "user":
+        if plan.runtime_action is None:
+            print(f"private runtime: not needed {private_runtime_home()}")
+        else:
+            print(f"private runtime: {plan.runtime_action} {private_runtime_home()}")
+    elif plan.runtime_action == "reuse":
+        print(f"private runtime: reuse required at {private_runtime_home()} (project scope)")
+    else:
+        print(
+            "private runtime: refuse; project scope requires a healthy user "
+            f"runtime at {private_runtime_home()}"
+        )
     print()
     print(f"runtime directories ({len(plan.runtime_dirs)}):")
     for directory in plan.runtime_dirs:

--- a/installer/runtime.py
+++ b/installer/runtime.py
@@ -1,0 +1,229 @@
+"""Installer-owned private Python runtime lifecycle."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import re
+import shutil
+import subprocess
+import tempfile
+import venv
+from pathlib import Path
+
+from .foundation import MIN_PYTHON, REPO_ROOT, _scope_home
+
+RUNTIME_REQUIREMENTS = REPO_ROOT / "requirements-runtime.txt"
+RUNTIME_METADATA_FILENAME = ".orchflows-runtime.json"
+
+
+def private_runtime_home() -> Path:
+    """The user-owned runtime shared by every orchflows checkout."""
+
+    return _scope_home("user", None) / "runtime"
+
+
+def private_runtime_python(runtime_home: Path | None = None) -> Path:
+    home = private_runtime_home() if runtime_home is None else runtime_home
+    return home / ("Scripts/python.exe" if os.name == "nt" else "bin/python")
+
+
+def _runtime_requirement_lines() -> list[str]:
+    return [
+        line.strip()
+        for line in RUNTIME_REQUIREMENTS.read_text(encoding="utf-8").splitlines()
+        if line.strip() and not line.lstrip().startswith("#")
+    ]
+
+
+def _runtime_metadata() -> dict:
+    return {
+        "schema": 1,
+        "requirements_sha256": hashlib.sha256(
+            RUNTIME_REQUIREMENTS.read_bytes()
+        ).hexdigest(),
+    }
+
+
+def _read_runtime_metadata(runtime_home: Path) -> dict | None:
+    try:
+        reading = json.loads(
+            (runtime_home / RUNTIME_METADATA_FILENAME).read_text(encoding="utf-8")
+        )
+    except (OSError, ValueError):
+        return None
+    return reading if isinstance(reading, dict) else None
+
+
+def private_runtime_is_owned(runtime_home: Path | None = None) -> bool:
+    """Whether ``home`` carries metadata written by this installer.
+
+    Requirement drift makes a runtime unhealthy but does not make it
+    unowned. A directory with missing or foreign metadata is never safe for
+    the installer to recursively replace.
+    """
+
+    home = private_runtime_home() if runtime_home is None else runtime_home
+    metadata = _read_runtime_metadata(home)
+    return bool(
+        metadata is not None
+        and set(metadata) == {"schema", "requirements_sha256"}
+        and metadata.get("schema") == 1
+        and isinstance(metadata.get("requirements_sha256"), str)
+        and re.fullmatch(r"[0-9a-f]{64}", metadata["requirements_sha256"])
+    )
+
+
+def private_runtime_is_healthy(runtime_home: Path | None = None) -> bool:
+    home = private_runtime_home() if runtime_home is None else runtime_home
+    runtime_python = private_runtime_python(home)
+    if not runtime_python.is_file():
+        return False
+    metadata = _read_runtime_metadata(home)
+    if metadata is None:
+        return False
+    try:
+        expected_metadata = _runtime_metadata()
+    except OSError:
+        return False
+    if metadata != expected_metadata:
+        return False
+    try:
+        probe = subprocess.run(
+            [
+                str(runtime_python),
+                "-I",
+                "-c",
+                "import json, sys; print(json.dumps({"
+                "'prefix': sys.prefix, 'version': list(sys.version_info[:3])}))",
+            ],
+            capture_output=True,
+            text=True,
+            timeout=10,
+            check=False,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return False
+    if probe.returncode != 0:
+        return False
+    try:
+        reading = json.loads(probe.stdout)
+        version = tuple(reading["version"])
+        return (
+            Path(reading["prefix"]).resolve() == home.resolve()
+            and version >= MIN_PYTHON
+        )
+    except (KeyError, OSError, TypeError, ValueError):
+        return False
+
+
+def private_runtime_action(runtime_home: Path | None = None) -> str:
+    """Return the action apply would take: create, reuse, repair or refuse."""
+
+    home = private_runtime_home() if runtime_home is None else runtime_home
+    if private_runtime_is_healthy(home):
+        return "reuse"
+    if not home.exists():
+        return "create"
+    return "repair" if private_runtime_is_owned(home) else "refuse"
+
+
+def _dependency_environment() -> dict[str, str]:
+    """Keep ambient project/Python configuration out of runtime installs."""
+
+    environment = os.environ.copy()
+    for name in (
+        "PIP_CONFIG_FILE",
+        "PIP_PREFIX",
+        "PIP_TARGET",
+        "PIP_USER",
+        "PYTHONHOME",
+        "PYTHONPATH",
+    ):
+        environment.pop(name, None)
+    environment["PIP_CONFIG_FILE"] = os.devnull
+    return environment
+
+
+def _build_private_runtime(runtime_home: Path) -> Path:
+    requirement_lines = _runtime_requirement_lines()
+    venv.EnvBuilder(with_pip=bool(requirement_lines)).create(runtime_home)
+    runtime_python = private_runtime_python(runtime_home)
+    if requirement_lines:
+        installed = subprocess.run(
+            [
+                str(runtime_python),
+                "-m",
+                "pip",
+                "install",
+                "--disable-pip-version-check",
+                "--requirement",
+                str(RUNTIME_REQUIREMENTS),
+            ],
+            check=False,
+            env=_dependency_environment(),
+        )
+        if installed.returncode != 0:
+            raise RuntimeError("private runtime dependency installation failed")
+    (runtime_home / RUNTIME_METADATA_FILENAME).write_text(
+        json.dumps(_runtime_metadata(), sort_keys=True) + "\n", encoding="utf-8"
+    )
+    if not private_runtime_is_healthy(runtime_home):
+        raise RuntimeError(f"private runtime is not healthy at {runtime_python}")
+    return runtime_python
+
+
+def _create_private_runtime() -> Path:
+    """Create or replace the managed runtime without risking the old one.
+
+    A replacement is built and probed in a sibling staging directory first.
+    Only an installer-owned target is moved aside, and a failed swap restores
+    it before the error reaches the caller.
+    """
+
+    runtime_home = private_runtime_home()
+    action = private_runtime_action(runtime_home)
+    if action == "reuse":
+        return private_runtime_python(runtime_home)
+    if action == "refuse":
+        raise RuntimeError(
+            f"refusing to replace unowned private runtime at {runtime_home}; "
+            "move it aside or remove it manually, then reinstall"
+        )
+
+    runtime_home.parent.mkdir(parents=True, exist_ok=True)
+    staging = Path(
+        tempfile.mkdtemp(prefix=f".{runtime_home.name}-build-", dir=runtime_home.parent)
+    )
+    backup = None
+    try:
+        _build_private_runtime(staging)
+        if runtime_home.exists():
+            backup = Path(
+                tempfile.mkdtemp(
+                    prefix=f".{runtime_home.name}-backup-", dir=runtime_home.parent
+                )
+            )
+            backup.rmdir()
+            runtime_home.replace(backup)
+        try:
+            staging.replace(runtime_home)
+        except Exception:
+            if backup is not None and backup.exists() and not runtime_home.exists():
+                backup.replace(runtime_home)
+            raise
+        if not private_runtime_is_healthy(runtime_home):
+            shutil.rmtree(runtime_home)
+            if backup is not None and backup.exists():
+                backup.replace(runtime_home)
+            raise RuntimeError(
+                "private runtime replacement is not healthy at "
+                f"{private_runtime_python(runtime_home)}"
+            )
+        if backup is not None and backup.exists():
+            shutil.rmtree(backup)
+        return private_runtime_python(runtime_home)
+    finally:
+        if staging.exists():
+            shutil.rmtree(staging)

--- a/installer/uninstall.py
+++ b/installer/uninstall.py
@@ -180,6 +180,18 @@ def run_uninstall(scope: str, project_root: Path | None, dry_run: bool) -> dict:
     for dir_str in receipt.get("dirs", []):
         manual_actions.append({"path": dir_str, "action": "remove directory manually when empty"})
 
+    runtime = receipt.get("runtime")
+    if isinstance(runtime, dict) and runtime.get("home"):
+        manual_actions.append(
+            {
+                "path": str(runtime["home"]),
+                "action": (
+                    "retained private runtime; remove manually after installed "
+                    "orchflows commands no longer need it"
+                ),
+            }
+        )
+
     manual_actions.append(
         {"path": str(receipt_path), "action": "delete receipt after completing manual cleanup"}
     )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,5 @@
+[project]
+name = "orchflows"
+version = "0.0.0"
+requires-python = ">=3.9"
+dependencies = []

--- a/requirements-runtime.txt
+++ b/requirements-runtime.txt
@@ -1,0 +1,2 @@
+# Runtime dependencies installed into ~/.orchflows/runtime.
+# This revision has no third-party runtime dependencies.

--- a/scripts/tickets_packet.py
+++ b/scripts/tickets_packet.py
@@ -1,6 +1,8 @@
 """Ticket packet support."""
 
 from __future__ import annotations
+import re
+import shlex
 import sys
 from pathlib import Path
 try:
@@ -33,6 +35,21 @@ PACKET_SECTIONS = (('objective', 'Objective'), ('inputs', 'Fixed inputs'), ('ret
 CHECKER_EXECUTOR = 'orch-critique'
 REVERIFIER_EXECUTOR = 'orch-verify'
 CHECKER_PATH_EXECUTORS = (CHECKER_EXECUTOR, REVERIFIER_EXECUTOR)
+_SHELL_SAFE_TOKEN = re.compile(r'^[A-Za-z0-9_./:\\=-]+$')
+
+
+def _command_text(*arguments) -> str:
+    """Render argv as one executable command for the host's native shell."""
+
+    values = [str(argument) for argument in arguments]
+    if all(_SHELL_SAFE_TOKEN.fullmatch(value) for value in values):
+        return ' '.join(values)
+    if sys.platform == 'win32':
+        def quote(value: str) -> str:
+            return "'" + value.replace("'", "''") + "'"
+
+        return '& ' + ' '.join(quote(value) for value in values)
+    return shlex.join(values)
 CUT_LENS_PARTS = ('skills', 'kernel', 'orch-decompose', 'references', 'cut-lens.md')
 GATE_CRITIQUE_ID = '{root}.gate.critique.{lens}'
 GATE_REPAIR_ID = '{root}.gate.repair'
@@ -112,19 +129,19 @@ def _further_child_prompt(executor, loaded: dict, ticket_path: Path, run_id, scr
     is_root = _executor_of(loaded) == ROOT_EXECUTOR
     recorded = str(loaded.get('workspace_baseline') or '').strip().split()
     baseline = recorded[0] if recorded else 'REV'
-    cut_check = f"{sys.executable} {script.with_name('cutcheck.py')} --baseline {baseline} {run_id}"
+    cut_check = _command_text(sys.executable, script.with_name('cutcheck.py'), '--baseline', baseline, run_id)
     unresolved = '' if recorded else ', REV being the revision the set was cut from'
     if is_root and executor == CHECKER_EXECUTOR:
         head.append(f"This is the rules/verification.md §10 checker's pass on the cut {claimed_by} produced under its claim, never a second decomposition: the lens is {_cut_lens_path()}, and its object is the issued subtree — the `{loaded['id']}.NN` items and the gate stubs — read as data.")
         head.append("Your authority is not the root's `write_scope`, which is the run's workspace and the units' to write. It is the unclaimed subtree's cut-time sections, corrected in place with:")
-        head.append(f'{sys.executable} {script} amend {run_id} ID --section SECTION --file PATH')
+        head.append(_command_text(sys.executable, script, 'amend', run_id, 'ID', '--section', 'SECTION', '--file', 'PATH'))
         head.append('and, for an item the cut is missing:')
-        head.append(f'{sys.executable} {script} new {run_id} ID --file PATH')
+        head.append(_command_text(sys.executable, script, 'new', run_id, 'ID', '--file', 'PATH'))
         head.append('Both are refused once a unit is claimed, and so is this packet: the cut is corrected before any unit of it is dispatched.')
         head.append(f'Your repair is accepted on the cut check re-run to exit 0 (rules/verification.md §11){unresolved}:')
         head.append(cut_check)
         head.append("Append your findings and the changes you made to the root's `## Result`, and record the pass with:")
-        head.append(f"{sys.executable} {script} check {run_id} {loaded['id']} --by NAME")
+        head.append(_command_text(sys.executable, script, 'check', run_id, loaded['id'], '--by', 'NAME'))
     elif is_root:
         head.append(f'This is the rules/verification.md §10 re-verification of a checked cut, never a second decomposition: the completion test at the checked set is the cut check, read on the host that produced it{unresolved}:')
         head.append(cut_check)
@@ -133,7 +150,7 @@ def _further_child_prompt(executor, loaded: dict, ticket_path: Path, run_id, scr
         scope = effective_write_scope(loaded)
         head.append(f"This is the rules/verification.md §10 checker's pass on a result {claimed_by} produced under its claim, never a re-execution of the item: the lens is the ticket's own `## Completion test`, at {at_identity}.")
         head.append(f"Your authority is the ticket's own write scope, {scope} — correct inside it, and append your findings, changes and the verification entries they invalidate to `## Result`. Record the pass, after correcting, with:")
-        head.append(f"{sys.executable} {script} check {run_id} {loaded['id']} --by NAME")
+        head.append(_command_text(sys.executable, script, 'check', run_id, loaded['id'], '--by', 'NAME'))
     else:
         head.append(f"This is the rules/verification.md §10 re-verification of a checked result, never a re-execution of the item: run the ticket's `## Completion test` at {at_identity}, reusing prior `## Verification` entries whose `covers` are unchanged there.")
         head.append("Your authority grants no write: the item's workspace and its `## Result` are another context's, and `## Verification` is the one section you file.")
@@ -252,13 +269,13 @@ def _packet_under_run_lock(rest):
             prompt.append("Your branch is not the revision those repository-level checks decide, and your green is provisional until the tip's.")
     if has_own_workspace:
         prompt.append('Workspace establishment (isolation: required), your first act, run from inside your own workspace:')
-        prompt.append(f"{sys.executable} {script.with_name('workspace.py')} start {run_id} {loaded['id']}")
+        prompt.append(_command_text(sys.executable, script.with_name('workspace.py'), 'start', run_id, loaded['id']))
     prompt.append('Run-state channel (rules/visibility.md §6), from your own workspace, with TEXT and NAME replaced:')
-    prompt.append(f'{sys.executable} {script} run-state {run_id} --note TEXT')
-    prompt.append(f'{sys.executable} {script} run-state {run_id} --artifact NAME --text TEXT')
+    prompt.append(_command_text(sys.executable, script, 'run-state', run_id, '--note', 'TEXT'))
+    prompt.append(_command_text(sys.executable, script, 'run-state', run_id, '--artifact', 'NAME', '--text', 'TEXT'))
     prompt.append(f"Filing channel (contracts/work-item.md's filing law), from your own workspace, with SECTION one of {list(EXECUTOR_SECTIONS)}, PATH a file in your own workspace and TEXT one line; add --append to write after content already there:")
-    prompt.append(f"{sys.executable} {script} result {run_id} {loaded['id']} --section SECTION --file PATH")
-    prompt.append(f"{sys.executable} {script} result {run_id} {loaded['id']} --section SECTION --text TEXT")
+    prompt.append(_command_text(sys.executable, script, 'result', run_id, loaded['id'], '--section', 'SECTION', '--file', 'PATH'))
+    prompt.append(_command_text(sys.executable, script, 'result', run_id, loaded['id'], '--section', 'SECTION', '--text', 'TEXT'))
     assigned_name = str(loaded.get('claimed_by') or '').strip() or None if executor in DISPATCHING_EXECUTORS else None
     if assigned_name is not None:
         prompt.append(f"Your own assigned name is `{assigned_name}` (the ticket's `claimed_by`): every packet you dispatch carries it as that child's `reply_to`.")

--- a/templates/host-block.md
+++ b/templates/host-block.md
@@ -40,7 +40,7 @@ missing input, tool, or document; surprising output; a gap or ambiguity
 in a skill, rule, or contract; a workaround — log it the moment it
 happens, then continue:
 
-    {{PYTHON}} {{ORCH_BIN}}/friction.py "<what happened>" "<what was expected or missing>"
+{{FRICTION_COMMANDS}}
 
 Optional flags: `--category`, `--skill <orch-name>`, `--ticket <id>`,
 `--run <run-id>`.

--- a/tests/test_cutcheck.py
+++ b/tests/test_cutcheck.py
@@ -33,6 +33,34 @@ from tests.baseline_pin import (  # noqa: E402  the invocation's one owner
 from tests.tree_removal import remove_repo_tree  # noqa: E402  the removal's one owner
 
 
+class RuntimeInterpreterBoundaryTests(unittest.TestCase):
+    """Cut checks execute ticket oracles in the caller's project context."""
+
+    def test_oracle_subprocesses_inherit_the_caller_environment(self):
+        caller = {
+            "PATH": "cutcheck-oracle-path",
+            "VIRTUAL_ENV": "cutcheck-oracle-venv",
+        }
+        observed = []
+
+        def run_in_caller(*args, **kwargs):
+            observed.append((dict(os.environ), kwargs))
+            return subprocess.CompletedProcess(args[0], 0, b"", b"")
+
+        with mock.patch.dict(os.environ, caller, clear=False):
+            with mock.patch.object(cutcheck.subprocess, "run", side_effect=run_in_caller):
+                with mock.patch.object(
+                    cutcheck._execute_module, "_mutations", return_value=[]
+                ):
+                    self.assertEqual(0, cutcheck._run_once("git status --short", ROOT))
+                self.assertEqual(0, cutcheck._git(["status"], ROOT).returncode)
+
+        self.assertEqual(2, len(observed))
+        for environment, kwargs in observed:
+            self.assertEqual(caller, {name: environment[name] for name in caller})
+            self.assertNotIn("env", kwargs)
+
+
 def reported(result, family=cutcheck.FAMILY):
     return [line for line in result.stdout.splitlines() if family in line]
 

--- a/tests/test_cutcheck_cases/confinement.py
+++ b/tests/test_cutcheck_cases/confinement.py
@@ -366,5 +366,5 @@ class VisibilitySymlinkClauseTest(unittest.TestCase):
         clause = _visibility_clause(5)
         self.assertIn("No symlinks", clause, clause)
         bullet = " ".join((ROOT / "ARCHITECTURE.md").read_text(encoding="utf-8").split())
-        for kept in ("stdlib Python 3", "Windows and POSIX", "no network"):
+        for kept in ("Python 3.9+", "Windows and POSIX", "no network"):
             self.assertIn(kept, bullet)

--- a/tests/test_installer.py
+++ b/tests/test_installer.py
@@ -17,6 +17,7 @@ from tests.test_installer_cases.managed_text.roles import TestRoleAgentInstructi
 from tests.test_installer_cases.planning.day_zero import TestDayZeroBootstrap
 from tests.test_installer_cases.planning.host_detection import DryRunOracleTest, TestHostAutoDetection
 from tests.test_installer_cases.planning.runtime import TestClaudeAdapterSet, TestRuntimeDirsSeedTheSink
+from tests.test_installer_cases.planning.private_runtime import RuntimeVenvTests
 from tests.test_installer_cases.planning.scoped_hosts import (
     RoleProfileRefusalTest,
     TestScopedHostConfiguration,
@@ -49,6 +50,7 @@ DryRunOracleTest.__module__ = __name__
 TestHostAutoDetection.__module__ = __name__
 TestClaudeAdapterSet.__module__ = __name__
 TestRuntimeDirsSeedTheSink.__module__ = __name__
+RuntimeVenvTests.__module__ = __name__
 RoleProfileRefusalTest.__module__ = __name__
 TestScopedHostConfiguration.__module__ = __name__
 TestScriptNames.__module__ = __name__

--- a/tests/test_installer_cases/managed_text/host_block.py
+++ b/tests/test_installer_cases/managed_text/host_block.py
@@ -22,7 +22,9 @@ class TestHostBlockRendering(unittest.TestCase):
     def test_render_host_block_substitutes_resolved_interpreter(self):
         rendered = self._rendered("/usr/bin/python3")
 
-        self.assertIn("/usr/bin/python3 /bin/friction.py", rendered)
+        self.assertIn("/usr/bin/python3", rendered)
+        self.assertIn("/bin/friction.py", rendered)
+        self.assertNotIn("{{FRICTION_COMMANDS}}", rendered)
         self.assertNotIn("{{PYTHON}}", rendered)
         self.assertNotIn("{{ORCH_LIB}}", rendered)
 
@@ -79,14 +81,17 @@ class TestHostBlockRendering(unittest.TestCase):
         for gone in ("orch-task", "orch-deliver", "orch-compose"):
             self.assertNotIn(gone, rendered)
 
-    def test_build_plan_host_block_uses_running_interpreter(self):
+    def test_build_plan_host_block_uses_private_runtime_interpreter(self):
         with tempfile.TemporaryDirectory() as tmp:
             project = Path(tmp)
 
             plan = install.build_plan("project", project)
 
             block = plan.blocks[0].content
-            self.assertIn(f"{install.resolved_python_interpreter()} ", block)
+            self.assertIn("$HOME/.orchflows/runtime/bin/python", block)
+            self.assertIn("$HOME\\.orchflows\\runtime\\Scripts\\python.exe", block)
+            self.assertNotIn(str(install.private_runtime_python()), block)
+            self.assertNotIn(f"{install.resolved_python_interpreter()} ", block)
             self.assertNotIn("{{PYTHON}}", block)
 
 
@@ -165,8 +170,7 @@ _HOST_BLOCK_DEMANDS = {
         "{{ORCH_LIB}}/by-name/<orch-name>/SKILL.md",
     ),
     "log friction the moment it happens, and never skip the log": (
-        '{{PYTHON}} {{ORCH_BIN}}/friction.py "<what happened>" '
-        '"<what was expected or missing>"',
+        "{{FRICTION_COMMANDS}}",
         "`--category`",
         "`--skill <orch-name>`",
         "`--ticket <id>`",

--- a/tests/test_installer_cases/planning/day_zero.py
+++ b/tests/test_installer_cases/planning/day_zero.py
@@ -22,7 +22,7 @@ class TestDayZeroBootstrap(unittest.TestCase):
         # Unresolved, for the reason test_project_plan_writes_only_...
         # states: the rendered text carries this spelling, and resolving
         # it here disagrees on any host whose temp dir holds a symlink.
-        self.user_docs = str(self.home / ".orchflows" / "lib" / "docs")
+        self.user_docs = "~/.orchflows/lib/docs"
 
     def project_plan(self):
         with patch.object(install.Path, "home", return_value=self.home):
@@ -46,8 +46,12 @@ class TestDayZeroBootstrap(unittest.TestCase):
 
         # One native path per factory, not a directory plus a separator
         # the host may not use: this is what the reader opens.
-        self.assertIn(str(Path(self.user_docs) / "vocabulary-authoring.md"), vocabulary)
-        self.assertIn(str(Path(self.user_docs) / "documentation.md"), ownership_map)
+        self.assertIn(
+            str(PurePosixPath(self.user_docs) / "vocabulary-authoring.md"), vocabulary
+        )
+        self.assertIn(
+            str(PurePosixPath(self.user_docs) / "documentation.md"), ownership_map
+        )
         for content in (vocabulary, ownership_map):
             # Rendered against the user library, like the host block: a
             # project install carries no library of its own to point at.
@@ -88,7 +92,9 @@ class TestDayZeroBootstrap(unittest.TestCase):
             self.assertIn(str(dest), output)
 
     def bootstrap(self) -> dict:
-        with patch.object(install.Path, "home", return_value=self.home):
+        with patch.object(install.Path, "home", return_value=self.home), patch.object(
+            install, "private_runtime_is_healthy", return_value=True
+        ):
             return install.apply_plan(install.build_plan("project", self.project))
 
     def recorded(self, receipt) -> dict:

--- a/tests/test_installer_cases/planning/private_runtime.py
+++ b/tests/test_installer_cases/planning/private_runtime.py
@@ -1,0 +1,248 @@
+"""Private runtime lifecycle and project-environment boundaries."""
+
+from __future__ import annotations
+
+from ..support import *  # noqa: F403
+
+
+class RuntimeVenvTests(unittest.TestCase):
+    def setUp(self):
+        self._tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self._tmp.cleanup)
+        self.root = Path(self._tmp.name).resolve()
+        self.home = self.root / "home"
+        self.home.mkdir()
+        self.project_runtime = self.root / "project" / ".venv"
+
+    def test_user_install_uses_private_runtime_when_project_venv_is_active(self):
+        install.venv.EnvBuilder(with_pip=False).create(self.project_runtime)
+        project_python = install.private_runtime_python(self.project_runtime)
+        program = "\n".join(
+            (
+                "from pathlib import Path",
+                "from unittest.mock import patch",
+                "import importlib.util, sys",
+                f"spec = importlib.util.spec_from_file_location('installer_under_test', {str(install.REPO_ROOT / 'install.py')!r})",
+                "installer = importlib.util.module_from_spec(spec)",
+                "sys.modules[spec.name] = installer",
+                "spec.loader.exec_module(installer)",
+                f"with patch.object(installer.Path, 'home', return_value=Path({str(self.home)!r})), patch.object(installer, 'detect_hosts', return_value=(False, True)):",
+                "    raise SystemExit(installer.main(['--user', '--yes']))",
+            )
+        )
+        completed = subprocess.run(
+            [str(project_python), "-c", program],
+            capture_output=True,
+            text=True,
+            encoding="utf-8",
+            errors="replace",
+            env=dict(os.environ, VIRTUAL_ENV=str(self.project_runtime)),
+        )
+        self.assertEqual(0, completed.returncode, completed.stdout + completed.stderr)
+
+        runtime_home = self.home / ".orchflows" / "runtime"
+        runtime_python = install.private_runtime_python(runtime_home)
+        rendered = (self.home / ".codex" / "AGENTS.md").read_text(encoding="utf-8")
+        self.assertTrue(runtime_python.is_file())
+        self.assertIn(str(runtime_python), rendered)
+        self.assertNotEqual(project_python.resolve(), runtime_python.resolve())
+        self.assertNotIn(str(self.project_runtime), rendered)
+
+    def test_user_install_reuses_healthy_private_runtime(self):
+        with patch.object(install.Path, "home", return_value=self.home), mock_host_clis("codex"):
+            install.apply_plan(install.build_plan("user", None))
+            marker = install.private_runtime_home() / "reuse-marker"
+            marker.write_text("keep", encoding="utf-8")
+            install.apply_plan(install.build_plan("user", None))
+        self.assertEqual("keep", marker.read_text(encoding="utf-8"))
+
+    def test_user_install_repairs_an_unhealthy_private_runtime(self):
+        with patch.object(install.Path, "home", return_value=self.home), mock_host_clis("codex"):
+            install.apply_plan(install.build_plan("user", None))
+            runtime_home = install.private_runtime_home()
+            marker = runtime_home / "unhealthy-marker"
+            marker.write_text("remove me", encoding="utf-8")
+            metadata = install._runtime_metadata()
+            metadata["requirements_sha256"] = "0" * 64
+            (runtime_home / install.RUNTIME_METADATA_FILENAME).write_text(
+                json.dumps(metadata) + "\n", encoding="utf-8"
+            )
+            install.apply_plan(install.build_plan("user", None))
+        self.assertFalse(marker.exists())
+        self.assertTrue(install.private_runtime_is_healthy(runtime_home))
+
+    def test_dry_run_has_no_runtime_or_filesystem_effects(self):
+        output = io.StringIO()
+        with patch.object(install.Path, "home", return_value=self.home), mock_host_clis(
+            "codex"
+        ), redirect_stdout(output):
+            result = install.main(["--user", "--dry-run"])
+        self.assertEqual(0, result)
+        self.assertIn(
+            f"private runtime: create {self.home / '.orchflows' / 'runtime'}",
+            output.getvalue(),
+        )
+        self.assertEqual([], list(self.home.iterdir()))
+
+    def test_project_install_does_not_create_a_runtime(self):
+        project = self.root / "project"
+        project.mkdir()
+        output = io.StringIO()
+        with patch.object(install.Path, "home", return_value=self.home), mock_host_clis("codex"):
+            install.apply_plan(install.build_plan("user", None))
+            marker = install.private_runtime_home() / "project-reuse-marker"
+            marker.write_text("keep", encoding="utf-8")
+        with patch.object(install.Path, "home", return_value=self.home), redirect_stdout(output):
+            plan = install.build_plan("project", project)
+            install.print_plan(plan)
+            install.apply_plan(plan)
+        self.assertIn("private runtime: reuse required", output.getvalue())
+        self.assertEqual("keep", marker.read_text(encoding="utf-8"))
+        self.assertFalse((project / ".orchflows" / "runtime").exists())
+
+    def test_project_install_refuses_before_writing_without_a_user_runtime(self):
+        project = self.root / "project"
+        project.mkdir()
+        with patch.object(install.Path, "home", return_value=self.home):
+            plan = install.build_plan("project", project)
+            with self.assertRaisesRegex(RuntimeError, "run install.py --user first"):
+                install.apply_plan(plan)
+        self.assertFalse((project / "CLAUDE.md").exists())
+        self.assertFalse((project / "AGENTS.md").exists())
+        self.assertFalse((project / ".orchflows").exists())
+
+    def test_failed_repair_preserves_the_previous_runtime(self):
+        with patch.object(install.Path, "home", return_value=self.home), mock_host_clis("codex"):
+            install.apply_plan(install.build_plan("user", None))
+            runtime_home = install.private_runtime_home()
+            old_python = install.private_runtime_python(runtime_home)
+            marker = runtime_home / "old-generation"
+            marker.write_text("keep", encoding="utf-8")
+            metadata = install._runtime_metadata()
+            metadata["requirements_sha256"] = "0" * 64
+            (runtime_home / install.RUNTIME_METADATA_FILENAME).write_text(
+                json.dumps(metadata) + "\n", encoding="utf-8"
+            )
+            with patch.object(
+                install, "_build_private_runtime", side_effect=RuntimeError("build failed")
+            ):
+                with self.assertRaisesRegex(RuntimeError, "build failed"):
+                    install.apply_plan(install.build_plan("user", None))
+        self.assertTrue(old_python.is_file())
+        self.assertEqual("keep", marker.read_text(encoding="utf-8"))
+
+    def test_unowned_runtime_is_refused_and_preserved(self):
+        runtime_home = self.home / ".orchflows" / "runtime"
+        runtime_home.mkdir(parents=True)
+        marker = runtime_home / "not-ours"
+        marker.write_text("keep", encoding="utf-8")
+        with patch.object(install.Path, "home", return_value=self.home), mock_host_clis("codex"):
+            with self.assertRaisesRegex(RuntimeError, "unowned private runtime"):
+                install.apply_plan(install.build_plan("user", None))
+        self.assertEqual("keep", marker.read_text(encoding="utf-8"))
+
+    def test_rendered_friction_command_executes_from_a_spaced_home(self):
+        spaced_home = self.root / "home with spaces"
+        spaced_home.mkdir()
+        with patch.object(install.Path, "home", return_value=spaced_home), mock_host_clis("codex"):
+            install.apply_plan(install.build_plan("user", None))
+        rendered = (spaced_home / ".codex" / "AGENTS.md").read_text(encoding="utf-8")
+        shell = "PowerShell" if os.name == "nt" else "POSIX"
+        command = next(
+            line.strip().split(":", 1)[1].strip()
+            for line in rendered.splitlines()
+            if line.strip().startswith(f"{shell}:")
+        )
+        command = command.replace("<what happened>", "spaced home")
+        command = command.replace("<what was expected or missing>", "runnable command")
+        if os.name == "nt":
+            completed = subprocess.run(
+                ["powershell", "-NoProfile", "-Command", command],
+                capture_output=True,
+                text=True,
+                encoding="utf-8",
+                errors="replace",
+            )
+        else:
+            completed = subprocess.run(
+                ["/bin/sh", "-c", command],
+                capture_output=True,
+                text=True,
+                encoding="utf-8",
+                errors="replace",
+            )
+        self.assertEqual(0, completed.returncode, completed.stderr)
+        self.assertEqual("friction logged", completed.stdout.strip())
+
+    def test_dry_run_reports_create_reuse_and_repair(self):
+        with patch.object(install.Path, "home", return_value=self.home), mock_host_clis("codex"):
+            self.assertEqual("create", install.build_plan("user", None).runtime_action)
+            install.apply_plan(install.build_plan("user", None))
+            self.assertEqual("reuse", install.build_plan("user", None).runtime_action)
+            metadata = install._runtime_metadata()
+            metadata["requirements_sha256"] = "0" * 64
+            (install.private_runtime_home() / install.RUNTIME_METADATA_FILENAME).write_text(
+                json.dumps(metadata) + "\n", encoding="utf-8"
+            )
+            self.assertEqual("repair", install.build_plan("user", None).runtime_action)
+
+    def test_failed_first_install_leaves_runtime_discoverable_to_uninstall(self):
+        with patch.object(install.Path, "home", return_value=self.home), mock_host_clis("codex"):
+            plan = install.build_plan("user", None)
+            real_create = install._create_private_runtime
+
+            def create_then_fail():
+                real_create()
+                raise RuntimeError("later install step failed")
+
+            with patch.object(install, "_create_private_runtime", side_effect=create_then_fail):
+                with self.assertRaisesRegex(RuntimeError, "later install step failed"):
+                    install.apply_plan(plan)
+            receipt = json.loads(plan.receipt_path.read_text(encoding="utf-8"))
+            report = install.run_uninstall("user", None, dry_run=True)
+            runtime_home = install.private_runtime_home()
+        self.assertTrue(receipt["install_in_progress"])
+        self.assertEqual(str(runtime_home), receipt["runtime"]["home"])
+        manual = {entry["path"]: entry["action"] for entry in report["manual_actions"]}
+        self.assertIn("retained", manual[str(runtime_home)])
+
+    def test_update_and_uninstall_follow_the_private_runtime_policy(self):
+        with patch.object(install.Path, "home", return_value=self.home), mock_host_clis("codex"):
+            first = install.apply_plan(install.build_plan("user", None))
+            runtime_home = install.private_runtime_home()
+            second = install.apply_plan(install.build_plan("user", None))
+            report = install.run_uninstall("user", None, dry_run=False)
+        self.assertEqual(first["runtime"], second["runtime"])
+        self.assertEqual(str(runtime_home), second["runtime"]["home"])
+        manual = {entry["path"]: entry["action"] for entry in report["manual_actions"]}
+        self.assertIn("retained", manual[str(runtime_home)])
+        self.assertTrue(install.private_runtime_is_healthy(runtime_home))
+
+    def test_dependency_contract_is_empty_documented_and_project_safe(self):
+        declared = [
+            line.strip()
+            for line in install.RUNTIME_REQUIREMENTS.read_text(encoding="utf-8").splitlines()
+            if line.strip() and not line.lstrip().startswith("#")
+        ]
+        self.assertEqual([], declared)
+        self.assertIn("dependencies = []", (install.REPO_ROOT / "pyproject.toml").read_text(encoding="utf-8"))
+        self.assertNotIn("Stdlib-only", install.__doc__ or "")
+        self.assertIn("requirements-runtime.txt", (install.REPO_ROOT / "ARCHITECTURE.md").read_text(encoding="utf-8"))
+        self.assertIn("requirements-runtime.txt", (install.REPO_ROOT / "README.md").read_text(encoding="utf-8"))
+
+    def test_dependency_install_ignores_project_and_pip_location_overrides(self):
+        contaminated = {
+            "PIP_PREFIX": "project-prefix",
+            "PIP_TARGET": "project-target",
+            "PIP_USER": "1",
+            "PYTHONHOME": "project-python-home",
+            "PYTHONPATH": "project-python-path",
+            "VIRTUAL_ENV": "project-venv",
+        }
+        with patch.dict(os.environ, contaminated, clear=False):
+            environment = install._dependency_environment()
+        for name in contaminated:
+            if name == "VIRTUAL_ENV":
+                self.assertEqual("project-venv", environment[name])
+            else:
+                self.assertNotEqual(contaminated[name], environment.get(name))

--- a/tests/test_installer_cases/planning/scoped_hosts.py
+++ b/tests/test_installer_cases/planning/scoped_hosts.py
@@ -357,9 +357,10 @@ class TestScopedHostConfiguration(unittest.TestCase):
             # Resolving here would only agree with the rendered text on a
             # host whose temp dir has no symlink in it -- macOS resolves
             # /var to /private/var and the comparison fails for no reason.
-            user_lib = str(home / ".orchflows" / "lib")
+            user_lib = "~/.orchflows/lib"
             for block in plan.blocks:
                 self.assertIn(user_lib, block.content)
+                self.assertNotIn(str(home), block.content)
                 self.assertNotIn(str(project), block.content)
 
     def test_project_apply_writes_only_blocks_and_receipt(self):
@@ -367,7 +368,9 @@ class TestScopedHostConfiguration(unittest.TestCase):
             home = Path(tmp) / "home"
             project = Path(tmp) / "project"
             project.mkdir()
-            with patch.object(install.Path, "home", return_value=home):
+            with patch.object(install.Path, "home", return_value=home), patch.object(
+                install, "private_runtime_is_healthy", return_value=True
+            ):
                 plan = install.build_plan("project", project)
                 install.apply_plan(plan)
 
@@ -404,7 +407,9 @@ class TestScopedHostConfiguration(unittest.TestCase):
                 encoding="utf-8",
             )
 
-            with patch.object(install.Path, "home", return_value=home):
+            with patch.object(install.Path, "home", return_value=home), patch.object(
+                install, "private_runtime_is_healthy", return_value=True
+            ):
                 plan = install.build_plan("project", project)
                 install.apply_plan(plan)
 

--- a/tests/test_tickets_cases/packet_execution.py
+++ b/tests/test_tickets_cases/packet_execution.py
@@ -2,6 +2,139 @@
 
 from .packet_workspace import *  # noqa: F401,F403
 
+RUNTIME_CLAIMED_TICKET = ISOLATED_TICKET.replace(
+    "status: ready", "status: claimed\nclaimed_by: agent-a"
+)
+RUNTIME_ROOT_TICKET = (
+    FULL_TICKET.replace("id: T1", "id: R1")
+    .replace("executor: orch-tdd", "executor: orch-decompose")
+    .replace("status: ready", "status: claimed\nclaimed_by: cutter-a")
+)
+
+
+class RuntimeInterpreterBoundaryTests(unittest.TestCase):
+    """Built-ins stay in their runtime while caller environment stays local."""
+
+    def test_internal_builtin_commands_use_the_current_interpreter(self):
+        runtime = "ORCHFLOWS_RUNTIME_INTERPRETER"
+        prompts = []
+        with mock.patch.object(tickets_mod._tickets_packet_module.sys, "executable", runtime):
+            with tempfile.TemporaryDirectory() as tmp:
+                tmp = Path(tmp)
+                make_packet_repo(tmp, RUNTIME_CLAIMED_TICKET)
+                for extra in ((), ("--executor", "orch-critique")):
+                    prompts.append(
+                        run_cmd(
+                            tmp, "packet", "testrun", "T1", "--reply-to", "main", *extra
+                        )["packet"]["prompt"]
+                    )
+            with tempfile.TemporaryDirectory() as tmp:
+                tmp = Path(tmp)
+                path = make_packet_repo(tmp, RUNTIME_ROOT_TICKET, tid="R1")
+                make_tickets(path.parent, {"R1.01": ("pending", "[]")})
+                for executor in ("orch-critique", "orch-verify"):
+                    prompts.append(
+                        run_cmd(
+                            tmp,
+                            "packet",
+                            "testrun",
+                            "R1",
+                            "--reply-to",
+                            "main",
+                            "--executor",
+                            executor,
+                        )["packet"]["prompt"]
+                    )
+
+        builtins = {"cutcheck.py", "tickets.py", "workspace.py"}
+        rendered = []
+        for prompt in prompts:
+            for line in prompt.splitlines():
+                tokens = line.split()
+                if len(tokens) > 1 and Path(tokens[1]).name in builtins:
+                    rendered.append(tokens)
+        self.assertEqual(builtins, {Path(tokens[1]).name for tokens in rendered})
+        for tokens in rendered:
+            self.assertEqual(runtime, tokens[0], tokens)
+
+    def test_ticket_commands_inherit_the_caller_environment(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            sink = Path(tmp) / "caller state"
+            caller = {
+                STATE_HOME_ENV_VAR: str(sink),
+                "VIRTUAL_ENV": str(Path(tmp) / "project venv"),
+            }
+            with mock.patch.dict(os.environ, caller, clear=False):
+                completed = run_full(ROOT, "run-state", "inheritance", "--note", "from caller")
+            self.assertEqual(0, completed.returncode, completed.stderr)
+            payload = json.loads(completed.stdout)
+            notes = sink / "runs" / "inheritance" / "notes.md"
+            self.assertEqual(str(notes), payload["run_state"]["path"])
+            self.assertEqual("from caller\n", notes.read_text(encoding="utf-8"))
+
+    def test_rendered_builtin_command_executes_from_a_spaced_install_path(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp = Path(tmp)
+            make_packet_repo(tmp, RUNTIME_CLAIMED_TICKET)
+            installed = tmp / "installed bin with spaces"
+            installed.mkdir()
+            source = TICKETS_PY.parent
+            names = {"state_root.py", "cutcheck.py"}
+            names.update(path.name for path in source.glob("tickets*.py"))
+            names.update(path.name for path in source.glob("workspace*.py"))
+            for name in names:
+                (installed / name).write_text(
+                    (source / name).read_text(encoding="utf-8"), encoding="utf-8"
+                )
+            completed = subprocess.run(
+                [
+                    sys.executable,
+                    str(installed / "tickets.py"),
+                    "packet",
+                    "testrun",
+                    "T1",
+                    "--reply-to",
+                    "main",
+                ],
+                capture_output=True,
+                text=True,
+                encoding="utf-8",
+                errors="replace",
+                cwd=str(tmp),
+            )
+            self.assertEqual(0, completed.returncode, completed.stderr)
+            prompt = json.loads(completed.stdout)["packet"]["prompt"]
+            command = next(
+                line
+                for line in prompt.splitlines()
+                if "run-state" in line and "--note" in line
+            ).replace("TEXT", "spaced-ok")
+            if os.name == "nt":
+                invoked = subprocess.run(
+                    ["powershell", "-NoProfile", "-Command", command],
+                    capture_output=True,
+                    text=True,
+                    encoding="utf-8",
+                    errors="replace",
+                    cwd=str(tmp),
+                )
+            else:
+                invoked = subprocess.run(
+                    ["/bin/sh", "-c", command],
+                    capture_output=True,
+                    text=True,
+                    encoding="utf-8",
+                    errors="replace",
+                    cwd=str(tmp),
+                )
+            self.assertEqual(0, invoked.returncode, invoked.stderr)
+            self.assertEqual(
+                "spaced-ok\n",
+                (sink_root() / "runs" / "testrun" / "notes.md").read_text(
+                    encoding="utf-8"
+                ),
+            )
+
 @unittest.skipUnless(git_available(), "git is not on PATH")
 class TestExecutedPacketSeam(unittest.TestCase):
     """The establishment line is not read, it is run: lifted verbatim out of

--- a/tests/test_tickets_cases/run_state_resolution.py
+++ b/tests/test_tickets_cases/run_state_resolution.py
@@ -49,7 +49,7 @@ class TestRunStateRootResolution(unittest.TestCase):
             # Windows refusal against, and it too starts nothing.
             self.assertEqual(
                 {"__future__", "contextlib", "datetime", "fcntl", "json",
-                 "msvcrt", "pathlib", "re", "scripts", "state_root", "sys",
+                 "msvcrt", "pathlib", "re", "scripts", "shlex", "state_root", "sys",
                  "tempfile", "time", "tickets_format", "tickets_store",
                  "tickets_issue", "tickets_lifecycle", "tickets_packet",
                  "tickets_result", "tickets_worklog", "tickets_dispatch",

--- a/tests/test_workspace_cases/grade_cases.py
+++ b/tests/test_workspace_cases/grade_cases.py
@@ -1,6 +1,31 @@
 """Workspace isolation, scope, and cleanup grading behavior."""
 
 from .common import *  # noqa: F401,F403
+from unittest import mock
+
+
+class RuntimeInterpreterBoundaryTests(unittest.TestCase):
+    """Workspace grading leaves git in the caller's worktree environment."""
+
+    def test_git_subprocesses_inherit_the_caller_environment(self):
+        caller = {
+            "PATH": "workspace-git-path",
+            "VIRTUAL_ENV": "workspace-git-venv",
+        }
+        observed = []
+
+        def run_in_caller(*args, **kwargs):
+            observed.append((dict(os.environ), kwargs))
+            return subprocess.CompletedProcess(args[0], 0, b"", b"")
+
+        with mock.patch.dict(os.environ, caller, clear=False):
+            with mock.patch.object(workspace.workspace_git.subprocess, "run", side_effect=run_in_caller):
+                self.assertEqual((0, "", ""), workspace._git("status", "--porcelain"))
+
+        self.assertEqual(1, len(observed))
+        environment, kwargs = observed[0]
+        self.assertEqual(caller, {name: environment[name] for name in caller})
+        self.assertNotIn("env", kwargs)
 
 @unittest.skipUnless(git_available(), "git is required for a real worktree fixture")
 class TestCheckGradesFromTheCallersGit(unittest.TestCase):


### PR DESCRIPTION
## Summary

- create and own a private per-user Python runtime at `~/.orchflows/runtime`
- run built-in orchflows scripts with that interpreter without activating it or changing the caller's `PATH`/`VIRTUAL_ENV`
- make project installs borrow the user runtime through caller-local paths, with safe create/reuse/repair/refuse behavior
- add an empty runtime dependency contract so third-party libraries can be introduced later without changing the installation boundary
- render generated commands safely for spaced paths on PowerShell and POSIX shells

## User impact

Users install once at user scope. Claude Code and Codex sessions do not create or activate a venv, and a project's own `.venv`, worktree environment, and toolchain remain untouched. Project-only installation refuses before writing if the user runtime is missing or unhealthy.

No third-party dependency is added in this change.

## Verification

- `python tools/validate.py`
- `python tools/run_tests.py -j 4` — 2,141 tests, 0 failures/errors, 17 skipped
- `python -m unittest discover -s tests -v` — 2,141 tests, OK, 17 skipped
- focused preflight on Python 3.9, 3.11, and 3.12 — installer, benchmark, and schema modules all green
- `python install.py --dry-run`
- `git diff --check`

The default local preflight saturated this 24-core Windows host and tripped existing fixed 10/60-second fixture timeouts. Those modules passed standalone, at four-worker full-suite concurrency, and in the focused three-interpreter preflight above.
