### PR TITLE
tickets_scope: a terminal member's spent plan satisfies its companion requirement

### DIFF
--- a/scripts/tickets_scope.py
+++ b/scripts/tickets_scope.py
@@ -49,10 +49,7 @@ def _finding(code, field, detail):
 
 
 def _ordered(findings):
-    rows = {
-        (str(item["code"]), str(item["field"]), str(item["detail"]))
-        for item in findings
-    }
+    rows = {(str(item["code"]), str(item["field"]), str(item["detail"])) for item in findings}
     return [_finding(*row) for row in sorted(rows)]
 
 
@@ -303,7 +300,9 @@ def grade_closure(ticket_id, text, siblings, edges):
     already spent under the authority it was worked with, so counting it here
     reports a finished unit and a pending one as two owners of the one
     companion the pending unit still has to write.  The ticket being graded is
-    always a member: its own plan is the authority under grade.
+    always a member: its own plan is the authority under grade.  A spent plan
+    still answers, though -- what a terminal member planned with a covering
+    mutation is written -- so it is owed by no live member and missing of none.
     """
 
     current = _parse_frontmatter(text)
@@ -314,12 +313,15 @@ def grade_closure(ticket_id, text, siblings, edges):
         for member_id, member_text in member_texts.items()
     }
     key = _closure_key(ticket_id, parsed[ticket_id])
+    cut = {member: data for member, data in parsed.items() if _closure_key(member, data) == key}
     members = {
-        member_id: data
-        for member_id, data in parsed.items()
-        if _closure_key(member_id, data) == key
-        and (member_id == ticket_id or str(data.get("status") or "") not in TERMINAL)
+        member: data for member, data in cut.items()
+        if member == ticket_id or str(data.get("status") or "") not in TERMINAL
     }
+    spent = tuple(
+        (item["operation"], item["path"]) for member, data in cut.items()
+        if member not in members for item in parse_mutations(data)[0]
+    )
     findings, plans, authorized = [], {}, {}
     for member_id in sorted(members):
         data = members[member_id]
@@ -378,7 +380,8 @@ def grade_closure(ticket_id, text, siblings, edges):
         owners[required] = node_owners
         rendered = f"{required[0]}:{required[1]}"
         if not node_owners:
-            findings.append(_finding("scope-owner-missing", "mutations", rendered))
+            if not any(_plan_covers(plan, required) for plan in spent):
+                findings.append(_finding("scope-owner-missing", "mutations", rendered))
             continue
         if len(node_owners) > 1:
             findings.append(_finding(
@@ -504,6 +507,4 @@ def grade_scope(*, ticket_id, text, siblings, adapter_id, context=None):
     }
 
 
-__all__ = (
-    "MANIFEST_PATH", "parse_manifest", "path_covers", "unplanned_mutations", "grade_closure", "grade_scope",
-)
+__all__ = ("MANIFEST_PATH", "parse_manifest", "path_covers", "unplanned_mutations", "grade_closure", "grade_scope")

--- a/tests/serial_compat_manifest.json
+++ b/tests/serial_compat_manifest.json
@@ -1,6 +1,6 @@
 {
  "discovery": {
-  "count": 3082,
+  "count": 3086,
   "identities": [
    "test_affected_tests.TestDiscoveryCache.test_a_new_commit_is_a_new_key_and_is_discovered_again",
    "test_affected_tests.TestDiscoveryCache.test_a_tree_that_cannot_answer_for_a_commit_falls_back_and_says_so",
@@ -852,10 +852,14 @@
    "test_v2_closure.SealedV2RootMembershipTest.test_a_sealed_root_standing_alone_still_owns_the_companions_it_plans",
    "test_v2_closure.SealedV2RootMembershipTest.test_the_root_of_a_sealed_cut_is_not_a_second_owner_of_a_companion",
    "test_v2_closure.SealedV2RootMembershipTest.test_two_units_of_a_sealed_cut_are_still_two_owners",
-   "test_v2_closure.TerminalMembershipTest.test_a_companion_whose_only_owner_is_spent_is_reported_unowned",
+   "test_v2_closure.TerminalMembershipTest.test_a_companion_no_member_planned_is_still_reported_unowned",
+   "test_v2_closure.TerminalMembershipTest.test_a_companion_whose_only_owner_is_spent_is_satisfied_not_unowned",
    "test_v2_closure.TerminalMembershipTest.test_a_terminal_member_is_not_a_second_owner_of_a_companion",
    "test_v2_closure.TerminalMembershipTest.test_a_terminal_ticket_being_graded_is_a_member_of_its_own_closure",
    "test_v2_closure.TerminalMembershipTest.test_two_live_members_are_still_two_owners",
+   "test_v2_closure.TerminalSatisfactionTest.test_a_companion_no_member_ever_planned_is_still_reported_unowned",
+   "test_v2_closure.TerminalSatisfactionTest.test_a_terminal_members_spent_plan_satisfies_the_companion_it_covers",
+   "test_v2_closure.TerminalSatisfactionTest.test_two_live_planners_are_still_two_owners_beside_a_terminal_one",
    "test_v2_closure.V1GroupingUnchangedTest.test_a_member_of_another_cohort_stays_outside_the_closure",
    "test_v2_closure.V1GroupingUnchangedTest.test_a_stamped_cohort_still_groups_a_ticket_that_also_carries_a_cut",
    "test_v2_closure.V1GroupingUnchangedTest.test_cohortless_v1_members_group_exactly_as_they_did",
@@ -3085,7 +3089,7 @@
    "tests.test_workspace_cases.start_cases.TestTheStampPreservesTheTicketsByteDomain.test_only_the_two_stamped_lines_differ_from_the_prior_bytes",
    "tests.test_workspace_cases.start_cases.TestTicketsPayloadIsGradedNotItsExitStatus.test_an_error_payload_returned_at_exit_zero_is_a_failure"
   ],
-  "sha256": "1ae92f5ca865975051e21df2f804ebe353d0904e2acd3928b70c7d2dbdd345a9"
+  "sha256": "fe67ca66f15ee32fab2da2f840c09135a3a1cdc5563b8d0c6713ce87cb6dc382"
  },
  "mutation_owners": [
   {

--- a/tests/test_v2_closure.py
+++ b/tests/test_v2_closure.py
@@ -1,12 +1,15 @@
 """Closure membership: which tickets one mutation plan is graded against.
 
