### PR TITLE
workspace.py start: truthful isolation, flagged sharing

### DIFF
--- a/scripts/workspace.py
+++ b/scripts/workspace.py
@@ -232,8 +232,8 @@ def _cmd_start(rest):
     # a workspace whose branch and baseline the join has to be able to read,
     # and the preparation's own verdict is reported rather than raised
     prepared = workspace_prepare.prepare(top)
-    # after recording: this item's own stamp is in the sink, skipped by id
-    sharing = _sharers(path, ticket_id, branch)
+    # after recording: this item's own stamp is in the sink, and skipped
+    sharing = _sharers(path, _git_out, _is_ancestor, branch)
     return {
         "start": {
             "run": run,

--- a/scripts/workspace.py
+++ b/scripts/workspace.py
@@ -35,6 +35,9 @@ Exit codes:
        says the item failed, 6 says the question was asked from the wrong
        place, and an integrator that reads one as the other rejects intact
        work.
+    7  shared-workspace: another claimed item of the run recorded this same
+       tree, so it is not this item's alone. ``start`` records before it
+       flags: the join must still read what the item was executed in.
 
 Subcommands:
     start <run> <id>
@@ -104,6 +107,7 @@ EXIT_WRONG_BRANCH_POINT = 3
 EXIT_SCOPE_BREACH = 4
 EXIT_NO_RECORD = 5
 EXIT_WRONG_VANTAGE = 6
+EXIT_SHARED_WORKSPACE = 7
 VERDICTS = {
     EXIT_OK: "pass",
     EXIT_ERROR: "error",
@@ -112,6 +116,7 @@ VERDICTS = {
     EXIT_SCOPE_BREACH: "scope-breach",
     EXIT_NO_RECORD: "no-record",
     EXIT_WRONG_VANTAGE: "wrong-vantage",
+    EXIT_SHARED_WORKSPACE: "shared-workspace",
 }
 AMBIGUOUS = workspace_git.AMBIGUOUS
 # ``contracts/work-item.md``: ``write_scope`` is exactly what the item may
@@ -227,6 +232,8 @@ def _cmd_start(rest):
     # a workspace whose branch and baseline the join has to be able to read,
     # and the preparation's own verdict is reported rather than raised
     prepared = workspace_prepare.prepare(top)
+    # after recording: this item's own stamp is in the sink, skipped by id
+    sharing = _sharers(path, ticket_id, branch)
     return {
         "start": {
             "run": run,
@@ -236,12 +243,14 @@ def _cmd_start(rest):
             BASELINE_KEY: baseline,
             "workspace_root": str(top),
             "main_root": str(root),
-            "isolated": top != root,
+            # a linked tree is necessary, and no longer sufficient
+            "isolated": top != root and not sharing,
+            "shared_with": sharing,
             "dirty": dirty,
             WRITE_SCOPE_KEY: list(scope),
             **prepared,
         }
-    }, EXIT_OK
+    }, EXIT_SHARED_WORKSPACE if sharing else EXIT_OK
 
 
 def _extract_flag(args: list, flag: str):
@@ -258,6 +267,7 @@ def _extract_flag(args: list, flag: str):
 _normalized_scope = workspace_scope._normalized_scope
 _in_scope = workspace_scope._in_scope
 _actual_mutations = workspace_scope._actual_mutations
+_sharers = workspace_git._sharers
 
 def _is_ancestor(ancestor: str, descendant: str) -> bool:
     return workspace_git._is_ancestor(_git, ancestor, descendant)

--- a/scripts/workspace_git.py
+++ b/scripts/workspace_git.py
@@ -246,6 +246,31 @@ def _detached_trees(git_out, is_ancestor, sha) -> int:
     ])
 
 
+def _records_this_tree(git_out, is_ancestor, recorded: str, branch: str) -> bool:
+    """Whether a sibling's recorded workspace is the tree ``branch`` stands in.
+
+    A branch name follows the item: it reads the same after every commit, so
+    equality of two branch records is the whole test. A ``detached:`` record
+    names the revision ``start`` read instead, and the tree it was written
+    from leaves that revision behind on the item's first commit -- so equality
+    answers no for the sharer that has done exactly what a claimed item is
+    dispatched to do. Where such a record still names a directory,
+    ``_detached_tip`` says which, on the reasoning it already applies at the
+    join -- the standing detached worktree at or past that revision, and only
+    where its answer is a single one. So the record is resolved to a tip, and
+    that tip has to be where this caller stands. Neither half alone is the
+    test: without the first a sharer disappears the moment it commits, and
+    without the second any resolvable record reads as this tree, flagging two
+    workspaces that share nothing but a repository against each other.
+    """
+
+    if recorded == branch:
+        return True
+    if not (recorded.startswith(DETACHED_PREFIX) and branch.startswith(DETACHED_PREFIX)):
+        return False
+    return _detached_tip(git_out, is_ancestor, _tip_ref(recorded)) == _tip_ref(branch)
+
+
 def _sharers(ticket_path, git_out, is_ancestor, branch: str) -> list:
     """Every other claimed ticket of this run that recorded this same tree.
 
@@ -270,15 +295,12 @@ def _sharers(ticket_path, git_out, is_ancestor, branch: str) -> list:
     report about the caller's tree, and it must not be the thing that stops an
     item over some other item's malformed file.
 
-    A detached record names the revision ``start`` read rather than a ref, so
-    it identifies a directory only where one directory could have written it:
-    two workspaces materialized at one revision record the identical string.
-    Which directories could have is a question git answers and no frontmatter
-    stamp is needed for -- the standing detached worktrees at or past that
-    revision. Exactly one of them and the record names it, which is the
-    shared-tree case with the branch left off; more and equality is no
-    evidence at all, and reading it as evidence flags two genuinely isolated
-    workspaces, the same ambiguity ``_detached_tip`` refuses to resolve.
+    A detached workspace records no ref, so which tree a record names is
+    decided by ``_records_this_tree`` rather than by the record string --
+    including this caller's own, checked first: where more than one standing
+    detached worktree could have written the caller's revision, the caller
+    cannot say which tree it is reporting about, and a sibling that recorded
+    that identical revision is no evidence of sharing.
     """
 
     if branch.startswith(DETACHED_PREFIX) and _detached_trees(
@@ -294,7 +316,8 @@ def _sharers(ticket_path, git_out, is_ancestor, branch: str) -> list:
         data = tickets._load_ticket(path)
         if "error" in data or data.get("status") != "claimed":
             continue
-        if str(data.get("workspace_branch") or "").strip() == branch:
+        recorded = str(data.get("workspace_branch") or "").strip()
+        if _records_this_tree(git_out, is_ancestor, recorded, branch):
             found.append(str(data.get("id") or path.stem))
     return sorted(found)
 

--- a/scripts/workspace_git.py
+++ b/scripts/workspace_git.py
@@ -229,6 +229,53 @@ def _record(ticket_path, prior_text: str, branch: str, baseline: str) -> dict:
     }
 
 
