### PR TITLE
tickets_scope: exclude the v2-sealed cut root from companion eligibility

### DIFF
--- a/scripts/tickets_scope.py
+++ b/scripts/tickets_scope.py
@@ -241,6 +241,7 @@ def _cycle_nodes(graph):
 
 
 ROOT_COHORT_PREFIX = "v1:root:"
+ROOT_GENERATION_SUBJECT_RE = re.compile(r"^v2:root:([A-Za-z0-9][A-Za-z0-9._-]*):")
 GATE_INFIX = ".gate."
 V2_FIELDS = ("root_generation", "cut_generation", "ownership_regions", "assignment_seal")
 
@@ -267,22 +268,27 @@ def _closure_key(ticket_id, data):
     return f"cut:{generation}" if generation else f"unsealed:{ticket_id}"
 
 
-def _companion_owners(cohort, members):
-    """The member ids that may own a scope-edge companion in this cohort.
+def _companion_owners(data, members):
+    """The member ids that may own a scope-edge companion in this cut.
 
-    A decomposed cohort's root holds its whole subtree's write scope and its
-    gate stubs repair anywhere that subtree writes, so both cover every
-    companion the cut plans. Counting them would report the lawful shape --
-    one unit owning the companion -- as several owners, and the shape with no
-    unit owner as owned. Where the cohort holds no unit at all the whole
-    membership is eligible again, so a root graded on its own still owns the
-    companions it plans -- and a root standing with only gate stubs is read
-    exactly as it was, several owners and all.
+    A cut's root holds its whole subtree's write scope and its gate stubs
+    repair anywhere that subtree writes, so both cover every companion the cut
+    plans. Counting them would report the lawful shape -- one unit owning the
+    companion -- as several owners, and the shape with no unit owner as owned.
+    Where the cut holds no unit at all the whole membership is eligible again,
+    so a root graded alone still owns the companions it plans -- and a root
+    with only gate stubs is read exactly as it was, several owners and all.
+
+    A v1 decomposition stamps every member with the root's cohort; a sealed v2
+    cut stamps none and freezes the root in ``root_generation`` instead, so
+    reading the cohort alone left a v2 root unnamed and eligible, making both
+    misreadings above.  Only its subject is read here -- whether the identity
+    is well formed is ``tickets_generations``'s -- and never split by position.
     """
 
-    root_id = (
-        cohort[len(ROOT_COHORT_PREFIX):] if cohort.startswith(ROOT_COHORT_PREFIX) else ""
-    )
+    cohort = str(data.get("cohort") or "")
+    sealed = ROOT_GENERATION_SUBJECT_RE.match(str(data.get("root_generation") or ""))
+    root_id = cohort[len(ROOT_COHORT_PREFIX):] if cohort.startswith(ROOT_COHORT_PREFIX) else (sealed.group(1) if sealed else "")
     units = {
         member_id for member_id in members
         if member_id != root_id and GATE_INFIX not in member_id
@@ -301,7 +307,6 @@ def grade_closure(ticket_id, text, siblings, edges):
     """
 
     current = _parse_frontmatter(text)
-    cohort = str(current.get("cohort") or "")
     member_texts = dict(siblings)
     member_texts[ticket_id] = text
     parsed = {
@@ -337,7 +342,7 @@ def grade_closure(ticket_id, text, siblings, edges):
                 ))
 
     owners = {}
-    eligible = _companion_owners(cohort, plans)
+    eligible = _companion_owners(current, plans)
     initial = set()
     for member_id, nodes in plans.items():
         for node in nodes:

--- a/tests/serial_compat_manifest.json
+++ b/tests/serial_compat_manifest.json
@@ -1,6 +1,6 @@
 {
  "discovery": {
-  "count": 3078,
+  "count": 3082,
   "identities": [
    "test_affected_tests.TestDiscoveryCache.test_a_new_commit_is_a_new_key_and_is_discovered_again",
    "test_affected_tests.TestDiscoveryCache.test_a_tree_that_cannot_answer_for_a_commit_falls_back_and_says_so",
@@ -848,6 +848,10 @@
    "test_v2_closure.CohortlessV2MembershipTest.test_one_sealed_cut_is_still_one_closure",
    "test_v2_closure.CohortlessV2MembershipTest.test_v2_tickets_with_distinct_cut_generations_grade_independently",
    "test_v2_closure.ReproducerAtTheAdmissionGradeTest.test_a_lawful_v2_ticket_is_admitted_beside_a_defective_sibling",
+   "test_v2_closure.SealedV2RootMembershipTest.test_a_companion_only_the_sealed_root_plans_is_still_reported_unowned",
+   "test_v2_closure.SealedV2RootMembershipTest.test_a_sealed_root_standing_alone_still_owns_the_companions_it_plans",
+   "test_v2_closure.SealedV2RootMembershipTest.test_the_root_of_a_sealed_cut_is_not_a_second_owner_of_a_companion",
+   "test_v2_closure.SealedV2RootMembershipTest.test_two_units_of_a_sealed_cut_are_still_two_owners",
    "test_v2_closure.TerminalMembershipTest.test_a_companion_whose_only_owner_is_spent_is_reported_unowned",
    "test_v2_closure.TerminalMembershipTest.test_a_terminal_member_is_not_a_second_owner_of_a_companion",
    "test_v2_closure.TerminalMembershipTest.test_a_terminal_ticket_being_graded_is_a_member_of_its_own_closure",
@@ -3081,7 +3085,7 @@
    "tests.test_workspace_cases.start_cases.TestTheStampPreservesTheTicketsByteDomain.test_only_the_two_stamped_lines_differ_from_the_prior_bytes",
    "tests.test_workspace_cases.start_cases.TestTicketsPayloadIsGradedNotItsExitStatus.test_an_error_payload_returned_at_exit_zero_is_a_failure"
   ],
-  "sha256": "796797f1526998ee4f9641127073f4b965d24b846410c9b8e1c846f1831c58e3"
+  "sha256": "1ae92f5ca865975051e21df2f804ebe353d0904e2acd3928b70c7d2dbdd345a9"
  },
  "mutation_owners": [
   {

--- a/tests/test_v2_closure.py
+++ b/tests/test_v2_closure.py
@@ -30,6 +30,7 @@ from tests.test_tickets_issue_cases.generation_lifecycle import (  # noqa: E402
 
 CUT_ONE = "v2:cut:00-root:1:sha256:" + "a1" * 32
 CUT_TWO = "v2:cut:00-root:2:sha256:" + "b2" * 32
+ROOT_ONE = "v2:root:00-root:1:sha256:" + "c3" * 32
 
 
 def _body(ticket_id, header, *, mutations, scope, depends, status):
@@ -71,12 +72,14 @@ def v1_ticket(ticket_id, *, mutations=(), scope=(), depends=(), status="pending"
     return _body(ticket_id, header, mutations=mutations, scope=scope, depends=depends, status=status)
 
 
-def v2_ticket(ticket_id, *, mutations=(), scope=(), depends=(), status="pending", cut_generation=None):
+def v2_ticket(ticket_id, *, mutations=(), scope=(), depends=(), status="pending", cut_generation=None, root_generation=None):
     """A v2 ticket: no cohort, and a sealed cut identity only once sealed."""
 
     header = ["admission: v2:pending", "ownership_regions: []"]
     if cut_generation is not None:
         header.append(f"cut_generation: {cut_generation}")
+    if root_generation is not None:
+        header.append(f"root_generation: {root_generation}")
     return _body(ticket_id, header, mutations=mutations, scope=scope, depends=depends, status=status)
 
 
@@ -219,6 +222,79 @@ class TerminalMembershipTest(unittest.TestCase):
         result = grade("00-root.07", members)
         self.assertIn("mutation-outside-write-scope", codes(result))
         self.assertIn("00-root.07.mutations", fields(result))
+
+
+class SealedV2RootMembershipTest(unittest.TestCase):
+    """A sealed cut names its root in the seal, and nowhere else.
+
+    A v1 decomposition stamps every member with ``cohort: v1:root:<id>``, and
+    that prefix was the only place the companion rule looked for the root.  A
+    sealed v2 cut stamps no cohort at all, so the root went unnamed and stayed
+    companion-eligible -- and its whole-subtree plan then covered every
+    companion the cut planned.  Both halves of the rule inverted at once: the
+    lawful shape reported ``scope-owner-multiple`` naming the root beside its
+    own unit, and a companion no unit planned reported nothing at all, because
+    the root looked like its one owner.  Live, that refused admission to every
+    member of a sealed run.  The root here is named by ``root_generation``,
+    not by an executor or an id shape.
+    """
+
+    CONTENT = manifest(edge("change:scripts/feature.py", "change:tests/pins.json"))
+
+    def cut(self, *, unit_owns_companion=True):
+        """A sealed cut: a root planning its whole subtree, and two units."""
+
+        sealed = {"cut_generation": CUT_ONE, "root_generation": ROOT_ONE}
+        members = {
+            "00-root": v2_ticket(
+                "00-root", mutations=["change:scripts/feature.py", "change:tests/pins.json"],
+                scope=["scripts/", "tests/"], **sealed,
+            ),
+            "00-root.05": v2_ticket(
+                "00-root.05", mutations=["change:scripts/feature.py"], scope=["scripts/feature.py"], **sealed,
+            ),
+            "00-root.11": v2_ticket(
+                "00-root.11", mutations=["change:tests/pins.json"], scope=["tests/pins.json"], **sealed,
+            ),
+        }
+        if not unit_owns_companion:
+            del members["00-root.11"]
+        return members
+
+    def test_the_root_of_a_sealed_cut_is_not_a_second_owner_of_a_companion(self):
+        result = grade("00-root.05", self.cut(), self.CONTENT)
+        self.assertNotIn("scope-owner-multiple", codes(result))
+        self.assertNotIn("scope-owner-missing", codes(result))
+
+    def test_a_companion_only_the_sealed_root_plans_is_still_reported_unowned(self):
+        """The other half: excluding the root must not authorize what it plans."""
+
+        result = grade("00-root.05", self.cut(unit_owns_companion=False), self.CONTENT)
+        self.assertIn("scope-owner-missing", codes(result))
+        self.assertNotIn("scope-owner-multiple", codes(result))
+
+    def test_two_units_of_a_sealed_cut_are_still_two_owners(self):
+        """The grader still fires: exit-green is not the rule going quiet."""
+
+        members = self.cut()
+        members["00-root.07"] = v2_ticket(
+            "00-root.07", mutations=["change:tests/pins.json"], scope=["tests/pins.json"],
+            cut_generation=CUT_ONE, root_generation=ROOT_ONE,
+        )
+        result = grade("00-root.05", members, self.CONTENT)
+        self.assertIn("scope-owner-multiple", codes(result))
+        self.assertIn(
+            "change:tests/pins.json owned by 00-root.07, 00-root.11",
+            [item["detail"] for item in result["findings"]],
+        )
+
+    def test_a_sealed_root_standing_alone_still_owns_the_companions_it_plans(self):
+        """Where the cut holds no unit, the whole membership is eligible again."""
+
+        members = {"00-root": self.cut()["00-root"]}
+        result = grade("00-root", members, self.CONTENT)
+        self.assertNotIn("scope-owner-missing", codes(result))
+        self.assertNotIn("scope-owner-multiple", codes(result))
 
 
 class V1GroupingUnchangedTest(unittest.TestCase):


### PR DESCRIPTION
## Summary
- Under a sealed v2 cut, `_companion_owners` resolved the cut root's id only from the `v1:root:` cohort prefix, which v2-sealed members no longer carry — so the root plan was counted as a competing scope owner. Every member of a sealed cut was refused `ready` with `scope-owner-multiple` (and packet emission + post-seal cutcheck failed on the same findings); the inverse half suppressed `scope-owner-missing` where only the root plans a companion.
- `_companion_owners` now receives the graded ticket's frontmatter and falls back to the subject of `root_generation`, matched under the ticket-id charset (`ROOT_GENERATION_SUBJECT_RE`) — never split by colon position.
- Four regression cases in `tests/test_v2_closure.py::SealedV2RootMembershipTest` cover both inverted halves plus two positive controls (grader still fires; over-broad root-drop caught).
- Serial-compat manifest regenerated for the added tests (discovery 3078 → 3082, mutation owners unchanged at 416).

## Provenance
Fix run `20260825T151500Z-tickets-scope-v2-root-exclusion`: symptom reproduced deterministically and independently checked at e6b987ee; cause proven by a one-line toggle with positive controls (two rival hypotheses killed by measurement); repair checked by outside execution and verified at cd54dc0c. All five required checks exit 0 at the tip (tree 2ea7cef29a16).

🤖 Generated with [Claude Code](https://claude.com/claude-code)