### PR TITLE
Expose orch-investigate in the Codex install catalog

### DIFF
--- a/install.py
+++ b/install.py
@@ -27,10 +27,10 @@ the installer warns and exits successfully without writing anything.
   and referenced from ``~/.claude/CLAUDE.md`` by one appended ``@<path>``
   import line — idempotent, migrating any legacy inline marker block found
   there from an older install.
-- Codex (when a Codex CLI is on ``PATH``): prompts, four redirect skill stubs
+- Codex (when a Codex CLI is on ``PATH``): prompts, five redirect skill stubs
   (``~/.codex/skills/<name>/SKILL.md`` for ``orch-spec``,
-  ``orch-frontier``, ``fix``, ``orch-build``) that point at the library
-  instead of
+  ``orch-frontier``, ``fix``, ``orch-build``, ``orch-investigate``) that
+  point at the library instead of
   duplicating it, role agents, agent-limits config. ``CODEX_HOME`` replaces
   ``~/.codex`` throughout, matching the CLI. The always-on layer
   stays an inline marker block upserted into ``~/.codex/AGENTS.md`` — a

--- a/installer/foundation.py
+++ b/installer/foundation.py
@@ -46,12 +46,11 @@ HOST_BLOCK_TEMPLATE = REPO_ROOT / "templates" / "host-block.md"
 CODEX_LIMITS_START = "# BEGIN ORCHFLOWS AGENT LIMITS"
 CODEX_LIMITS_END = "# END ORCHFLOWS AGENT LIMITS"
 PROFILE_ROLES = ("planner", "worker")
-# The four names both hosts expose as first-class adapters; every other
-# name resolves at ``by-name/``. The routed composition ``fix`` replaced the
-# demoted ``orch-fix`` skill.
+# The four names exposed by Claude's bounded adapter set. The routed
+# composition ``fix`` replaced the demoted ``orch-fix`` skill.
 SHARED_ADAPTER_NAMES = ("orch-spec", "orch-frontier", "fix", "orch-build")
-# The Codex redirect set is that same set, under its older name.
-CODEX_SKILL_REDIRECT_NAMES = SHARED_ADAPTER_NAMES
+# Codex also exposes its investigation worker as a first-class callable skill.
+CODEX_SKILL_REDIRECT_NAMES = SHARED_ADAPTER_NAMES + ("orch-investigate",)
 CLAUDE_ADAPTER_SETS = ("all", "four")
 AUTO_REMOVE_KINDS = frozenset(("adapter", "prompt", "codex-skill", "frontend-asset"))
 CODEX_MAX_THREADS = 20

--- a/tests/serial_compat_manifest.json
+++ b/tests/serial_compat_manifest.json
@@ -196,7 +196,7 @@
    "test_installer.TestClaudeAdapterSet.test_the_parser_accepts_the_two_sets_and_refuses_any_other",
    "test_installer.TestClaudeAdapterSet.test_the_plan_count_and_printout_follow_the_adapter_set",
    "test_installer.TestClaudeAdapterSet.test_the_receipt_records_only_the_minted_adapters",
-   "test_installer.TestClaudeAdapterSet.test_the_shared_four_names_the_set_both_hosts_expose",
+   "test_installer.TestClaudeAdapterSet.test_the_shared_four_and_codex_redirect_names_are_explicit",
    "test_installer.TestClaudeAlwaysOnImport.test_apply_migrates_legacy_inline_block_in_claude_md",
    "test_installer.TestClaudeAlwaysOnImport.test_apply_writes_host_block_file_and_appends_import_line",
    "test_installer.TestClaudeAlwaysOnImport.test_reapply_does_not_duplicate_import_line",
@@ -301,7 +301,7 @@
    "test_installer.TestScopedHostConfiguration.test_template_surfaces_cover_every_entry_value",
    "test_installer.TestScopedHostConfiguration.test_user_plan_merges_limits_and_writes_native_role_agents",
    "test_installer.TestScopedHostConfiguration.test_user_plan_targets_user_config_and_agent_directories",
-   "test_installer.TestScopedHostConfiguration.test_user_plan_writes_claude_adapters_and_four_codex_skill_stubs",
+   "test_installer.TestScopedHostConfiguration.test_user_plan_writes_claude_adapters_and_codex_skill_stubs",
    "test_installer.TestScopedHostConfiguration.test_user_plan_writes_flat_by_name_index_for_every_package",
    "test_installer.TestScriptNames.test_build_plan_installs_every_managed_script_with_matching_content",
    "test_installer.TestScriptNames.test_build_plan_ships_doclint_the_documentation_oracle",