-Two reproducers drive this module.  The first is checker-opus-02's, filed on
+Three reproducers drive this module.  The first is checker-opus-02's, filed on
 ticket 00-root.02: once v2 tickets stamp no cohort, every cohortless ticket in
 a run reads the same empty cohort string, collapses into one closure, and each
 member inherits every other member's mutation findings.  The second is live in
 this repository's own run -- a terminal member's spent plan still counted as a
 companion owner, so a completed unit and a pending one were reported as two
-owners of the same required node.
+owners of the same required node.  The third is the tail of that same ruling,
+live in run 20260825T143105Z: excluding the spent plan from ownership was read
+as leaving what it wrote unowned, and a sealed cut clean at seal became
+unadmittable once its companion planner finished.
 """
 
 from __future__ import annotations
@@ -197,20 +200,33 @@ class TerminalMembershipTest(unittest.TestCase):
             [item["detail"] for item in result["findings"]],
         )
 
-    def test_a_companion_whose_only_owner_is_spent_is_reported_unowned(self):
-        """The other face of the ruling, so the join is not surprised by it.
+    def test_a_companion_whose_only_owner_is_spent_is_satisfied_not_unowned(self):
+        """Superseded: this case once asserted ``scope-owner-missing`` here.
 
-        Excluding a terminal member does not quietly authorize the node it
-        used to own.  Where the cut planned exactly one owner and that unit
-        has gone terminal, the companion the live member still triggers has
-        no owner left in the closure, and the grade says so.
+        Excluding a terminal member from ownership was read as leaving the
+        node it used to own unowned, and live in run 20260825T143105Z that
+        refused admission to every remaining member of a sealed cut over a
+        file the terminal unit had already written.  The exclusion answers
+        double-owner noise, not finished work: the spent plan satisfies the
+        requirement it covers, and its planner still joins no owner set.  The
+        guard against quiet authorization survives one case down -- a node no
+        member ever planned is still reported unowned.
         """
 
         members = self.companions("complete")
         del members["00-root.11"]
         result = grade("00-root.05", members, self.CONTENT)
-        self.assertIn("scope-owner-missing", codes(result))
+        self.assertNotIn("scope-owner-missing", codes(result))
         self.assertNotIn("scope-owner-multiple", codes(result))
