### PR TITLE
tests: prevent facade discovery duplication

### DIFF
--- a/tests/test_cutcheck.py
+++ b/tests/test_cutcheck.py
@@ -266,6 +266,19 @@ CASE_MODULES = (
     "scope",
 )
 
+# Case modules deliberately share this facade's helpers through ``import *``.
+# TestCase classes are loader-owned instead: exporting one would bind the same
+# class into every case module and make discovery execute it once per binding.
+__all__ = tuple(
+    name
+    for name, value in globals().items()
+    if not name.startswith("_")
+    and not (
+        isinstance(value, type)
+        and issubclass(value, unittest.TestCase)
+    )
+)
+
 
 def load_tests(loader, standard_tests, pattern):
     # The explicit loader keeps every case in this module's child process.

--- a/tests/test_cutcheck_cases/execution.py
+++ b/tests/test_cutcheck_cases/execution.py
@@ -1,6 +1,7 @@
 """Cutcheck behavioral cases loaded explicitly by tests.test_cutcheck."""
 
 from tests.test_cutcheck import *  # noqa: F401,F403
+from tests.test_cutcheck import RuntimeInterpreterBoundaryTests  # noqa: F401
 
 try:
     del load_tests

--- a/tests/test_run_tests.py
+++ b/tests/test_run_tests.py
@@ -11,6 +11,7 @@ shape stops being something only three cells of the matrix can see.
 
 from __future__ import annotations
 
+import importlib
 import io
 import os
 import re
@@ -213,6 +214,31 @@ class TestGuardedSeams(unittest.TestCase):
 
 
 class TestWorkflowContract(unittest.TestCase):
+    def test_star_imported_facades_do_not_export_test_cases(self):
+        facade_pattern = re.compile(
+            r"^from (tests\.test_[^. ]+) import \*", re.MULTILINE
+        )
+        facades = {
+            match.group(1)
+            for path in (REPO_ROOT / "tests").rglob("*.py")
+            for match in facade_pattern.finditer(path.read_text(encoding="utf-8"))
+        }
+        offenders = []
+        for module_name in sorted(facades):
+            module = importlib.import_module(module_name)
+            exported = getattr(
+                module,
+                "__all__",
+                tuple(name for name in vars(module) if not name.startswith("_")),
+            )
+            offenders.extend(
+                "{}.{}".format(module_name, name)
+                for name in exported
+                if isinstance(getattr(module, name), type)
+                and issubclass(getattr(module, name), unittest.TestCase)
+            )
+        self.assertEqual([], offenders)
+
     def test_ci_has_exactly_the_five_supported_boundary_legs(self):
         workflow = CHECKS_YML.read_text(encoding="utf-8")
         matrix = workflow.split("      matrix:\n", 1)[1].split("\n    steps:", 1)[0]


### PR DESCRIPTION
Fixes the test-discovery performance regression introduced in #70.

## What changed

- Prevent facade modules from star-exporting unittest TestCase classes.
- Keep RuntimeInterpreterBoundaryTests bound in exactly one cutcheck case module.
- Add a repository-wide guard against future facade TestCase exports.

## Root cause

The split cutcheck modules each use a star import from tests.test_cutcheck. The new boundary TestCase was therefore rebound into all 13 discovered case modules and executed 13 times.

## Validation

- Full discovery: 2,130 unique IDs, zero duplicates.
- Sharded suite: 2,130 tests, 0 failures/errors, 53.30s.
- Serial compatibility suite: 2,130 tests, 0 failures/errors, 277.693s.
- Regression guard fails on the prior revision and passes on this repair.
- validate, installer dry-run, and git diff check pass.