+def _sharers(ticket_path, ticket_id: str, branch: str) -> list:
+    """Every other claimed ticket of this run that recorded this same tree.
+
+    ``start`` cannot see a workspace from the outside: from inside any linked
+    worktree the tree looks the caller's own, which is why ``top != root``
+    answered true for a whole cut dispatched into one shared directory. What
+    can be seen is what the siblings recorded. ``_record`` stamps
+    ``workspace_branch`` into each item's ticket, the run's tickets are this
+    one's own neighbours in the sink, and git checks a branch out in at most
+    one tree -- so a sibling carrying this branch is standing where this item
+    stands.
+
+    Only ``claimed`` siblings count. A finished item has left the tree, and
+    counting it would flag a long run's last item for every workspace its
+    predecessors have already released, which is a flag nobody could act on.
+    The item's own ticket is skipped so that a re-established workspace never
+    reports itself as its own sharer -- by then its own stamp is in the sink.
+
+    The read goes through the same ``tickets`` loader the caller grades its own
+    ticket with, never a second resolver. A sibling that will not parse is no
+    evidence of sharing, so it is passed over rather than raised: this is a
+    report about the caller's tree, and it must not be the thing that stops an
+    item over some other item's malformed file.
+
+    A detached record is where the branch proxy stops, and it stops here
+    rather than reporting past its evidence. ``DETACHED_PREFIX`` names the
+    revision ``start`` read, not a ref, so two workspaces materialized at one
+    revision record the identical string from different directories -- the
+    same ambiguity ``_detached_tip`` refuses to resolve for the same reason.
+    Equality of two such records is no evidence of a shared tree, and reading
+    it as evidence flags two genuinely isolated workspaces.
+    """
+
+    if branch.startswith(DETACHED_PREFIX):
+        return []
+    found = []
+    for path in sorted(ticket_path.parent.glob("*.md")):
+        if path == ticket_path:
+            continue
+        data = tickets._load_ticket(path)
+        if "error" in data or data.get("status") != "claimed":
+            continue
+        if str(data.get("workspace_branch") or "").strip() == branch:
+            found.append(str(data.get("id") or path.stem))
+    return sorted(found)
+
+
 def _is_ancestor(git, ancestor: str, descendant: str) -> bool:
     code, _, err = git("merge-base", "--is-ancestor", ancestor, descendant)
     if code in (0, 1):

--- a/scripts/workspace_git.py
+++ b/scripts/workspace_git.py
@@ -229,7 +229,24 @@ def _record(ticket_path, prior_text: str, branch: str, baseline: str) -> dict:
     }
 
 
-def _sharers(ticket_path, ticket_id: str, branch: str) -> list:
+def _detached_trees(git_out, is_ancestor, sha) -> int:
+    """How many standing worktrees a ``detached:`` record could name.
+
+    Those at or past the revision it names: a worktree that has committed
+    since has moved past it, so equality of tips would miss the very tree the
+    record was written from. The same set ``_detached_tip`` resolves a tip
+    out of, counted by directory rather than by tip -- two worktrees at one
+    revision are one tip and two answers.
+    """
+
+    return len([
+        entry for entry in _worktrees(git_out)
+        if "detached" in entry and entry.get("HEAD")
+        and is_ancestor(sha, entry["HEAD"])
+    ])
+
+
+def _sharers(ticket_path, git_out, is_ancestor, branch: str) -> list:
     """Every other claimed ticket of this run that recorded this same tree.
 
     ``start`` cannot see a workspace from the outside: from inside any linked
@@ -253,19 +270,25 @@ def _sharers(ticket_path, ticket_id: str, branch: str) -> list:
     report about the caller's tree, and it must not be the thing that stops an
     item over some other item's malformed file.
 
-    A detached record is where the branch proxy stops, and it stops here
-    rather than reporting past its evidence. ``DETACHED_PREFIX`` names the
-    revision ``start`` read, not a ref, so two workspaces materialized at one
-    revision record the identical string from different directories -- the
-    same ambiguity ``_detached_tip`` refuses to resolve for the same reason.
-    Equality of two such records is no evidence of a shared tree, and reading
-    it as evidence flags two genuinely isolated workspaces.
+    A detached record names the revision ``start`` read rather than a ref, so
+    it identifies a directory only where one directory could have written it:
+    two workspaces materialized at one revision record the identical string.
+    Which directories could have is a question git answers and no frontmatter
+    stamp is needed for -- the standing detached worktrees at or past that
+    revision. Exactly one of them and the record names it, which is the
+    shared-tree case with the branch left off; more and equality is no
+    evidence at all, and reading it as evidence flags two genuinely isolated
+    workspaces, the same ambiguity ``_detached_tip`` refuses to resolve.
     """
 