@@ -611,6 +611,7 @@
    "test_serial_compat_hardening.TestManifestHardening.test_only_observed_intentional_residue_is_allowlisted",
    "test_serial_compat_hardening.TestManifestHardening.test_required_fidelity_category_cannot_be_silently_removed",
    "test_serial_compat_hardening.TestStateBoundaryDiscrimination.test_each_process_seam_is_detected_and_restorable_seams_are_restored",
+   "test_serial_compat_manifest_regression.TestCodexRedirectManifestRegression.test_the_codex_redirect_test_identities_stay_serial_compatible",
    "test_serial_manifest.TestCommittedManifest.test_every_committed_owner_still_carries_its_restoration",
    "test_serial_manifest.TestCommittedManifest.test_the_committed_bytes_are_exactly_what_regeneration_would_write",
    "test_serial_manifest.TestRegeneration.test_a_prior_owner_keeps_its_restoration_and_a_new_owner_has_none",
@@ -4186,7 +4187,7 @@
   },
   {
    "module": "tests.test_installer_cases.planning.scoped_hosts",
-   "owner": "TestScopedHostConfiguration.test_user_plan_writes_claude_adapters_and_four_codex_skill_stubs",
+   "owner": "TestScopedHostConfiguration.test_user_plan_writes_claude_adapters_and_codex_skill_stubs",
    "restoration": "sharded-module-guard",
    "seams": [
     "monkeypatch"

--- a/tests/serial_compat_manifest.json
+++ b/tests/serial_compat_manifest.json
@@ -1,6 +1,6 @@
 {
  "discovery": {
-  "count": 3086,
+  "count": 3088,
   "identities": [
    "test_affected_tests.TestDiscoveryCache.test_a_new_commit_is_a_new_key_and_is_discovered_again",
    "test_affected_tests.TestDiscoveryCache.test_a_tree_that_cannot_answer_for_a_commit_falls_back_and_says_so",
@@ -3091,7 +3091,7 @@
    "tests.test_workspace_cases.start_cases.TestTheStampPreservesTheTicketsByteDomain.test_only_the_two_stamped_lines_differ_from_the_prior_bytes",
    "tests.test_workspace_cases.start_cases.TestTicketsPayloadIsGradedNotItsExitStatus.test_an_error_payload_returned_at_exit_zero_is_a_failure"
   ],
-  "sha256": "fe67ca66f15ee32fab2da2f840c09135a3a1cdc5563b8d0c6713ce87cb6dc382"
+  "sha256": "919d7aade9422d75bd940f5f5276ba050462207e6cffd9b6aff0bba21d7545bc"
  },
  "mutation_owners": [
   {

--- a/tests/serial_compat_manifest.json
+++ b/tests/serial_compat_manifest.json
@@ -191,6 +191,7 @@
    "test_installer.TestClaudeAdapterSet.test_all_is_the_default_and_mints_every_package_and_template",
    "test_installer.TestClaudeAdapterSet.test_four_changes_nothing_but_the_claude_adapter_list",
    "test_installer.TestClaudeAdapterSet.test_four_mints_exactly_the_four_shared_adapters",
+   "test_installer.TestClaudeAdapterSet.test_installer_description_says_codex_writes_five_redirect_stubs",
    "test_installer.TestClaudeAdapterSet.test_the_cli_defaults_to_all_and_carries_four_into_the_plan",
    "test_installer.TestClaudeAdapterSet.test_the_four_adapters_carry_the_same_content_they_carry_under_all",
    "test_installer.TestClaudeAdapterSet.test_the_parser_accepts_the_two_sets_and_refuses_any_other",

--- a/tests/test_installer_cases/planning/runtime.py
+++ b/tests/test_installer_cases/planning/runtime.py
@@ -154,14 +154,15 @@ class TestClaudeAdapterSet(unittest.TestCase):
     def _names(pairs):
         return {dest.parent.name for dest, _ in pairs}
 
-    def test_the_shared_four_names_the_set_both_hosts_expose(self):
+    def test_the_shared_four_and_codex_redirect_names_are_explicit(self):
         self.assertEqual(
             ("orch-spec", "orch-frontier", "fix", "orch-build"),
             install.SHARED_ADAPTER_NAMES,
         )
-        # The Codex redirect set and the Claude four-adapter set are one set,
-        # not two tuples that happen to agree today.
-        self.assertIs(install.SHARED_ADAPTER_NAMES, install.CODEX_SKILL_REDIRECT_NAMES)
+        self.assertEqual(
+            (*install.SHARED_ADAPTER_NAMES, "orch-investigate"),
+            install.CODEX_SKILL_REDIRECT_NAMES,
+        )
 
     def test_four_mints_exactly_the_four_shared_adapters(self):
         plan = self._plan("four")

--- a/tests/test_installer_cases/planning/runtime.py
+++ b/tests/test_installer_cases/planning/runtime.py
@@ -164,6 +164,16 @@ class TestClaudeAdapterSet(unittest.TestCase):
             install.CODEX_SKILL_REDIRECT_NAMES,
         )
 
+    def test_installer_description_says_codex_writes_five_redirect_stubs(self):
+        description = install.__doc__ or ""
+        _, separator, codex_description = description.partition("- Codex ")
+        self.assertTrue(separator, "Codex description paragraph is missing")
+        codex_description = codex_description.partition("\n\n")[0]
+        self.assertIn("five redirect skill stubs", codex_description)
+        self.assertNotIn("four redirect skill stubs", codex_description)
+        for redirect_name in install.CODEX_SKILL_REDIRECT_NAMES:
+            self.assertIn(f"``{redirect_name}``", codex_description)
+
     def test_four_mints_exactly_the_four_shared_adapters(self):
         plan = self._plan("four")
         self.assertEqual(set(install.SHARED_ADAPTER_NAMES), self._names(plan.claude_adapters))

--- a/tests/test_installer_cases/planning/scoped_hosts.py
+++ b/tests/test_installer_cases/planning/scoped_hosts.py
@@ -147,7 +147,7 @@ class TestScopedHostConfiguration(unittest.TestCase):
                 self.assertIn(parsed["name"], {"orch_planner", "orch_worker"})
                 self.assertIn("developer_instructions", parsed)
 
-    def test_user_plan_writes_claude_adapters_and_four_codex_skill_stubs(self):
+    def test_user_plan_writes_claude_adapters_and_codex_skill_stubs(self):
         with tempfile.TemporaryDirectory() as tmp:
             home = Path(tmp)
             (home / ".claude").mkdir(parents=True)
@@ -210,6 +210,10 @@ class TestScopedHostConfiguration(unittest.TestCase):
             }
             self.assertEqual(
                 expected_stub_names,
+                {dest.parent.name for dest, _ in plan.codex_skills},
+            )
+            self.assertEqual(
+                {*install.SHARED_ADAPTER_NAMES, "orch-investigate"},
                 {dest.parent.name for dest, _ in plan.codex_skills},
             )
             for dest, content in plan.codex_skills:

--- a/tests/test_serial_compat_manifest_regression.py
+++ b/tests/test_serial_compat_manifest_regression.py
@@ -1,0 +1,55 @@
+"""Regression pin for installer test identities in the serial manifest."""
+
+from __future__ import annotations
+
+import json
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parent.parent
+MANIFEST = ROOT / "tests" / "serial_compat_manifest.json"
+
+
+class TestCodexRedirectManifestRegression(unittest.TestCase):
+    def test_the_codex_redirect_test_identities_stay_serial_compatible(self):
+        manifest = json.loads(MANIFEST.read_text(encoding="utf-8"))
+        identities = set(manifest["discovery"]["identities"])
+
+        self.assertIn(
+            "test_installer.TestClaudeAdapterSet."
+            "test_the_shared_four_and_codex_redirect_names_are_explicit",
+            identities,
+        )
+        self.assertIn(
+            "test_installer.TestScopedHostConfiguration."
+            "test_user_plan_writes_claude_adapters_and_codex_skill_stubs",
+            identities,
+        )
+
+        scoped_host_owners = [
+            owner
+            for owner in manifest["mutation_owners"]
+            if owner["module"] == "tests.test_installer_cases.planning.scoped_hosts"
+            and owner["owner"].startswith(
+                "TestScopedHostConfiguration.test_user_plan_writes_claude_adapters"
+            )
+        ]
+        self.assertEqual(
+            [
+                {
+                    "module": "tests.test_installer_cases.planning.scoped_hosts",
+                    "owner": (
+                        "TestScopedHostConfiguration."
+                        "test_user_plan_writes_claude_adapters_and_codex_skill_stubs"
+                    ),
+                    "restoration": "sharded-module-guard",
+                    "seams": ["monkeypatch"],
+                }
+            ],
+            scoped_host_owners,
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Delivers the already verified orch-investigate redirect repair and regression pins. The serial compatibility manifest was regenerated after integrating the current main branch.