### PR TITLE
Stop root-cohort receipts hashing sibling cuts

### DIFF
--- a/scripts/tickets_admission.py
+++ b/scripts/tickets_admission.py
@@ -226,7 +226,9 @@ def _canonical_cut(ticket_id: str, text: str, siblings: dict, adapter: str,
         })
     cohort = str(data.get("cohort") or "")
     members = []
-    for sibling_id in sorted(siblings):
+    # Root-cohort sibling cuts stay lawfully correctable while this member
+    # runs (`cohort_sealed`), so they never enter its receipt: only ticket and batch cohorts, which freeze together, hash together.
+    for sibling_id in () if cohort.startswith(_ROOT_COHORT_PREFIX) else sorted(siblings):
         sibling_text = siblings[sibling_id]
         sibling_data = _parse_frontmatter(sibling_text)
         if str(sibling_data.get("cohort") or "") != cohort:

--- a/tests/serial_compat_manifest.json
+++ b/tests/serial_compat_manifest.json
@@ -1,6 +1,6 @@
 {
  "discovery": {
-  "count": 2653,
+  "count": 2656,
   "identities": [
    "test_architecture_owners.NewToolOwnershipTest.test_dropping_any_one_sentence_fails_the_check",
    "test_architecture_owners.NewToolOwnershipTest.test_the_section_names_each_new_tool_with_its_responsibility",
@@ -1491,6 +1491,9 @@
    "tests.test_tickets_cases.cohort_seal.MemberSealTest.test_a_ready_member_is_as_open_as_a_pending_one",
    "tests.test_tickets_cases.cohort_seal.MemberSealTest.test_the_graded_member_seals_its_own_cut_once_it_is_taken_up",
    "tests.test_tickets_cases.cohort_seal.MemberSealTest.test_ticket_and_batch_cohorts_seal_on_every_member_as_before",
+   "tests.test_tickets_cases.cohort_seal.ReceiptCohortScopeTest.test_a_batch_cohort_receipt_still_reads_every_member",
+   "tests.test_tickets_cases.cohort_seal.ReceiptCohortScopeTest.test_a_root_cohort_receipt_survives_a_pending_sibling_correction",
+   "tests.test_tickets_cases.cohort_seal.RunningFrontierCorrectionTest.test_a_lawful_amend_leaves_a_claimed_siblings_further_packet_current",
    "tests.test_tickets_cases.cohort_seal.RunningFrontierCorrectionTest.test_amend_reaches_a_pending_member_while_its_siblings_run",
    "tests.test_tickets_cases.cohort_seal.RunningFrontierCorrectionTest.test_both_callers_still_refuse_a_member_the_seal_holds",
    "tests.test_tickets_cases.cohort_seal.RunningFrontierCorrectionTest.test_recut_reaches_the_pending_gate_stub_while_its_siblings_run",
@@ -2656,7 +2659,7 @@
    "tests.test_workspace_cases.start_cases.TestStartRecordsWhatItObserved.test_in_the_main_checkout_it_exits_zero_and_records",
    "tests.test_workspace_cases.start_cases.TestTicketsPayloadIsGradedNotItsExitStatus.test_an_error_payload_returned_at_exit_zero_is_a_failure"
   ],
-  "sha256": "8f109be4aff2de130c39ccf47410f6e50be06bee166b3173ceb7922967554b04"
+  "sha256": "9a54ef2aa0e039113dc1d6a9d396aac3aaa000a6bc9856d76fc5f3ff69887f42"
  },
  "mutation_owners": [
   {

--- a/tests/test_tickets_cases/cohort_seal.py
+++ b/tests/test_tickets_cases/cohort_seal.py
@@ -6,8 +6,10 @@ stays correctable however far its siblings have run: under rolling
 dispatch the decomposer is still cutting while units complete, and no
 running sibling can depend on a pending one -- an incomplete dependency
 is refused admission -- so a correction that touches only pending members
-cannot reach anything in flight. A stale cohort-member receipt on a
-claimed sibling is the receipt layer's concern, not the seal's.
+cannot reach anything in flight. The receipt layer reads the cohort the
+same way: a root-cohort receipt hashes no sibling cuts, so a claimed
+member's receipt survives those lawful corrections
+(`ReceiptCohortScopeTest`, and the packet case below).
 
 The member's own state is what still seals it: claimed, suspended,
 terminal, or carrying a `claimed_at` a lease left behind.
@@ -137,6 +139,43 @@ class MemberSealTest(unittest.TestCase):
         self.assertTrue(sealed(batch, "B"))
 
 
+class ReceiptCohortScopeTest(unittest.TestCase):
+    """The receipt hashes exactly what the seal freezes."""
+
+    def test_a_root_cohort_receipt_survives_a_pending_sibling_correction(self):
+        cohort = tickets_mod.root_cohort(ROOT_ID)
+        claimed = taken_up(
+            v1_ticket(RUNNING_ID, cohort=cohort, baseline=repository_head())
+        )
+        sibling = v1_ticket(UNIT_ID, cohort=cohort, baseline=repository_head())
+        before = tickets_mod.grade_admission(
+            RUNNING_ID, claimed, {RUNNING_ID: claimed, UNIT_ID: sibling}
+        )
+        self.assertEqual([], before["findings"])
+        corrected = sibling.replace(
+            "Change one observable artifact.",
+            "Change one observable artifact, corrected mid-run.",
+        )
+        after = tickets_mod.grade_admission(
+            RUNNING_ID, claimed, {RUNNING_ID: claimed, UNIT_ID: corrected}
+        )
+        self.assertEqual(before["receipt"], after["receipt"])
+
+    def test_a_batch_cohort_receipt_still_reads_every_member(self):
+        # Batch cohorts freeze together (`cohort_sealed`), so there a
+        # sibling's cut is part of what the receipt sealed.
+        cohort = tickets_mod.batch_cohort(["A", "B"])
+        first = v1_ticket("A", cohort=cohort, baseline=repository_head())
+        second = v1_ticket("B", cohort=cohort, baseline=repository_head())
+        before = tickets_mod.grade_admission("A", first, {"A": first, "B": second})
+        self.assertEqual([], before["findings"])
+        changed = second.replace(
+            "Change one observable artifact.", "Change another observable artifact."
+        )
+        after = tickets_mod.grade_admission("A", first, {"A": first, "B": changed})
+        self.assertNotEqual(before["receipt"], after["receipt"])
+
+
 class RunningFrontierCorrectionTest(unittest.TestCase):
     """The two callers, in the state the reproduction reports."""
 
@@ -196,6 +235,40 @@ class RunningFrontierCorrectionTest(unittest.TestCase):
                 (run_dir / f"{GATE_ID}.md").read_text(encoding="utf-8"),
             )
             self.untouched(run_dir, before)
+
+    def test_a_lawful_amend_leaves_a_claimed_siblings_further_packet_current(self):
+        # The wedge the receipt used to build: the §10 checker or
+        # re-verifier packet is requested only after the executor has been
+        # working under its claim, exactly the window a sibling correction
+        # lands in. The claimed member's own cut is untouched, so the
+        # packet must still find its stored receipt current.
+        with tempfile.TemporaryDirectory() as raw:
+            tmp = Path(raw)
+            baseline = initialize_git_fixture(tmp)
+            run_dir = use_sink(tmp) / "tickets" / "testrun"
+            run_dir.mkdir(parents=True)
+            cohort = tickets_mod.root_cohort(ROOT_ID)
+            running = v1_ticket(RUNNING_ID, cohort=cohort, baseline=baseline)
+            running = running.replace("independence: gate", "independence: checker")
+            (run_dir / f"{RUNNING_ID}.md").write_text(running, encoding="utf-8")
+            (run_dir / f"{UNIT_ID}.md").write_text(
+                v1_ticket(UNIT_ID, cohort=cohort, baseline=baseline), encoding="utf-8"
+            )
+            claim = run_cmd(tmp, "claim", "testrun", RUNNING_ID, "--by", "agent-a")
+            self.assertNotIn("error", claim)
+            amended = run_cmd(
+                tmp, "amend", "testrun", UNIT_ID, "--section", "Objective",
+                "--text", "Change one observable artifact, corrected mid-run.",
+            )
+            self.assertNotIn("error", amended)
+            packet = run_cmd(
+                tmp, "packet", "testrun", RUNNING_ID, "--reply-to", "main",
+                "--executor", "orch-verify",
+            )
+            self.assertNotIn("error", packet)
+            self.assertRegex(
+                packet["packet"]["admission"], r"^v1:git:sha256:[0-9a-f]{64}$"
+            )
 
     def test_both_callers_still_refuse_a_member_the_seal_holds(self):
         # A pending member carrying a claim time reaches `cohort_sealed`


### PR DESCRIPTION
Fixes the sharpest item in the 20260823T130218Z-orchflows-speed gate's candidate scope: *"a further-child packet on a claimed item compares the whole cohort_members vector (stale receipts after lawful sibling corrections)."*

## The defect

A `v1:root:` cohort runs on a rolling frontier: `cohort_sealed` judges each member alone, so a pending sibling stays lawfully amendable — and the decomposer can still issue `new` units — while other members run under claims. But the admission receipt hashed the whole `cohort_members` vector, so any lawful `amend`/`recut`/`new` on a pending member changed every member's canonical cut:

- **Pending/ready siblings self-heal** — `ready` re-grades and rewrites their receipts.
- **Claimed siblings cannot** — there is no re-admission path for a claimed ticket, so `packet` emission (including the rules/verification.md §10 checker/re-verifier packet, requested precisely *after* the executor worked under its claim) fails with `ticket has no current admission receipt`. The only escape was the hand-written packet that S1 F1 outlawed.

## The fix

`_canonical_cut` hashes sibling cuts only for `v1:ticket:` and `v1:batch:` cohorts, which freeze together under `cohort_sealed`. For root cohorts the `dependencies` vector (id, status, result hash) already carries everything a claim actually froze — matching `cohort_sealed`'s own rationale that an unclaimed member is reachable by nobody.

## Verification

- New `ReceiptCohortScopeTest`: a root-cohort receipt survives a pending sibling's correction; a batch-cohort receipt still reads every member (the fix does not overreach).
- New end-to-end case in `RunningFrontierCorrectionTest`: claim → lawful `amend` of a pending sibling → `packet --executor orch-verify` on the claimed member succeeds with a current receipt.
- Can-fail proof: both new root-cohort tests were run against the unfixed receipt (mutant) and fail red on exactly the wedge error.
- All five required checks pass (`tools/run_required.py`, exit 0); serial-compat manifest regenerated (2653 → 2656 tests, mutation owners unchanged at 376).

Upgrade note: root-cohort receipt values change. Pending/ready tickets in existing runs re-admit themselves; a ticket claimed across the upgrade hits the packet error once — the same error today's behavior already produces on any sibling correction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