-    if branch.startswith(DETACHED_PREFIX):
+    if branch.startswith(DETACHED_PREFIX) and _detached_trees(
+        git_out, is_ancestor, _tip_ref(branch)
+    ) != 1:
         return []
     found = []
     for path in sorted(ticket_path.parent.glob("*.md")):
+        # by path, which is the id the caller was dispatched under: ``_locate``
+        # builds this one from the run and id it was given
         if path == ticket_path:
             continue
         data = tickets._load_ticket(path)

--- a/tests/serial_compat_manifest.json
+++ b/tests/serial_compat_manifest.json
@@ -1,6 +1,6 @@
 {
  "discovery": {
-  "count": 2770,
+  "count": 2774,
   "identities": [
    "test_architecture_owners.NewToolOwnershipTest.test_dropping_any_one_sentence_fails_the_check",
    "test_architecture_owners.NewToolOwnershipTest.test_the_section_names_each_new_tool_with_its_responsibility",
@@ -2741,6 +2741,10 @@
    "tests.test_workspace_cases.prepare.TestStartReportsTheBrowserWithoutFetchingOne.test_a_playwright_that_does_not_answer_is_unknown_not_missing",
    "tests.test_workspace_cases.prepare.TestStartReportsTheBrowserWithoutFetchingOne.test_an_empty_cache_is_missing",
    "tests.test_workspace_cases.prepare.TestTheInstallCeilingIsReal.test_the_ceiling_is_ten_minutes_and_a_timeout_is_a_failure",
+   "tests.test_workspace_cases.sharing_cases.TestStartSeesWhoElseRecordedThisTree.test_a_branch_record_is_never_resolved_as_a_revision",
+   "tests.test_workspace_cases.sharing_cases.TestStartSeesWhoElseRecordedThisTree.test_a_commit_between_two_starts_does_not_silence_that_shared_tree",
+   "tests.test_workspace_cases.sharing_cases.TestStartSeesWhoElseRecordedThisTree.test_a_record_naming_some_other_standing_tree_is_not_this_one",
+   "tests.test_workspace_cases.sharing_cases.TestStartSeesWhoElseRecordedThisTree.test_a_record_two_standing_trees_could_carry_stays_silent",
    "tests.test_workspace_cases.sharing_cases.TestStartSeesWhoElseRecordedThisTree.test_a_sibling_no_longer_claimed_has_left_the_tree",
    "tests.test_workspace_cases.sharing_cases.TestStartSeesWhoElseRecordedThisTree.test_a_sibling_on_another_branch_is_not_sharing_this_tree",
    "tests.test_workspace_cases.sharing_cases.TestStartSeesWhoElseRecordedThisTree.test_a_sibling_that_recorded_nothing_is_not_sharing_this_tree",
@@ -2773,7 +2777,7 @@
    "tests.test_workspace_cases.start_cases.TestStartRecordsWhatItObserved.test_in_the_main_checkout_it_exits_zero_and_records",
    "tests.test_workspace_cases.start_cases.TestTicketsPayloadIsGradedNotItsExitStatus.test_an_error_payload_returned_at_exit_zero_is_a_failure"
   ],
-  "sha256": "e70d7f874fa1353b1cad5f089e4b5df602f31c5bf6852b050ab368fbf3d6ed60"
+  "sha256": "4f2b3244c7b48116bc62f5a238b0b9c15bcc2ab23b776763abc49197d2af0853"
  },
  "mutation_owners": [
   {

--- a/tests/serial_compat_manifest.json
+++ b/tests/serial_compat_manifest.json
@@ -1,6 +1,6 @@
 {
  "discovery": {
-  "count": 2768,
+  "count": 2770,
   "identities": [
    "test_architecture_owners.NewToolOwnershipTest.test_dropping_any_one_sentence_fails_the_check",
    "test_architecture_owners.NewToolOwnershipTest.test_the_section_names_each_new_tool_with_its_responsibility",
@@ -2749,6 +2749,8 @@
    "tests.test_workspace_cases.sharing_cases.TestStartSeesWhoElseRecordedThisTree.test_every_claimed_sharer_is_named_not_only_the_first",
    "tests.test_workspace_cases.sharing_cases.TestStartSeesWhoElseRecordedThisTree.test_starting_the_same_item_twice_never_flags_it_against_itself",
    "tests.test_workspace_cases.sharing_cases.TestStartSeesWhoElseRecordedThisTree.test_the_main_checkout_stays_unisolated_and_still_exits_zero",
+   "tests.test_workspace_cases.sharing_cases.TestStartSeesWhoElseRecordedThisTree.test_the_main_checkout_that_shares_is_flagged_like_any_other",
+   "tests.test_workspace_cases.sharing_cases.TestStartSeesWhoElseRecordedThisTree.test_two_claimed_items_in_one_shared_detached_worktree_are_flagged",
    "tests.test_workspace_cases.sharing_cases.TestStartSeesWhoElseRecordedThisTree.test_two_detached_workspaces_at_one_revision_are_not_sharing_a_tree",
    "tests.test_workspace_cases.sharing_cases.TestTheSharedTreeCodeIsItsOwnAndDocumented.test_the_code_collides_with_no_existing_meaning",
    "tests.test_workspace_cases.sharing_cases.TestTheSharedTreeCodeIsItsOwnAndDocumented.test_the_docstring_exit_code_table_carries_the_new_code",
@@ -2771,7 +2773,7 @@
    "tests.test_workspace_cases.start_cases.TestStartRecordsWhatItObserved.test_in_the_main_checkout_it_exits_zero_and_records",
    "tests.test_workspace_cases.start_cases.TestTicketsPayloadIsGradedNotItsExitStatus.test_an_error_payload_returned_at_exit_zero_is_a_failure"
   ],
-  "sha256": "4dcdeb469bd26268699d654bebf092aa3989f866ded017149e0bc76dc99380a1"
+  "sha256": "e70d7f874fa1353b1cad5f089e4b5df602f31c5bf6852b050ab368fbf3d6ed60"
  },
  "mutation_owners": [
   {

--- a/tests/serial_compat_manifest.json
+++ b/tests/serial_compat_manifest.json
@@ -1,6 +1,6 @@
 {
  "discovery": {
-  "count": 2757,
+  "count": 2768,
   "identities": [
    "test_architecture_owners.NewToolOwnershipTest.test_dropping_any_one_sentence_fails_the_check",
    "test_architecture_owners.NewToolOwnershipTest.test_the_section_names_each_new_tool_with_its_responsibility",
@@ -2741,6 +2741,17 @@
    "tests.test_workspace_cases.prepare.TestStartReportsTheBrowserWithoutFetchingOne.test_a_playwright_that_does_not_answer_is_unknown_not_missing",
    "tests.test_workspace_cases.prepare.TestStartReportsTheBrowserWithoutFetchingOne.test_an_empty_cache_is_missing",
    "tests.test_workspace_cases.prepare.TestTheInstallCeilingIsReal.test_the_ceiling_is_ten_minutes_and_a_timeout_is_a_failure",
+   "tests.test_workspace_cases.sharing_cases.TestStartSeesWhoElseRecordedThisTree.test_a_sibling_no_longer_claimed_has_left_the_tree",
+   "tests.test_workspace_cases.sharing_cases.TestStartSeesWhoElseRecordedThisTree.test_a_sibling_on_another_branch_is_not_sharing_this_tree",
+   "tests.test_workspace_cases.sharing_cases.TestStartSeesWhoElseRecordedThisTree.test_a_sibling_that_recorded_nothing_is_not_sharing_this_tree",
+   "tests.test_workspace_cases.sharing_cases.TestStartSeesWhoElseRecordedThisTree.test_a_tree_another_claimed_item_recorded_is_not_isolated",
+   "tests.test_workspace_cases.sharing_cases.TestStartSeesWhoElseRecordedThisTree.test_a_tree_no_other_claimed_item_recorded_is_isolated",
+   "tests.test_workspace_cases.sharing_cases.TestStartSeesWhoElseRecordedThisTree.test_every_claimed_sharer_is_named_not_only_the_first",
+   "tests.test_workspace_cases.sharing_cases.TestStartSeesWhoElseRecordedThisTree.test_starting_the_same_item_twice_never_flags_it_against_itself",
+   "tests.test_workspace_cases.sharing_cases.TestStartSeesWhoElseRecordedThisTree.test_the_main_checkout_stays_unisolated_and_still_exits_zero",
+   "tests.test_workspace_cases.sharing_cases.TestStartSeesWhoElseRecordedThisTree.test_two_detached_workspaces_at_one_revision_are_not_sharing_a_tree",
+   "tests.test_workspace_cases.sharing_cases.TestTheSharedTreeCodeIsItsOwnAndDocumented.test_the_code_collides_with_no_existing_meaning",
+   "tests.test_workspace_cases.sharing_cases.TestTheSharedTreeCodeIsItsOwnAndDocumented.test_the_docstring_exit_code_table_carries_the_new_code",
    "tests.test_workspace_cases.start_cases.TestCheckDisambiguatesItsRevisionRanges.test_every_range_is_terminated_before_the_pathspec",
    "tests.test_workspace_cases.start_cases.TestStartFailureBehavior.test_a_bare_path_scope_is_recorded_as_before",
    "tests.test_workspace_cases.start_cases.TestStartFailureBehavior.test_a_dirty_path_with_a_comma_is_refused_by_name",
@@ -2760,7 +2771,7 @@
    "tests.test_workspace_cases.start_cases.TestStartRecordsWhatItObserved.test_in_the_main_checkout_it_exits_zero_and_records",
    "tests.test_workspace_cases.start_cases.TestTicketsPayloadIsGradedNotItsExitStatus.test_an_error_payload_returned_at_exit_zero_is_a_failure"
   ],
-  "sha256": "f0c3b4ad5a2d6c027b0a3fd300a0055ffe817c895583a6ab2f501c9afa64c849"
+  "sha256": "4dcdeb469bd26268699d654bebf092aa3989f866ded017149e0bc76dc99380a1"
  },
  "mutation_owners": [
   {

--- a/tests/test_workspace.py
+++ b/tests/test_workspace.py
@@ -13,6 +13,7 @@ from tests.test_workspace_cases.contract_cases import *  # noqa: E402,F401,F403
 from tests.test_workspace_cases.grade_cases import *  # noqa: E402,F401,F403
 from tests.test_workspace_cases.operation_cases import *  # noqa: E402,F401,F403
 from tests.test_workspace_cases.prepare import *  # noqa: E402,F401,F403
+from tests.test_workspace_cases.sharing_cases import *  # noqa: E402,F401,F403
 from tests.test_workspace_cases.start_cases import *  # noqa: E402,F401,F403
 
 

--- a/tests/test_workspace_cases/sharing_cases.py
+++ b/tests/test_workspace_cases/sharing_cases.py
@@ -1,0 +1,220 @@
+"""Whether the tree ``start`` stands in is this item's alone.
+
+``start`` used to decide isolation with one line, ``top != root``: true from
+any linked worktree at all. Every sibling of a run dispatched into one shared
+worktree therefore heard ``isolated: true``, and the field said only that the
+caller was not standing in the main checkout. These cases are the third
+position that line cannot tell apart from the second -- a caller inside a
+linked worktree that another claimed item of the same run already recorded.
+"""
+
+from .common import *  # noqa: F401,F403
+
+
+def restatus(ticket: Path, status: str) -> None:
+    """A fixture ticket at some status other than ``make_ticket``'s claimed."""
+
+    ticket.write_text(
+        ticket.read_text(encoding="utf-8").replace(
+            "status: claimed", f"status: {status}"
+        ),
+        encoding="utf-8",
+    )
+
+
+@unittest.skipUnless(git_available(), "git is required for a real worktree fixture")
+class TestStartSeesWhoElseRecordedThisTree(unittest.TestCase):
+    """Both directions of the isolation claim, from one shared worktree."""
+
+    def _start_in_a_worktree(self, tmp: Path, siblings=()):
+        """One repository, one linked worktree, and the siblings named.
+
+        Each sibling is ``(id, branch, status)``: the branch it recorded, so a
+        sibling standing in this same tree is one whose ``workspace_branch``
+        is ``wt-branch``. The item under start is always ``T-self``.
+        """
+
+        main, run_dir = make_repo(tmp)
+        for tid, branch, status in siblings:
+            stamps = ((workspace.BRANCH_KEY, branch),) if branch else ()
+            path = make_ticket(run_dir, tid, extra=stamps)
+            if status != "claimed":
+                restatus(path, status)
+        mine = make_ticket(run_dir, "T-self")
+        worktree = add_worktree(main, "wt-branch", tmp / "wt")
+        return run_workspace(worktree, "start", "testrun", "T-self"), mine
+
+    def test_a_tree_another_claimed_item_recorded_is_not_isolated(self):
+        """The case the shipped line could not see, and the run's reason."""
+
+        with tempfile.TemporaryDirectory() as tmp:
+            done, mine = self._start_in_a_worktree(
+                Path(tmp), siblings=(("T-sibling", "wt-branch", "claimed"),)
+            )
+
+            body = payload_of(done)["start"]
+            self.assertFalse(
+                body["isolated"],
+                "a tree another claimed item of the run recorded is not this "
+                "item's alone",
+            )
+            self.assertEqual(["T-sibling"], body["shared_with"])
+            self.assertEqual(
+                workspace.EXIT_SHARED_WORKSPACE, done.returncode, done.stdout
+            )
+            # flagged, not refused: the join still has to be able to read what
+            # this item was executed in, so the stamps land before the flag
+            self.assertIn(
+                "workspace_branch: wt-branch\n", mine.read_text(encoding="utf-8")
+            )
+
+    def test_a_tree_no_other_claimed_item_recorded_is_isolated(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            done, _ = self._start_in_a_worktree(Path(tmp))
+
+            self.assertEqual(0, done.returncode, done.stdout + done.stderr)
+            body = payload_of(done)["start"]
+            self.assertTrue(body["isolated"])
+            self.assertEqual([], body["shared_with"])
+
+    def test_a_sibling_on_another_branch_is_not_sharing_this_tree(self):
+        """Git checks a branch out in at most one tree, so a different
+        recorded branch is a different tree, whatever else it shares."""
+
+        with tempfile.TemporaryDirectory() as tmp:
+            done, _ = self._start_in_a_worktree(
+                Path(tmp), siblings=(("T-elsewhere", "other-branch", "claimed"),)
+            )
+
+            self.assertEqual(0, done.returncode, done.stdout + done.stderr)
+            self.assertTrue(payload_of(done)["start"]["isolated"])
+
+    def test_a_sibling_that_recorded_nothing_is_not_sharing_this_tree(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            done, _ = self._start_in_a_worktree(
+                Path(tmp), siblings=(("T-unstarted", None, "claimed"),)
+            )
+
+            self.assertEqual(0, done.returncode, done.stdout + done.stderr)
+            self.assertTrue(payload_of(done)["start"]["isolated"])
+
+    def test_a_sibling_no_longer_claimed_has_left_the_tree(self):
+        """A finished item is not a live sharer. Were every terminal sibling
+        counted, a long run's last item would be flagged for the trees its
+        predecessors have already left, and the flag would mean nothing."""
+
+        with tempfile.TemporaryDirectory() as tmp:
+            done, _ = self._start_in_a_worktree(
+                Path(tmp), siblings=(("T-finished", "wt-branch", "complete"),)
+            )
+
+            self.assertEqual(0, done.returncode, done.stdout + done.stderr)
+            self.assertTrue(payload_of(done)["start"]["isolated"])
+
+    def test_every_claimed_sharer_is_named_not_only_the_first(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            done, _ = self._start_in_a_worktree(
+                Path(tmp),
+                siblings=(
+                    ("T-b", "wt-branch", "claimed"),
+                    ("T-a", "wt-branch", "claimed"),
+                    ("T-away", "other-branch", "claimed"),
+                ),
+            )
+
+            self.assertEqual(
+                workspace.EXIT_SHARED_WORKSPACE, done.returncode, done.stdout
+            )
+            self.assertEqual(["T-a", "T-b"], payload_of(done)["start"]["shared_with"])
+
+    def test_two_detached_workspaces_at_one_revision_are_not_sharing_a_tree(self):
+        """The limit of the branch proxy, pinned as a limit.
+
+        A branch identifies a tree because git checks it out in at most one.
+        A detached record identifies no tree at all: it names the revision
+        ``start`` read, and two workspaces materialized at the same revision
+        record the identical string while standing in different directories --
+        the same ambiguity ``_detached_tip`` already refuses to resolve. So
+        equality of two detached records is not evidence of sharing, and
+        reading it as evidence flags two genuinely isolated workspaces.
+        """
+
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp = Path(tmp)
+            main, run_dir = make_repo(tmp)
+            payloads = []
+            for tid in ("T-first", "T-second"):
+                make_ticket(run_dir, tid)
+                worktree = tmp / f"wt-{tid}"
+                git(main, "worktree", "add", "--quiet", "--detach", str(worktree), "HEAD")
+                done = run_workspace(worktree, "start", "testrun", tid)
+                self.assertEqual(0, done.returncode, done.stdout + done.stderr)
+                payloads.append(payload_of(done)["start"])
+
+            # both recorded the same detached identity, and both are isolated
+            self.assertEqual(
+                payloads[0][workspace.BRANCH_KEY], payloads[1][workspace.BRANCH_KEY]
+            )
+            for body in payloads:
+                self.assertTrue(body["isolated"], body)
+                self.assertEqual([], body["shared_with"])
+
+    def test_starting_the_same_item_twice_never_flags_it_against_itself(self):
+        """``start`` records this item's own branch, so the second run reads a
+        sink already carrying it. The item's own id is skipped, or every
+        re-established workspace would report itself as its own sharer."""
+
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp = Path(tmp)
+            main, run_dir = make_repo(tmp)
+            make_ticket(run_dir, "T-self")
+            worktree = add_worktree(main, "wt-branch", tmp / "wt")
+
+            first = run_workspace(worktree, "start", "testrun", "T-self")
+            self.assertEqual(0, first.returncode, first.stdout + first.stderr)
+            again = run_workspace(worktree, "start", "testrun", "T-self")
+
+            self.assertEqual(0, again.returncode, again.stdout + again.stderr)
+            self.assertTrue(payload_of(again)["start"]["isolated"])
+
+    def test_the_main_checkout_stays_unisolated_and_still_exits_zero(self):
+        """The second position, unchanged. ``isolated`` is a conjunction now,
+        and the main checkout fails the first half of it for the reason it
+        always did -- which is not the shared-tree flag and must not earn its
+        exit code."""
+
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp = Path(tmp)
+            main, run_dir = make_repo(tmp)
+            make_ticket(run_dir, "T-self")
+
+            done = run_workspace(main, "start", "testrun", "T-self")
+
+            self.assertEqual(0, done.returncode, done.stdout + done.stderr)
+            self.assertFalse(payload_of(done)["start"]["isolated"])
+
+
+class TestTheSharedTreeCodeIsItsOwnAndDocumented(unittest.TestCase):
+    """Exit codes are this script's public verdicts. A new failure mode that
+    reused 1, or 2, would be read by an integrator as the meaning that code
+    already carries."""
+
+    def test_the_code_collides_with_no_existing_meaning(self):
+        existing = {
+            workspace.EXIT_OK, workspace.EXIT_ERROR,
+            workspace.EXIT_ISOLATION_MISSING, workspace.EXIT_WRONG_BRANCH_POINT,
+            workspace.EXIT_SCOPE_BREACH, workspace.EXIT_NO_RECORD,
+            workspace.EXIT_WRONG_VANTAGE,
+        }
+        self.assertEqual({0, 1, 2, 3, 4, 5, 6}, existing, "an existing code moved")
+        self.assertNotIn(workspace.EXIT_SHARED_WORKSPACE, existing)
+        self.assertIn(workspace.EXIT_SHARED_WORKSPACE, workspace.VERDICTS)
+
+    def test_the_docstring_exit_code_table_carries_the_new_code(self):
+        """The table a caller reads to learn what a code means. ``--help``
+        prints from ``VERDICTS``; this is the prose row beside it."""
+
+        docstring = ast.get_docstring(ast.parse(WORKSPACE_PY.read_text(encoding="utf-8")))
+        table = (docstring or "").partition("Exit codes:")[2]
+        self.assertIn(str(workspace.EXIT_SHARED_WORKSPACE), table)
+        self.assertIn(workspace.VERDICTS[workspace.EXIT_SHARED_WORKSPACE], table)

--- a/tests/test_workspace_cases/sharing_cases.py
+++ b/tests/test_workspace_cases/sharing_cases.py
@@ -194,6 +194,136 @@ class TestStartSeesWhoElseRecordedThisTree(unittest.TestCase):
                 workspace.EXIT_SHARED_WORKSPACE, done.returncode, done.stdout
             )
 
+    def test_a_commit_between_two_starts_does_not_silence_that_shared_tree(self):
+        """The case above after the ordinary act of working in the tree.
+
+        A ``detached:`` record names the revision ``start`` read, not a ref
+        that follows the item, so the first commit moves the tree off its own
+        record and equality of record strings stops seeing the sharer the case
+        above pins. Git still names the directory outright -- a single
+        standing detached worktree at or past the recorded revision -- so
+        whether a sharer has committed since cannot be what decides isolation.
+        """
+
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp = Path(tmp)
+            main, run_dir = make_repo(tmp)
+            shared = tmp / "wt-shared"
+            git(main, "worktree", "add", "--quiet", "--detach", str(shared), "HEAD")
+            for tid in ("T-first", "T-second"):
+                make_ticket(run_dir, tid)
+            first = run_workspace(shared, "start", "testrun", "T-first")
+            self.assertEqual(0, first.returncode, first.stdout + first.stderr)
+            commit_in(shared, {"scratch/a.txt": "first item work\n"}, "T-first works")
+
+            done = run_workspace(shared, "start", "testrun", "T-second")
+
+            body = payload_of(done)["start"]
+            # or the fixture pins the case above a second time rather than this one
+            self.assertNotEqual(
+                payload_of(first)["start"][workspace.BRANCH_KEY],
+                body[workspace.BRANCH_KEY],
+                "the intervening commit must move the recorded identity",
+            )
+            self.assertEqual(["T-first"], body["shared_with"])
+            self.assertFalse(
+                body["isolated"],
+                "a claimed sibling recorded this very directory; its having "
+                "committed since does not make the tree this item's alone",
+            )
+            self.assertEqual(
+                workspace.EXIT_SHARED_WORKSPACE, done.returncode, done.stdout
+            )
+
+    def test_a_record_two_standing_trees_could_carry_stays_silent(self):
+        """Where that directory-naming reasoning stops, pinned as a limit.
+
+        The sharer's record is read against the standing detached worktrees at
+        or past it, and it names a directory only where they answer with one
+        tip. Park a second detached worktree at the recorded revision and two
+        directories could have written it, so this reports nothing -- a sharer
+        missed, never two isolated workspaces flagged against each other. The
+        resolution runs over the revision the sibling recorded, not over the
+        caller's own: the caller's has moved on and is unambiguous here, so a
+        resolution moved onto it would answer for a record it cannot speak to.
+        """
+
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp = Path(tmp)
+            main, run_dir = make_repo(tmp)
+            shared = tmp / "wt-shared"
+            git(main, "worktree", "add", "--quiet", "--detach", str(shared), "HEAD")
+            git(main, "worktree", "add", "--quiet", "--detach", str(tmp / "wt-other"), "HEAD")
+            for tid in ("T-first", "T-second"):
+                make_ticket(run_dir, tid)
+            first = run_workspace(shared, "start", "testrun", "T-first")
+            self.assertEqual(0, first.returncode, first.stdout + first.stderr)
+            commit_in(shared, {"scratch/a.txt": "first item work\n"}, "T-first works")
+
+            done = run_workspace(shared, "start", "testrun", "T-second")
+
+            self.assertEqual(0, done.returncode, done.stdout + done.stderr)
+            body = payload_of(done)["start"]
+            self.assertEqual([], body["shared_with"])
+            self.assertTrue(body["isolated"], body)
+
+    def test_a_record_naming_some_other_standing_tree_is_not_this_one(self):
+        """The other half of reading a record as a directory.
+
+        Two detached workspaces that have each committed name one standing
+        tree apiece, unambiguously -- and they are different trees. Resolving
+        a record to a single directory is therefore only half the test; the
+        directory has to be the one this caller stands in, or the reasoning
+        that catches the shared tree above flags two workspaces that share
+        nothing but a repository.
+        """
+
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp = Path(tmp)
+            main, run_dir = make_repo(tmp)
+            for tid, content in (("T-first", "a\n"), ("T-second", "b\n")):
+                make_ticket(run_dir, tid)
+                tree = tmp / f"wt-{tid}"
+                git(main, "worktree", "add", "--quiet", "--detach", str(tree), "HEAD")
+                # each tree off the shared base onto its own commit, so each
+                # record resolves to exactly one standing worktree
+                commit_in(tree, {"scratch/a.txt": content}, f"{tid} works")
+            first = run_workspace(tmp / "wt-T-first", "start", "testrun", "T-first")
+            self.assertEqual(0, first.returncode, first.stdout + first.stderr)
+
+            done = run_workspace(tmp / "wt-T-second", "start", "testrun", "T-second")
+
+            self.assertEqual(0, done.returncode, done.stdout + done.stderr)
+            body = payload_of(done)["start"]
+            self.assertEqual([], body["shared_with"])
+            self.assertTrue(body["isolated"], body)
+
+    def test_a_branch_record_is_never_resolved_as_a_revision(self):
+        """Only a ``detached:`` record is read as a revision.
+
+        A branch a detached caller stands at or past is the ordinary case --
+        the tree was cut from it. Were a branch record resolved the way a
+        revision record is, that ancestry alone would name this caller's tip
+        and every sibling working on the branch the tree was cut from would be
+        reported as standing in it.
+        """
+
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp = Path(tmp)
+            main, run_dir = make_repo(tmp)
+            here = git(main, "rev-parse", "--abbrev-ref", "HEAD").strip()
+            make_ticket(run_dir, "T-on-branch", extra=((workspace.BRANCH_KEY, here),))
+            make_ticket(run_dir, "T-self")
+            detached = tmp / "wt-detached"
+            git(main, "worktree", "add", "--quiet", "--detach", str(detached), "HEAD")
+
+            done = run_workspace(detached, "start", "testrun", "T-self")
+
+            self.assertEqual(0, done.returncode, done.stdout + done.stderr)
+            body = payload_of(done)["start"]
+            self.assertEqual([], body["shared_with"])
+            self.assertTrue(body["isolated"], body)
+
     def test_starting_the_same_item_twice_never_flags_it_against_itself(self):
         """``start`` records this item's own branch, so the second run reads a
         sink already carrying it. The item's own id is skipped, or every

--- a/tests/test_workspace_cases/sharing_cases.py
+++ b/tests/test_workspace_cases/sharing_cases.py
@@ -159,6 +159,41 @@ class TestStartSeesWhoElseRecordedThisTree(unittest.TestCase):
                 self.assertTrue(body["isolated"], body)
                 self.assertEqual([], body["shared_with"])
 
+    def test_two_claimed_items_in_one_shared_detached_worktree_are_flagged(self):
+        """The other side of that limit, which is not a limit.
+
+        A detached record is ambiguous only where more than one worktree could
+        have written it. One shared detached tree is this run's own situation
+        with the branch left off -- two claimed items standing in one
+        directory -- and git names that directory outright: a single standing
+        detached worktree at or past the recorded revision is the only place
+        the record can have come from. Going silent here reports `isolated`
+        for the very shape `isolated` was made to see.
+        """
+
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp = Path(tmp)
+            main, run_dir = make_repo(tmp)
+            shared = tmp / "wt-shared"
+            git(main, "worktree", "add", "--quiet", "--detach", str(shared), "HEAD")
+            for tid in ("T-first", "T-second"):
+                make_ticket(run_dir, tid)
+            first = run_workspace(shared, "start", "testrun", "T-first")
+            self.assertEqual(0, first.returncode, first.stdout + first.stderr)
+
+            done = run_workspace(shared, "start", "testrun", "T-second")
+
+            body = payload_of(done)["start"]
+            self.assertFalse(
+                body["isolated"],
+                "a claimed sibling recorded this very directory; a detached "
+                "HEAD does not make the tree this item's alone",
+            )
+            self.assertEqual(["T-first"], body["shared_with"])
+            self.assertEqual(
+                workspace.EXIT_SHARED_WORKSPACE, done.returncode, done.stdout
+            )
+
     def test_starting_the_same_item_twice_never_flags_it_against_itself(self):
         """``start`` records this item's own branch, so the second run reads a
         sink already carrying it. The item's own id is skipped, or every
@@ -180,8 +215,8 @@ class TestStartSeesWhoElseRecordedThisTree(unittest.TestCase):
     def test_the_main_checkout_stays_unisolated_and_still_exits_zero(self):
         """The second position, unchanged. ``isolated`` is a conjunction now,
         and the main checkout fails the first half of it for the reason it
-        always did -- which is not the shared-tree flag and must not earn its
-        exit code."""
+        always did -- standing where the repository is checked out, which is
+        not news and must not earn the new code by itself."""
 
         with tempfile.TemporaryDirectory() as tmp:
             tmp = Path(tmp)
@@ -192,6 +227,32 @@ class TestStartSeesWhoElseRecordedThisTree(unittest.TestCase):
 
             self.assertEqual(0, done.returncode, done.stdout + done.stderr)
             self.assertFalse(payload_of(done)["start"]["isolated"])
+
+    def test_the_main_checkout_that_shares_is_flagged_like_any_other(self):
+        """The pair to the case above, and what tells the two apart.
+
+        ``isolated`` is false in the main checkout either way, so nothing in
+        that field distinguishes standing where the repository is checked out
+        from standing where a claimed sibling is also working. Only the code
+        and ``shared_with`` can, which is why the flag is decided on the
+        sharing alone and not under the linked-tree half of the conjunction.
+        """
+
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp = Path(tmp)
+            main, run_dir = make_repo(tmp)
+            here = git(main, "rev-parse", "--abbrev-ref", "HEAD").strip()
+            make_ticket(run_dir, "T-sibling", extra=((workspace.BRANCH_KEY, here),))
+            make_ticket(run_dir, "T-self")
+
+            done = run_workspace(main, "start", "testrun", "T-self")
+
+            body = payload_of(done)["start"]
+            self.assertFalse(body["isolated"])
+            self.assertEqual(["T-sibling"], body["shared_with"])
+            self.assertEqual(
+                workspace.EXIT_SHARED_WORKSPACE, done.returncode, done.stdout
+            )
 
 
 class TestTheSharedTreeCodeIsItsOwnAndDocumented(unittest.TestCase):


### PR DESCRIPTION
Delivers the top-ranked self-improve proposal from the 2026-08-24 mining cycle (`workspace-start-claims-isolation-it-does-not-provide`) through a full orchflows run (`20260824T122205Z-workspace-isolation`): spec → one-unit cut → executor → §10 checker → composite gate (critique, repair, verify). All acceptance criteria met at the tip; the covered line lands on merge as the delivery's contractual last act.

## The defect

`workspace.py start` decided isolation with one comparison — `top != root` — so *any* linked worktree reported `isolated: true`, including the shared integration worktree every sibling of a run occupies. During the trunk-slimming run this false comfort forced every worker and checker to hand-build clean trees, and every L1 verdict carried a shared-tree caveat (six confirmations, two checked contradictions in the friction sink).

## The fix (three deepening layers, one execution each)

- **Executor** (`8061c36`): `isolated` becomes `top != root AND no claimed sibling of the run recorded this tree` — `_sharers` walks the run's ticket directory and matches the `workspace_branch` stamps `_record` already writes. A shared tree is *flagged, not refused*: new exit code `7 shared-workspace` with `shared_with` naming the sharers, stamps recorded before the flag so the join can always read what an item ran in. Red-first fixture; six can-fail mutants.
- **Checker** (`c4bca3f`): refuted the "forced silence" claim on detached trees — the discriminator already existed in the module (`_detached_tip`, at-or-past ancestry); corrected the sharers match for standing detached worktrees and pinned the undefended guard placement. Zero lines added to the capped file (a dead parameter was the needed slot). Four mutants.
- **Gate repair** (`c2ab037`): the critique reproduced the remaining sequential-establishment silence (a commit landing between two starts in one shared detached tree); `_records_this_tree` now resolves a sibling's detached record to the standing tree at-or-past it. Red-first on the intervening-commit slice; five mutants including guard-moving. The one remaining silence is a documented missed-sharer-never-false-flag exception owned by the docstring.

## Verification

Terminal gate battery green at `c2ab037` in a clean detached worktree by an agent that executed no part of the result: validate 0 ERROR · full suite 2774 tests 0 failures (one transient PyPI fetch closed by the join's re-read) · serial lane ok (discovery 2774) · install dry-run clean · diff-check clean. Candidates queued rather than widened: suspended-with-claim sibling guard, `shared_with` id resolution, the exit-7 packet clause, the 509/510 factoring debt, `start` baseline non-idempotence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
