### PR TITLE
tickets_scope: spent cover satisfies fallback-shape co-ownership findings

### DIFF
--- a/scripts/tickets_scope.py
+++ b/scripts/tickets_scope.py
@@ -273,8 +273,8 @@ def _companion_owners(data, members):
     plans. Counting them would report the lawful shape -- one unit owning the
     companion -- as several owners, and the shape with no unit owner as owned.
     Where the cut holds no unit at all the whole membership is eligible again,
-    so a root graded alone still owns the companions it plans -- and a root
-    with only gate stubs is read exactly as it was, several owners and all.
+    so a root graded alone still owns what it plans.  That reinstatement is
+    reported beside the set: only there is an owner pair the umbrella itself.
 
     A v1 decomposition stamps every member with the root's cohort; a sealed v2
     cut stamps none and freezes the root in ``root_generation`` instead, so
@@ -290,7 +290,7 @@ def _companion_owners(data, members):
         member_id for member_id in members
         if member_id != root_id and GATE_INFIX not in member_id
     }
-    return units or set(members)
+    return (units, False) if units else (set(members), True)
 
 
 def grade_closure(ticket_id, text, siblings, edges):
@@ -302,7 +302,8 @@ def grade_closure(ticket_id, text, siblings, edges):
     companion the pending unit still has to write.  The ticket being graded is
     always a member: its own plan is the authority under grade.  A spent plan
     still answers, though -- what a terminal member planned with a covering
-    mutation is written -- so it is owed by no live member and missing of none.
+    mutation is written -- so it is missing of none; and where only the
+    umbrella fallback owns it, several owners is that umbrella, not a conflict.
     """
 
     current = _parse_frontmatter(text)
@@ -344,7 +345,7 @@ def grade_closure(ticket_id, text, siblings, edges):
                 ))
 
     owners = {}
-    eligible = _companion_owners(current, plans)
+    eligible, fallback = _companion_owners(current, plans)
     initial = set()
     for member_id, nodes in plans.items():
         for node in nodes:
@@ -379,15 +380,14 @@ def grade_closure(ticket_id, text, siblings, edges):
         }
         owners[required] = node_owners
         rendered = f"{required[0]}:{required[1]}"
+        if any(_plan_covers(plan, required) for plan in spent) and (fallback or not node_owners):
+            continue
         if not node_owners:
-            if not any(_plan_covers(plan, required) for plan in spent):
-                findings.append(_finding("scope-owner-missing", "mutations", rendered))
+            findings.append(_finding("scope-owner-missing", "mutations", rendered))
             continue
         if len(node_owners) > 1:
-            findings.append(_finding(
-                "scope-owner-multiple", "mutations",
-                f"{rendered} owned by {', '.join(sorted(node_owners))}",
-            ))
+            detail = f"{rendered} owned by {', '.join(sorted(node_owners))}"
+            findings.append(_finding("scope-owner-multiple", "mutations", detail))
             continue
         owner = next(iter(node_owners))
         matching = [plan for plan in plans[owner] if _plan_covers(plan, required)]

--- a/tests/serial_compat_manifest.json
+++ b/tests/serial_compat_manifest.json
@@ -1,6 +1,6 @@
 {
  "discovery": {
-  "count": 3086,
+  "count": 3088,
   "identities": [
    "test_affected_tests.TestDiscoveryCache.test_a_new_commit_is_a_new_key_and_is_discovered_again",
    "test_affected_tests.TestDiscoveryCache.test_a_tree_that_cannot_answer_for_a_commit_falls_back_and_says_so",
@@ -847,6 +847,8 @@
    "test_v2_closure.CohortlessV2MembershipTest.test_a_v2_ticket_still_grades_its_own_plan",
    "test_v2_closure.CohortlessV2MembershipTest.test_one_sealed_cut_is_still_one_closure",
    "test_v2_closure.CohortlessV2MembershipTest.test_v2_tickets_with_distinct_cut_generations_grade_independently",
+   "test_v2_closure.GatePhaseSatisfactionTest.test_a_gate_stub_is_admitted_over_a_companion_a_spent_unit_wrote",
+   "test_v2_closure.GatePhaseSatisfactionTest.test_without_spent_cover_the_fallbacks_several_owners_are_still_reported",
    "test_v2_closure.ReproducerAtTheAdmissionGradeTest.test_a_lawful_v2_ticket_is_admitted_beside_a_defective_sibling",
    "test_v2_closure.SealedV2RootMembershipTest.test_a_companion_only_the_sealed_root_plans_is_still_reported_unowned",
    "test_v2_closure.SealedV2RootMembershipTest.test_a_sealed_root_standing_alone_still_owns_the_companions_it_plans",
@@ -3089,7 +3091,7 @@
    "tests.test_workspace_cases.start_cases.TestTheStampPreservesTheTicketsByteDomain.test_only_the_two_stamped_lines_differ_from_the_prior_bytes",
    "tests.test_workspace_cases.start_cases.TestTicketsPayloadIsGradedNotItsExitStatus.test_an_error_payload_returned_at_exit_zero_is_a_failure"
   ],
-  "sha256": "fe67ca66f15ee32fab2da2f840c09135a3a1cdc5563b8d0c6713ce87cb6dc382"
+  "sha256": "0ca54c53b3ec8e8881aaa9cd895f3906730c7ef6597ff84e859967b7fe89b864"
  },
  "mutation_owners": [
   {

--- a/tests/test_v2_closure.py
+++ b/tests/test_v2_closure.py
@@ -1,6 +1,6 @@
 """Closure membership: which tickets one mutation plan is graded against.
 
