### PR TITLE
Reject forged ticket independence on file issue

### DIFF
--- a/scripts/tickets_issue.py
+++ b/scripts/tickets_issue.py
@@ -249,13 +249,44 @@ def _ceiling_error(subject: str, ticket_id: str, text: str):
     if count <= INSTRUCTION_BUDGET:
         return None
     return {'error': f'{subject} has a {count}-word instruction, over the {INSTRUCTION_BUDGET}-word ceiling (rules/token-economy.md, section 11): the objective, completion test, excluded actions and return fields a child loads every dispatch, never its fixed inputs. A compound objective is two items, not one longer ticket'}
+def _issue_defects(text: str) -> list:
+    """Contract and pre-dispatch defects in one ticket being issued.
+
+    Existing tickets may legitimately carry the immutable checker identity
+    written by ``tickets.py check``. An unissued ticket cannot: admitting it
+    would let a caller suppress the checker before dispatch.
+    """
+    defects = ticket_defects(text)
+    data = _parse_frontmatter(text)
+    if not data:
+        return defects
+    independence = 'checker'
+    if 'independence' in data:
+        independence = str(data.get('independence') or '').strip().strip('`').strip()
+        if independence not in INDEPENDENCE_VALUES:
+            defects.append(
+                f"independence '{independence}' is not one of {list(INDEPENDENCE_VALUES)}"
+            )
+    checked_by = str(data.get('checked_by') or '').strip()
+    if checked_by:
+        if independence == 'gate' and _executor_of(data) != ROOT_EXECUTOR:
+            defects.append(
+                "non-root independence 'gate' cannot carry 'checked_by' "
+                "(contracts/work-item.md)"
+            )
+        else:
+            defects.append(
+                "an unissued ticket cannot carry 'checked_by': only "
+                "`tickets.py check` sets it after checker dispatch"
+            )
+    return defects
 def _issue_ticket(run: str, ticket_id: str, text: str):
     """Grade one rendered ticket, then write it — in that order.
 
     Nothing is created before the grade: a refused cut leaves the run
     directory exactly as it found it, including not existing.
     """
-    defects = ticket_defects(text)
+    defects = _issue_defects(text)
     if defects:
         return {'error': f'ticket {run}/{ticket_id} is off contract (contracts/work-item.md): ' + '; '.join(defects)}
     over = _ceiling_error(f'ticket {run}/{ticket_id}', ticket_id, text)

--- a/tests/test_tickets_issue_cases/defect_cases.py
+++ b/tests/test_tickets_issue_cases/defect_cases.py
@@ -75,6 +75,19 @@ class TicketDefectsTest(unittest.TestCase):
         self.assertTrue(any("in-progress" in defect for defect in defects), defects)
         self.assertTrue(any("complete" in defect for defect in defects), defects)
 
+    def test_legacy_checker_reading_and_real_checker_lifecycle_remain_valid(self):
+        self.assertEqual([], tickets_mod.ticket_defects(GOOD_TICKET))
+        checked = GOOD_TICKET.replace("status: ready", "status: claimed").replace(
+            "executor: orch-tdd",
+            "executor: orch-tdd\nindependence: checker\nchecked_by: checker-a",
+        ).replace("claimed_by:", "claimed_by: agent-a")
+        self.assertEqual([], tickets_mod.ticket_defects(checked))
+
+        root_cut_check = checked.replace("executor: orch-tdd", "executor: orch-decompose").replace(
+            "independence: checker", "independence: gate"
+        )
+        self.assertEqual([], tickets_mod.ticket_defects(root_cut_check))
+
     def test_each_required_body_section_is_named_when_absent(self):
         for section in (
             "Objective", "Fixed inputs", "Completion test", "Return fields",

--- a/tests/test_tickets_issue_cases/new_cases.py
+++ b/tests/test_tickets_issue_cases/new_cases.py
@@ -311,6 +311,43 @@ class NewTest(unittest.TestCase):
             self.assertIn("oracle_class", payload["error"])
             self.assertFalse(self.ticket_path(sink).exists())
 
+    def test_a_file_cannot_forge_or_mix_its_independence_path(self):
+        variants = (
+            (
+                "off-enum independence",
+                GOOD_TICKET.replace(
+                    "executor: orch-tdd", "executor: orch-tdd\nindependence: solo"
+                ),
+                "solo",
+            ),
+            (
+                "gate plus checker identity",
+                GOOD_TICKET.replace(
+                    "executor: orch-tdd",
+                    "executor: orch-tdd\nindependence: gate\nchecked_by: checker-a",
+                ),
+                "checked_by",
+            ),
+            (
+                "checker identity before dispatch",
+                GOOD_TICKET.replace(
+                    "executor: orch-tdd",
+                    "executor: orch-tdd\nindependence: checker\nchecked_by: forged-before-dispatch",
+                ),
+                "checked_by",
+            ),
+        )
+        for label, text, evidence in variants:
+            with self.subTest(label), tempfile.TemporaryDirectory() as tmp:
+                tmp = Path(tmp)
+                sink = use_sink(tmp)
+                source = tmp / "T1.md"
+                source.write_text(text, encoding="utf-8")
+                payload = run_cmd("new", "testrun", "--file", str(source))
+                self.assertIn("error", payload)
+                self.assertIn(evidence, payload["error"])
+                self.assertFalse(self.ticket_path(sink).exists())
+
     def test_a_file_whose_run_disagrees_with_the_argument_is_refused(self):
         with tempfile.TemporaryDirectory() as tmp:
             tmp = Path(tmp)


### PR DESCRIPTION
## What changed

- validate ticket metadata supplied through `tickets.py new --file` before persistence
- reject off-enum `independence`, non-root `independence: gate` combined with `checked_by`, and pre-dispatch forged `checked_by`
- add regression coverage for all three malformed file-ingress forms while preserving valid lifecycle and legacy reads

## Why

The verification-guardrails adoption gate found that direct CLI issuance enforced the independence-path invariants, but file-form issuance could bypass them. That allowed forged or contradictory verification metadata to be written before dispatch.

## Impact

Malformed file-form tickets are refused without placement. Normal checker lifecycle, the root cut-reader exception, and legacy tickets remain compatible.

## Scope

Exactly three files:

- `scripts/tickets_issue.py`
- `tests/test_tickets_issue_cases/defect_cases.py`
- `tests/test_tickets_issue_cases/new_cases.py`

## Validation

- durable Orchflows gate: 4/4 frozen criteria PASS at `14dfb570c9671779af18beaa2617a61735d66ff6`
- repository preflight: PASS on local Python 3.9, 3.11, and 3.12
- full sharded and serial suites: 2,134 tests, 17 skipped, no failures
- `install.py --dry-run`: PASS
- `git diff --check`: PASS

CI remains responsible for Python 3.13 and the Ubuntu/macOS matrix cells.