+
+    def test_a_companion_no_member_planned_is_still_reported_unowned(self):
+        """Nothing spent and nothing live: the exclusion authorizes nothing."""
+
+        members = self.companions("complete")
+        del members["00-root.07"]
+        del members["00-root.11"]
+        result = grade("00-root.05", members, self.CONTENT)
+        self.assertIn("scope-owner-missing", codes(result))
 
     def test_a_terminal_ticket_being_graded_is_a_member_of_its_own_closure(self):
         members = {
@@ -295,6 +311,82 @@ class SealedV2RootMembershipTest(unittest.TestCase):
         result = grade("00-root", members, self.CONTENT)
         self.assertNotIn("scope-owner-missing", codes(result))
         self.assertNotIn("scope-owner-multiple", codes(result))
+
+
+class TerminalSatisfactionTest(unittest.TestCase):
+    """A spent plan is not authority, and it is still work that happened.
+
+    Live in run 20260825T143105Z: the sealed root planned ``write:scripts/``,
+    which closes the repository's own ``create:scripts/*.py`` edge onto
+    ``change:ARCHITECTURE.md``; the one unit that planned that companion went
+    ``complete``, left the closure with the terminal filter, and every
+    remaining member was then refused admission for ``scope-owner-missing``
+    on a file that was already written.  A sealed cut admission-clean at seal
+    became unadmittable at its tail, and the v2 reseal vantage refuses a cut
+    holding claimed or terminal members, so nothing in-run could correct it.
+    The terminal member stays out of ownership -- it is no second owner, no
+    ancestry owner, and never named in a finding -- and its plan alone
+    answers the requirement it covers.
+    """
+
+    CONTENT = manifest(edge("create:scripts/*.py", "change:ARCHITECTURE.md"))
+    SEALED = {"cut_generation": CUT_ONE, "root_generation": ROOT_ONE}
+
+    def cut(self, *, planner="00-root.03", planner_status="complete", second_planner=None):
+        """The live shape: a sealed root, a companion planner, a live unit."""
+
+        members = {
+            "00-root": v2_ticket(
+                "00-root", mutations=["write:scripts/", "change:ARCHITECTURE.md"],
+                scope=["scripts/", "ARCHITECTURE.md"], **self.SEALED,
+            ),
+            "00-root.06": v2_ticket(
+                "00-root.06", mutations=["change:scripts/nowview.py"],
+                scope=["scripts/nowview.py"], **self.SEALED,
+            ),
+        }
+        for member_id, status in ((planner, planner_status), (second_planner, "pending")):
+            if member_id:
+                members[member_id] = v2_ticket(
+                    member_id, mutations=["change:ARCHITECTURE.md"],
+                    scope=["ARCHITECTURE.md"], status=status, **self.SEALED,
+                )
+        return members
+
+    def test_a_terminal_members_spent_plan_satisfies_the_companion_it_covers(self):
+        for status in ("complete", "limited"):
+            with self.subTest(status=status):
+                result = grade("00-root.06", self.cut(planner_status=status), self.CONTENT)
+                self.assertNotIn("scope-owner-missing", codes(result))
+                self.assertNotIn("scope-owner-multiple", codes(result))
+                self.assertEqual([], [
+                    item for item in result["findings"] if "00-root.03" in item["detail"]
+                ])
+
+    def test_a_companion_no_member_ever_planned_is_still_reported_unowned(self):
+        """Nothing spent, nothing live: the requirement still has no owner."""
+
+        result = grade("00-root.06", self.cut(planner=None), self.CONTENT)
+        self.assertIn("scope-owner-missing", codes(result))
+        self.assertIn(
+            "change:ARCHITECTURE.md",
+            [item["detail"] for item in result["findings"]],
+        )
+
+    def test_two_live_planners_are_still_two_owners_beside_a_terminal_one(self):
+        """The terminal plan satisfies; it never joins an owner set."""
+
+        members = self.cut(second_planner="00-root.07")
+        members["00-root.08"] = v2_ticket(
+            "00-root.08", mutations=["change:ARCHITECTURE.md"],
+            scope=["ARCHITECTURE.md"], **self.SEALED,
+        )
+        result = grade("00-root.06", members, self.CONTENT)
+        self.assertIn("scope-owner-multiple", codes(result))
+        self.assertIn(
+            "change:ARCHITECTURE.md owned by 00-root.07, 00-root.08",
+            [item["detail"] for item in result["findings"]],
+        )
 
 
 class V1GroupingUnchangedTest(unittest.TestCase):


### PR DESCRIPTION
## Summary
- `grade_closure` excluded terminal members from a cut's closure while still seeding companion requirements from every member's plan, including the root's broad plan. Once the only unit owning a companion completed, the standing root plan re-fired the requirement with no eligible owner: a sealed v2 cut that was admission-clean at seal became unadmittable at its tail (`scope-owner-missing`), and the v2 reseal wall blocks in-run correction. Reproduced live in run 20260825T143105Z-now-page-redesign at 00-root.06.
- Fix (satisfaction-side, seeding untouched): the dropped terminal members' parsed plans are collected as spent plans, and `scope-owner-missing` is suppressed exactly when a spent plan covers the required node. Terminal members never enter owner sets, so `scope-owner-multiple`/`unauthorized`/`unordered` and the ancestry walk are unchanged — including PR #92's regression cases, byte-unamended and green.
- New `TerminalSatisfactionTest` (red at base on the satisfaction case, green after); one pre-existing case that pinned the removed behavior amended in place with its no-quiet-authorization guard preserved. Serial manifest regenerated (3082 → 3086, owners 416).

## Provenance
Single-ticket run `20260825T171500Z-tickets-scope-terminal-satisfaction`, executor orch-tdd, independently checked (adversarial re-run of all four oracles). All five required checks exit 0 at the tip (tree 39dd90a5c564). Module at exactly 510/510 — the next change must factor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)