-Three reproducers drive this module.  The first is checker-opus-02's, filed on
+Four reproducers drive this module.  The first is checker-opus-02's, filed on
 ticket 00-root.02: once v2 tickets stamp no cohort, every cohortless ticket in
 a run reads the same empty cohort string, collapses into one closure, and each
 member inherits every other member's mutation findings.  The second is live in
@@ -9,7 +9,10 @@ companion owner, so a completed unit and a pending one were reported as two
 owners of the same required node.  The third is the tail of that same ruling,
 live in run 20260825T143105Z: excluding the spent plan from ownership was read
 as leaving what it wrote unowned, and a sealed cut clean at seal became
-unadmittable once its companion planner finished.
+unadmittable once its companion planner finished.  The fourth is that ruling's
+own tail, live in the gate phase of the same run: with every unit terminal the
+companion fallback reinstates the root and its gate stubs, and the spent cover
+that silenced the missing branch did not reach the several-owners one.
 """
 
 from __future__ import annotations
@@ -385,6 +388,64 @@ class TerminalSatisfactionTest(unittest.TestCase):
         self.assertIn("scope-owner-multiple", codes(result))
         self.assertIn(
             "change:ARCHITECTURE.md owned by 00-root.07, 00-root.08",
+            [item["detail"] for item in result["findings"]],
+        )
+
+
+class GatePhaseSatisfactionTest(unittest.TestCase):
+    """The tail of the same ruling, one branch over: several surviving owners.
+
+    Live in the gate phase of run 20260825T143105Z, with every unit terminal:
+    ``_companion_owners`` finds no live unit, its fallback reinstates the whole
+    membership, and the root and its gate stubs -- which plan the subtree and
+    repair anywhere in it -- are read as two owners of a companion a finished
+    unit had already written.  Every gate ticket was refused admission over
+    work that was done.  Suppressing only ``scope-owner-missing`` on spent
+    cover left this branch firing, so spent cover now answers the owner-count
+    branches too -- but only where the fallback fired, which
+    ``_companion_owners`` reports beside its set.  Two live units planning one
+    companion are a conflict whatever a finished member wrote, and
+    ``TerminalSatisfactionTest`` keeps that case.  Eligibility is untouched.
+    """
+
+    CONTENT = manifest(edge("create:scripts/*.py", "change:ARCHITECTURE.md"))
+    SEALED = {"cut_generation": CUT_ONE, "root_generation": ROOT_ONE}
+    COMPANION = "change:ARCHITECTURE.md"
+
+    def cut(self, *, terminal_unit_plans_companion=True):
+        """A sealed cut at its gate: root, one spent unit, one gate stub."""
+
+        spent_plan = self.COMPANION if terminal_unit_plans_companion else "change:scripts/nowview.py"
+        return {
+            "00-root": v2_ticket(
+                "00-root", mutations=["write:scripts/", self.COMPANION],
+                scope=["scripts/", "ARCHITECTURE.md"], **self.SEALED,
+            ),
+            "00-root.03": v2_ticket(
+                "00-root.03", mutations=[spent_plan], scope=[spent_plan.split(":", 1)[1]],
+                status="complete", **self.SEALED,
+            ),
+            "00-root.gate.repair": v2_ticket(
+                "00-root.gate.repair", mutations=[self.COMPANION],
+                scope=["ARCHITECTURE.md"], **self.SEALED,
+            ),
+        }
+
+    def test_a_gate_stub_is_admitted_over_a_companion_a_spent_unit_wrote(self):
+        result = grade("00-root.gate.repair", self.cut(), self.CONTENT)
+        self.assertNotIn("scope-owner-multiple", codes(result))
+        self.assertNotIn("scope-owner-missing", codes(result))
+        self.assertEqual([], [
+            item for item in result["findings"] if self.COMPANION in item["detail"]
+        ])
+
+    def test_without_spent_cover_the_fallbacks_several_owners_are_still_reported(self):
+        """The suppression demands spent cover; it is not the branch going quiet."""
+
+        result = grade("00-root.gate.repair", self.cut(terminal_unit_plans_companion=False), self.CONTENT)
+        self.assertIn("scope-owner-multiple", codes(result))
+        self.assertIn(
+            f"{self.COMPANION} owned by 00-root, 00-root.gate.repair",
             [item["detail"] for item in result["findings"]],
         )
 


### PR DESCRIPTION
## Summary
- Third member of the companion-grading family: at a cut's gate phase every unit is terminal, so `_companion_owners`' units-empty fallback reinstates the whole membership — and the root plus the gate-repair stub read as co-owners of companions that finished units already delivered (`scope-owner-multiple`), refusing every gate ticket's admission. Reproduced live in run 20260825T143105Z-now-page-redesign.
- Fix: `_companion_owners` now returns `(eligible, fallback)` — eligibility byte-identical, only the arity changed — and `grade_closure`'s spent test becomes `(fallback or not node_owners)`: the missing-branch suppression from PR #93 stays unconditional, while multiple/unauthorized/ancestry are suppressed only when the fallback fired AND a terminal member's spent plan covers the node. Two live planners of one companion stay reported regardless of spent cover.
- New `GatePhaseSatisfactionTest`: the gate-phase satisfaction case (red at base, green after) plus a control proving the suppression demands spent cover. Keep-list (PR #92 + #93 cases, v1/v0 parity) unamended by construction — the test-file diff removes exactly two docstring lines. Serial manifest regenerated (3086 → 3088, owners 416).

## Provenance
Single-ticket run `20260825T184500Z-tickets-scope-spent-multiple`, orch-tdd under an explicit caller disposition (R2: fallback-gated suppression; the blanket alternative was rejected for retiring a real guard). Independently checked by outside execution of all four oracles at 90890e78. All five required checks exit 0 at the tip (tree 23250b2c6196). Both changed files now sit at exactly the 510-line ceiling — the next change to either must factor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)