### PR TITLE
Version is the root's property: one divergence law, a version-aware gate

### DIFF
--- a/scripts/tickets_context.py
+++ b/scripts/tickets_context.py
@@ -17,12 +17,14 @@ from __future__ import annotations
 from pathlib import Path
 if __package__:
     from .tickets_admission import grade_admission
-    from .tickets_format import _read_utf8
+    from .tickets_format import _parse_frontmatter, _read_utf8
     from .tickets_store import _runs_root
+    from .tickets_transitions import declared_version, pending_admission, version_divergence
 else:
     from tickets_admission import grade_admission
-    from tickets_format import _read_utf8
+    from tickets_format import _parse_frontmatter, _read_utf8
     from tickets_store import _runs_root
+    from tickets_transitions import declared_version, pending_admission, version_divergence
 
 
 def grader_context(run) -> dict:
@@ -55,9 +57,31 @@ def run_snapshot(run_dir):
 
 
 def graded_admission(ticket_id: str, text: str, siblings, run) -> dict:
-    """Grade one snapshot through the one context, for all four callers."""
-    return grade_admission(ticket_id, text, dict(siblings or {}),
-                           context=grader_context(run))
+    """Grade one snapshot through the one context, for all four callers.
+
+    The version-divergence grade lives here rather than in the pure grader
+    because it is the context's own question: a member against the root of
+    the run it stands in. `grade_admission` branches on the member's bytes
+    alone, so a self-consistent member at the wrong version grades clean
+    down its own path -- the recorded instance -- and only this door, which
+    every grading and emitting site shares, holds both tickets at once. A
+    divergent member keeps the pending sentinel of its declared version:
+    a receipt is admission's grant, and this finding refuses admission.
+    """
+    siblings = dict(siblings or {})
+    grade = grade_admission(ticket_id, text, siblings,
+                            context=grader_context(run))
+    root_id = str(ticket_id).split('.', 1)[0]
+    root_text = siblings.get(root_id) if root_id != str(ticket_id) else None
+    if root_text is not None:
+        data = _parse_frontmatter(text)
+        divergence = version_divergence(ticket_id, data,
+                                        _parse_frontmatter(root_text))
+        if divergence is not None:
+            grade = dict(grade)
+            grade['findings'] = list(grade['findings']) + [divergence]
+            grade['receipt'] = pending_admission(declared_version(data))
+    return grade
 
 
 __all__ = ('grader_context', 'graded_admission', 'run_snapshot')

--- a/scripts/tickets_dispatch.py
+++ b/scripts/tickets_dispatch.py
@@ -50,37 +50,12 @@ def _cmd_gate(rest):
     The probe is supplied from here rather than read inside the gate module
     so that one revision reaches every stub the family writes, and so that
     the seam a caller substitutes is the one this façade names.
-    """
-    refusal = _gate_version_refusal(rest)
-    return _gate_command(rest, head_probe=git_head) if refusal is None else refusal
-def _gate_version_refusal(rest):
-    """Refuse a gate whose stubs its builder cannot express, or ``None``.
 
-    `_gate_stub` writes a v1 admission and a v1 cohort by construction, so
-    under a root already carrying a sealed v2 assignment every stub the
-    family would write is one `ready` and `claim` refuse -- the recorded
-    instance is exactly that, v1 cohorts emitted under a v2 root. The root
-    is read here, before the builder runs, because a gate that has already
-    written its family has spent the dispatch this refusal exists to save.
-
-    Only the version is decided here. Every other reason a gate is refused
-    stays the builder's, so this adds a door and moves no law: anything it
-    cannot resolve -- a malformed line, an absent sink, a root that is not
-    there -- is passed through untouched for the builder to phrase.
+    No version door stands in front of the builder any more: the builder
+    emits at the root's declared version, and a member at the wrong one is
+    the one grade's own `version-root-divergence` refusal at every door.
     """
-    args = list(rest)
-    for flag in ('--lens', '--write-scope', '--acceptance-from'):
-        _extract_flag(args, flag)
-    if len(args) != 2:
-        return None
-    run, root_id = args
-    tickets_root = _tickets_root()
-    if tickets_root is None:
-        return None
-    text, failure = _read_utf8(tickets_root / run / f'{root_id}.md')
-    if failure is not None or not is_v2(_parse_frontmatter(text)):
-        return None
-    return {'error': f"gate root '{run}/{root_id}' carries a v2 sealed assignment, and a gate stub is written v1 by construction: every stub this would emit is one `ready` and `claim` refuse. Nothing was written"}
+    return _gate_command(rest, head_probe=git_head)
 def _template_stubs(directory: Path, values: dict):
     """``(stubs, error)`` — every stub in the template, substituted and graded.
     ``stubs`` maps a stub id to its text and its dependency ids, in file

--- a/scripts/tickets_dispatch_gate.py
+++ b/scripts/tickets_dispatch_gate.py
@@ -20,7 +20,8 @@ from __future__ import annotations
 import json
 import re
 if __package__:
-    from .tickets_admission import ADMISSION_PENDING, ticket_cohort
+    from .tickets_admission import ADMISSION_PENDING, ADMISSION_V2_PENDING, ticket_cohort
+    from .tickets_transitions import declared_version
     from .tickets_commands import GATE_USAGE
     from .tickets_emission import grade_run_emission
     from .tickets_format import PACK_NAME_PREFIX, PACK_NAME_SUFFIX, ROOT_EXECUTOR, parse_canonical_json, _executor_of, _extract_flag, _split_commas, ticket_defects
@@ -31,7 +32,8 @@ if __package__:
     from .tickets_store import NO_SINK_ERROR, _create_text_exclusively, _run_lock, _segment_error, _tickets_root
     from .tickets_worklog import _run_tickets
 else:
-    from tickets_admission import ADMISSION_PENDING, ticket_cohort
+    from tickets_admission import ADMISSION_PENDING, ADMISSION_V2_PENDING, ticket_cohort
+    from tickets_transitions import declared_version
     from tickets_commands import GATE_USAGE
     from tickets_emission import grade_run_emission
     from tickets_format import PACK_NAME_PREFIX, PACK_NAME_SUFFIX, ROOT_EXECUTOR, parse_canonical_json, _executor_of, _extract_flag, _split_commas, ticket_defects
@@ -113,15 +115,20 @@ def _with_inherited_inputs(sections: list, inherited: str) -> list:
                 content = '\n'.join(([content] if content.strip() else []) + lines)
         extended.append((heading, content))
     return extended
-def _gate_stub(run: str, ticket_id: str, executor: str, depends_on: list, write_scope: list, sections: list, pack=None, cohort=None, inherited_inputs='', baseline=None, isolation=None, excluded_actions=None, sequence=None) -> str:
-    """One gate stub: its own cohort, the root's authority, its own records.
+def _gate_stub(run: str, ticket_id: str, executor: str, depends_on: list, write_scope: list, sections: list, pack=None, cohort=None, inherited_inputs='', baseline=None, isolation=None, excluded_actions=None, sequence=None, version=1, root_generation=None) -> str:
+    """One gate stub at the root's version, on the root's authority.
     ``isolation`` and ``excluded_actions`` are the root's, passed in rather
     than defaulted, so a root that holds neither lends neither: what is
     copied is what was granted, never a safe-looking value invented here.
-    The cohort is the stub's own. A gate stub holds a broad write grant and
-    so does its root, and under same-cohort sole-owner closure those two
-    collide; issuing each stub in `v1:ticket:<its id>` keeps the collision
-    from forming instead of leaving a hand edit to undo it.
+    ``version`` is the root's declared admission version, never this
+    module's spelling of it. Under v1 the cohort is the stub's own: a gate
+    stub holds a broad write grant and so does its root, and under
+    same-cohort sole-owner closure those two collide; `v1:ticket:<its id>`
+    keeps the collision from forming. Under v2 there is no cohort to issue
+    -- a v2 ticket is frozen by its assignment seal -- so the stub joins
+    as a drafting member: the root's current `root_generation` and the v2
+    pending sentinel, exactly what `stamp-generation` leaves on a member,
+    with the next `draft-validate` and `seal` covering the family.
     ``sequence`` is the single-lens chain (rules/delegation.md §4): stated
     beside `executor` so the chain's head visibly is the executor.
     """
@@ -129,7 +136,8 @@ def _gate_stub(run: str, ticket_id: str, executor: str, depends_on: list, write_
     mutations = [f"{'write' if path.endswith('/') else 'change'}:{path}" for path in normalized_scope]
     exclusions = [str(entry) for entry in (excluded_actions or [])]
     isolation = str(isolation).strip() if isolation else ''
-    fields = {'id': ticket_id, 'run': run, 'status': 'pending', 'admission': ADMISSION_PENDING, 'cohort': cohort or ticket_cohort(ticket_id), 'executor': executor, 'sequence': list(sequence) if sequence else None, 'pack': pack, 'independence': 'gate', 'depends_on': list(depends_on), 'write_scope': list(write_scope), 'mutations': mutations, 'excluded_actions': exclusions or None, 'isolation': isolation or None, 'bound': NEW_DEFAULT_BOUND, 'claimed_by': '', 'claimed_at': ''}
+    v2 = int(version) == 2
+    fields = {'id': ticket_id, 'run': run, 'status': 'pending', 'admission': ADMISSION_V2_PENDING if v2 else ADMISSION_PENDING, 'cohort': None if v2 else cohort or ticket_cohort(ticket_id), 'executor': executor, 'sequence': list(sequence) if sequence else None, 'pack': pack, 'independence': 'gate', 'depends_on': list(depends_on), 'write_scope': list(write_scope), 'mutations': mutations, 'excluded_actions': exclusions or None, 'isolation': isolation or None, 'bound': NEW_DEFAULT_BOUND, 'claimed_by': '', 'claimed_at': '', 'root_generation': str(root_generation) if v2 and root_generation else None}
     body = _render_ticket(fields, _with_inherited_inputs(sections, inherited_inputs))
     text, error = render_ticket_inputs(body, run, inherited_inputs, baseline=baseline)
     if error is not None:
@@ -276,6 +284,8 @@ def _gate_under_run_lock(rest, head_probe=None):
     inherited_inputs = (root.get('sections') or {}).get('Fixed inputs', '')
     isolation = root.get('isolation')
     exclusions = list(root.get('excluded_actions') or [])
+    version = declared_version(root)
+    root_generation = str(root.get('root_generation') or '') or None
     gate_baseline = (head_probe or git_head)()
     if pack in ('orch-code-pack', 'orch-design-pack') and gate_baseline is None:
         return {'error': f'{pack} gate input rendering cannot resolve the run-project HEAD. Nothing was written'}
@@ -293,8 +303,8 @@ def _gate_under_run_lock(rest, head_probe=None):
     # owning its own repair bill has an incentive to soften findings.
     chained = len(lenses) == 1
     def stub(stub_id, executor, depends, stub_scope, stub_sections, sequence=None):
-        """One stub of this family, on this root's authority."""
-        return _gate_stub(run, stub_id, executor, depends, stub_scope, stub_sections, pack, inherited_inputs=inherited_inputs, baseline=gate_baseline, isolation=isolation, excluded_actions=exclusions, sequence=sequence)
+        """One stub of this family, on this root's authority and version."""
+        return _gate_stub(run, stub_id, executor, depends, stub_scope, stub_sections, pack, inherited_inputs=inherited_inputs, baseline=gate_baseline, isolation=isolation, excluded_actions=exclusions, sequence=sequence, version=version, root_generation=root_generation)
     try:
         for lens in lenses:
             invalid = _segment_error('lens', lens)
@@ -343,7 +353,12 @@ def _gate_under_run_lock(rest, head_probe=None):
         for path in written:
             path.unlink(missing_ok=True)
         return {'error': f'unwritable gate stub: {error}. Nothing was written'}
-    return {'gate': {'run': run, 'root': root_id, 'lenses': lenses, 'acceptance_from': acceptance_id, 'ids': [stub_id for stub_id, _ in rendered], 'paths': [str(path) for path in written]}}
+    payload = {'run': run, 'root': root_id, 'lenses': lenses, 'acceptance_from': acceptance_id, 'ids': [stub_id for stub_id, _ in rendered], 'paths': [str(path) for path in written]}
+    if version == 2:
+        # A v2 family lands drafting: the seal is the one door that writes
+        # generation fields, so completion is named rather than imitated.
+        payload['next'] = [f'draft-validate {run} {root_id}', f'seal {run} {root_id} --cut-generation <the new draft identity>']
+    return {'gate': payload}
 __all__ = (
     '_cmd_gate', '_gate_body', '_gate_input', '_gate_sections', '_gate_stub',
     '_gate_under_run_lock', '_inherited_input_lines', '_input_name',

--- a/scripts/tickets_transitions.py
+++ b/scripts/tickets_transitions.py
@@ -18,10 +18,10 @@ sentinel differs; `scripts/tickets_issue.py` and
 from __future__ import annotations
 from collections import namedtuple
 if __package__:
-    from .tickets_admission import ADMISSION_PENDING, ADMISSION_V2_PENDING, cohort_sealed
+    from .tickets_admission import ADMISSION_PENDING, ADMISSION_V2_PENDING, cohort_sealed, is_v2
     from .tickets_format import TERMINAL_STATES, VALID_STATUSES, _set_frontmatter_field
 else:
-    from tickets_admission import ADMISSION_PENDING, ADMISSION_V2_PENDING, cohort_sealed
+    from tickets_admission import ADMISSION_PENDING, ADMISSION_V2_PENDING, cohort_sealed, is_v2
     from tickets_format import TERMINAL_STATES, VALID_STATUSES, _set_frontmatter_field
 PENDING, READY, CLAIMED, SUSPENDED = 'pending', 'ready', 'claimed', 'suspended'
 STATUSES = tuple(sorted(VALID_STATUSES))
@@ -97,6 +97,38 @@ STAMPS = {
 def pending_admission(version: int = 1) -> str:
     """The pending-admission sentinel this admission version stamps."""
     return STAMPS[('stamp', int(version))].admission
+def declared_version(data) -> int:
+    """The admission version this ticket's own bytes declare.
+
+    The four public v2 fields opt in (`is_v2`), and so does the v2 pending
+    sentinel alone: a drafting member carries exactly that between the
+    door that emits it and the `seal` that writes its generation fields.
+    Everything else is v1, the default a bare ticket has always had.
+    """
+    if is_v2(data) or str(data.get('admission') or '').startswith('v2:'):
+        return 2
+    return 1
+def version_divergence(ticket_id: str, data: dict, root_data: dict):
+    """The finding that names a member disagreeing with its root, or None.
+
+    The version is the root's property: `stamp-generation` opens v2 on a
+    root and its whole cut at once, so a member emitted at the other
+    version is not an earlier lifecycle stage some later step rewrites --
+    nothing rewrites it -- but a ticket every grader reads
+    self-consistently down its own version's path while the run cannot run
+    it. The recorded instance wrote v1 gate stubs under a sealed v2 root,
+    and each graded clean until `ready`. Named here, beside the stamps, so
+    the one grade refuses it at every door while the flag that was wrong
+    is still in the caller's hand.
+    """
+    member, root = declared_version(data), declared_version(root_data)
+    if member == root:
+        return None
+    remedy = ('declare the opt-in the root carries: a v2 pending admission '
+              'or generation field, as `new --file` and `gate` emit'
+              if root == 2 else 'drop the v2 declaration: this root and its cut are v1')
+    return {'code': 'version-root-divergence', 'field': 'admission',
+            'detail': f'v{member} member under a v{root} root; {remedy}'}
 def stamp(command: str = 'stamp', version: int = 1):
     """The stamping entry for one command at one version, or None."""
     return STAMPS.get((command, int(version)))

--- a/tests/serial_compat_manifest.json
+++ b/tests/serial_compat_manifest.json
@@ -1,6 +1,6 @@
 {
  "discovery": {
-  "count": 3097,
+  "count": 3107,
   "identities": [
    "test_affected_tests.TestDiscoveryCache.test_a_new_commit_is_a_new_key_and_is_discovered_again",
    "test_affected_tests.TestDiscoveryCache.test_a_tree_that_cannot_answer_for_a_commit_falls_back_and_says_so",
@@ -676,7 +676,7 @@
    "test_tickets_emitters.EmissionLawPartition.test_a_finding_code_the_law_does_not_know_refuses",
    "test_tickets_emitters.EmissionLawPartition.test_an_emitter_owned_finding_is_refused",
    "test_tickets_emitters.EmissionLawPartition.test_an_unsealed_v2_assignment_is_deferred",
-   "test_tickets_emitters.GateGradesItsEmission.test_gate_refuses_a_root_whose_stubs_it_cannot_express",
+   "test_tickets_emitters.GateGradesItsEmission.test_gate_joins_a_sealed_v2_root_as_a_drafting_family",
    "test_tickets_emitters.InstantiateGradesItsEmission.test_every_shipped_composition_passes_its_own_door",
    "test_tickets_emitters.InstantiateGradesItsEmission.test_instantiate_refuses_stubs_the_next_door_refuses",
    "test_tickets_emitters.NewGradesItsEmission.test_new_refuses_the_locator_claim_refuses",
@@ -875,6 +875,16 @@
    "test_v2_cohort.V2CohortRulingTest.test_an_explicit_cohort_on_a_v2_ticket_is_refused_and_nothing_is_written",
    "test_v2_cohort.V2CohortRulingTest.test_placing_a_v2_ticket_stamps_no_cohort",
    "test_v2_cohort.V2CohortRulingTest.test_recut_leaves_a_v2_ticket_without_a_cohort",
+   "test_v2_membership.TheDoorsRefuseDivergence.test_new_file_lands_a_drafting_member_that_matches",
+   "test_v2_membership.TheDoorsRefuseDivergence.test_new_file_refuses_a_v1_member_under_a_sealed_v2_root",
+   "test_v2_membership.TheGateCompletesUnderV2.test_a_v1_root_still_issues_a_v1_gate",
+   "test_v2_membership.TheGateCompletesUnderV2.test_the_family_is_sealed_at_the_next_generation",
+   "test_v2_membership.TheVersionLaw.test_a_member_at_its_root_version_carries_no_divergence",
+   "test_v2_membership.TheVersionLaw.test_a_v1_member_under_a_v2_root_diverges",
+   "test_v2_membership.TheVersionLaw.test_a_v2_member_under_a_v1_root_diverges",
+   "test_v2_membership.TheVersionLaw.test_the_law_refuses_at_emission_and_is_not_deferred",
+   "test_v2_membership.TheVersionLaw.test_the_pure_halves_answer_alone",
+   "test_v2_membership.TheVersionLaw.test_the_root_itself_is_exempt",
    "test_v2_regrade.AdmissionVersionGateTest.test_a_ticket_with_no_admission_field_is_still_the_legacy_one",
    "test_v2_regrade.AdmissionVersionGateTest.test_a_v2_ticket_declared_edge_is_actually_closed",
    "test_v2_regrade.AdmissionVersionGateTest.test_a_v2_ticket_plan_still_bounds_its_actual_mutations",
@@ -3100,7 +3110,7 @@
    "tests.test_workspace_cases.start_cases.TestTheStampPreservesTheTicketsByteDomain.test_only_the_two_stamped_lines_differ_from_the_prior_bytes",
    "tests.test_workspace_cases.start_cases.TestTicketsPayloadIsGradedNotItsExitStatus.test_an_error_payload_returned_at_exit_zero_is_a_failure"
   ],
-  "sha256": "ed3f11bd521353847cc9170290d3cdc1c7d3904f831a5dcc50f8920a5ee53c6a"
+  "sha256": "3451a04bd87d3f2aba16cb2d82c9f8fdebae42d9e031f7c28fafe0388f15b07e"
  },
  "mutation_owners": [
   {
@@ -6119,6 +6129,30 @@
    "restoration": "sharded-module-guard",
    "seams": [
     "import-path"
+   ]
+  },
+  {
+   "module": "tests.test_v2_membership",
+   "owner": "<module>",
+   "restoration": "sharded-module-guard",
+   "seams": [
+    "import-path"
+   ]
+  },
+  {
+   "module": "tests.test_v2_membership",
+   "owner": "run_dir_of",
+   "restoration": "sharded-module-guard",
+   "seams": [
+    "environment"
+   ]
+  },
+  {
+   "module": "tests.test_v2_membership",
+   "owner": "use_sink",
+   "restoration": "sharded-module-guard",
+   "seams": [
+    "environment"
    ]
   },
   {

--- a/tests/test_tickets_emitters.py
+++ b/tests/test_tickets_emitters.py
@@ -408,27 +408,24 @@ class TheSealedBatchWedge(unittest.TestCase):
 
 
 class GateGradesItsEmission(unittest.TestCase):
-    def test_gate_refuses_a_root_whose_stubs_it_cannot_express(self):
-        """Recorded instance: gate stubs emitted v1 cohorts under a v2 root.
-
-        The builder writes a v1 admission and cohort by construction, so
-        under a sealed v2 root every stub it writes is one the next refuses.
-        """
+    def test_gate_joins_a_sealed_v2_root_as_a_drafting_family(self):
+        """The recorded instance, closed: stubs join the root's declared
+        version, and the law's half is `tests/test_v2_membership.py`."""
 
         with workspace() as (tmp, repo, head):
             run_dir = place_root(head, v2=True)
-
             validated = run_cmd(repo, "draft-validate", "testrun", "00-root")
-            self.assertNotIn("error", validated)
             sealed = run_cmd(
                 repo, "seal", "testrun", "00-root", "--cut-generation",
                 validated["draft_validation"]["cut_generation"])
             self.assertNotIn("error", sealed)
-
             payload = run_cmd(repo, "gate", "testrun", "00-root")
-            self.assertIn("v2 sealed assignment", str(payload.get("error")))
-            self.assertEqual([], sorted(run_dir.glob("*.gate.*.md")),
-                             "a refused gate writes no stub")
+            self.assertNotIn("error", payload)
+            stubs = sorted(run_dir.glob("*.gate.*.md"))
+            self.assertEqual(2, len(stubs), "one lens: chained critique + verify")
+            for data in map(frontmatter, stubs):
+                self.assertEqual(("v2:pending", None), (data.get("admission"), data.get("cohort")))
+                self.assertTrue(data.get("root_generation", "").startswith("v2:root:"))
 
 
 class RecutAndAmendGradeTheirEmission(unittest.TestCase):

--- a/tests/test_v2_membership.py
+++ b/tests/test_v2_membership.py
@@ -1,0 +1,307 @@
+"""A member's admission version is its root's, and divergence is refused.
+
+The class this module closes: every door computed a ticket's version from
+the ticket's own bytes, and the bytes were whatever the door wrote. A door
+that wrote v1 bytes under a v2 root produced a member every grader read
+self-consistently down the v1 path -- the recorded instance was the gate's
+stubs, clean at emission and one `ready` refuse each -- and the response
+had been a per-door stopgap in front of one builder. The law now lives in
+the one grade (`tickets_context.graded_admission`): `version-root-divergence`
+names a member disagreeing with the root of the run it stands in, at every
+door that grades or emits, while the flag is still in the caller's hand.
+
+The gate builder is the capability half: it emits at the root's declared
+version, so a sealed v2 root grows a drafting gate family that the next
+`draft-validate` and `seal` cover at the next generation.
+
+The sink idiom (a temporary ``ORCHFLOWS_STATE_HOME``) is restated here
+rather than imported, the convention `tests/test_tickets_gate.py` states,
+so this module runs alone under `tools/run_tests.py`'s per-module child.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+import tempfile
+import unittest
+from contextlib import contextmanager
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+import scripts.tickets as tickets_mod  # noqa: E402
+from scripts import tickets_emission  # noqa: E402
+from scripts.tickets_context import graded_admission  # noqa: E402
+from scripts.tickets_transitions import declared_version, version_divergence  # noqa: E402
+
+STATE_HOME_ENV_VAR = "ORCHFLOWS_STATE_HOME"
+
+STUB = """---
+id: {tid}
+run: testrun
+status: pending
+admission: v1:pending
+cohort: v1:ticket:{tid}
+executor: {executor}
+{pack}independence: {independence}
+depends_on: {depends_on}
+write_scope: [scripts/a.py]
+mutations: [change:scripts/a.py]
+isolation: required
+bound: 60m
+claimed_by:
+claimed_at:
+---
+"""
+BODY = ("\n## Objective\n\nDeliver the one thing this item is for.\n\n"
+        "## Fixed inputs\n\n{inputs}\n\n"
+        "## Completion test\n\n- it works | oracle: `true` | oracle_class: "
+        "deterministic | provenance: authored-here\n\n## Return fields\n\n"
+        "status; result; verification; feedback; risks\n\n## Result\n\n"
+        "## Verification\n\n## Feedback\n\n[]\n\n## Risks\n\n[]\n")
+PLAIN_INPUT = '- input: {"name":"subject","type":"literal","value":"the subject"}'
+GIT_INPUT = ('- input: {{"identity":{{"kind":"git-tree","repo":"run-project",'
+             '"revision":"{baseline}"}},"name":"baseline","type":"identity"}}')
+
+
+def stub(tid, baseline=None, executor=None, independence="checker",
+         depends_on="[]", v2=False):
+    """One admissible ticket, v1 by default, drafting-v2 when asked."""
+
+    git = baseline is not None
+    text = (STUB + BODY).format(
+        tid=tid, pack="pack: orch-code-pack\n" if git else "",
+        executor=executor or ("orch-tdd" if git else "orch-investigate"),
+        inputs=GIT_INPUT.format(baseline=baseline) if git else PLAIN_INPUT,
+        independence=independence, depends_on=depends_on)
+    if v2:
+        text = text.replace(f"cohort: v1:ticket:{tid}\n", "").replace(
+            "admission: v1:pending", "admission: v2:pending")
+    return text
+
+
+def use_sink(tmp: Path) -> Path:
+    sink = (tmp / "state-sink").resolve()
+    os.environ[STATE_HOME_ENV_VAR] = str(sink)
+    return sink
+
+
+def run_dir_of(run: str = "testrun") -> Path:
+    return Path(os.environ[STATE_HOME_ENV_VAR]) / "tickets" / run
+
+
+def git_repo(tmp: Path):
+    repo = tmp / "repo"
+    repo.mkdir(parents=True)
+    for command in (
+        ["git", "init", "-q"],
+        ["git", "config", "user.email", "t@example.invalid"],
+        ["git", "config", "user.name", "t"],
+    ):
+        subprocess.run(command, cwd=repo, check=True)
+    (repo / "seed.txt").write_text("seed\n", encoding="utf-8")
+    subprocess.run(["git", "add", "-A"], cwd=repo, check=True)
+    subprocess.run(["git", "commit", "-qm", "seed"], cwd=repo, check=True)
+    head = subprocess.run(["git", "rev-parse", "HEAD"], cwd=repo, check=True,
+                          capture_output=True, text=True).stdout.strip()
+    return repo, head
+
+
+@contextmanager
+def workspace():
+    with tempfile.TemporaryDirectory() as raw:
+        tmp = Path(raw)
+        use_sink(tmp)
+        repo, head = git_repo(tmp)
+        yield tmp, repo, head
+
+
+def run_cmd(cwd: Path, *args):
+    original = tickets_mod._cwd
+    tickets_mod._cwd = lambda: Path(cwd).resolve()
+    try:
+        try:
+            payload = tickets_mod._dispatch([str(arg) for arg in args])
+        except Exception as error:  # what `main` does with one
+            payload = {"error": str(error)}
+    finally:
+        tickets_mod._cwd = original
+    return json.loads(json.dumps(payload, ensure_ascii=False))
+
+
+def codes(payload) -> set:
+    return {finding.get("code") for finding in payload.get("findings") or []}
+
+
+def frontmatter(path: Path) -> dict:
+    data = {}
+    for line in path.read_text(encoding="utf-8").split("---")[1].strip().splitlines():
+        key, _, value = line.partition(":")
+        data[key.strip()] = value.strip()
+    return data
+
+
+def place_root(head, v2=False):
+    """A root and one unit of its cut, in the sink, as a door finds them."""
+
+    run_dir = run_dir_of()
+    run_dir.mkdir(parents=True, exist_ok=True)
+    for tid, extra in (("00-root", {"executor": "orch-decompose",
+                                    "independence": "gate"}), ("00-root.01", {})):
+        (run_dir / f"{tid}.md").write_text(stub(tid, head, v2=v2, **extra),
+                                           encoding="utf-8")
+    return run_dir
+
+
+def seal_run(repo):
+    """Validate and seal testrun's root; returns the sealed cut identity."""
+
+    validated = run_cmd(repo, "draft-validate", "testrun", "00-root")
+    identity = validated["draft_validation"]["cut_generation"]
+    sealed = run_cmd(repo, "seal", "testrun", "00-root",
+                     "--cut-generation", identity)
+    assert "error" not in sealed, sealed
+    return identity
+
+
+class TheVersionLaw(unittest.TestCase):
+    """`version-root-divergence`, stated once and graded everywhere."""
+
+    def grade(self, member_v2: bool, root_v2: bool):
+        with tempfile.TemporaryDirectory() as tmp:
+            use_sink(Path(tmp))
+            root = stub("00-root", executor="orch-decompose",
+                        independence="gate", v2=root_v2)
+            member = stub("00-root.01", v2=member_v2)
+            return graded_admission(
+                "00-root.01", member,
+                {"00-root": root, "00-root.01": member}, "testrun")
+
+    def test_a_v1_member_under_a_v2_root_diverges(self):
+        grade = self.grade(member_v2=False, root_v2=True)
+        self.assertIn("version-root-divergence", codes(grade))
+        self.assertEqual("v1:pending", grade["receipt"],
+                         "a divergent member is never granted a receipt")
+
+    def test_a_v2_member_under_a_v1_root_diverges(self):
+        self.assertIn("version-root-divergence",
+                      codes(self.grade(member_v2=True, root_v2=False)))
+
+    def test_a_member_at_its_root_version_carries_no_divergence(self):
+        for both in (False, True):
+            with self.subTest(v2=both):
+                self.assertNotIn("version-root-divergence",
+                                 codes(self.grade(member_v2=both, root_v2=both)))
+
+    def test_the_root_itself_is_exempt(self):
+        """The root defines the version; only members can disagree with it."""
+
+        with tempfile.TemporaryDirectory() as tmp:
+            use_sink(Path(tmp))
+            root = stub("00-root", executor="orch-decompose",
+                        independence="gate", v2=True)
+            self.assertNotIn("version-root-divergence", codes(graded_admission(
+                "00-root", root, {"00-root": root}, "testrun")))
+
+    def test_the_law_refuses_at_emission_and_is_not_deferred(self):
+        """Fail-closed at every door: divergence is the emitter's own."""
+
+        self.assertNotIn("version-root-divergence",
+                         tickets_emission.DEFERRED_CODES)
+        with tempfile.TemporaryDirectory() as tmp:
+            use_sink(Path(tmp))
+            root = stub("00-root", executor="orch-decompose",
+                        independence="gate", v2=True)
+            refusal = tickets_emission.grade_emission(
+                "new", "testrun", {"00-root.01": stub("00-root.01")},
+                {"00-root": root})
+            self.assertIsNotNone(refusal)
+            self.assertIn("version-root-divergence", codes(refusal))
+
+    def test_the_pure_halves_answer_alone(self):
+        """`declared_version` and `version_divergence` are the stated law."""
+
+        self.assertEqual(2, declared_version({"admission": "v2:pending"}))
+        self.assertEqual(2, declared_version({"root_generation": "v2:root:r:1:sha256:" + "0" * 64}))
+        self.assertEqual(1, declared_version({"admission": "v1:pending"}))
+        self.assertIsNone(version_divergence(
+            "r.01", {"admission": "v2:pending"}, {"assignment_seal": "sha256:x"}))
+        finding = version_divergence("r.01", {}, {"admission": "v2:pending"})
+        self.assertEqual("version-root-divergence", finding["code"])
+
+
+class TheDoorsRefuseDivergence(unittest.TestCase):
+    """The recorded instance's class, closed at a real door: `new --file`
+    writing a v1 member into a sealed v2 run refuses before the write."""
+
+    def test_new_file_refuses_a_v1_member_under_a_sealed_v2_root(self):
+        with workspace() as (tmp, repo, head):
+            run_dir = place_root(head, v2=True)
+            seal_run(repo)
+            candidate = tmp / "candidate.md"
+            candidate.write_text(stub("00-root.02", head), encoding="utf-8")
+            payload = run_cmd(repo, "new", "testrun", "00-root.02",
+                              "--file", str(candidate))
+            self.assertIn("version-root-divergence", codes(payload))
+            self.assertFalse((run_dir / "00-root.02.md").exists(),
+                             "a refused emission writes nothing")
+
+    def test_new_file_lands_a_drafting_member_that_matches(self):
+        with workspace() as (tmp, repo, head):
+            run_dir = place_root(head, v2=True)
+            seal_run(repo)
+            candidate = tmp / "candidate.md"
+            candidate.write_text(
+                stub("00-root.02", head).replace(
+                    "admission: v1:pending",
+                    "root_generation: " + frontmatter(
+                        run_dir / "00-root.md")["root_generation"]),
+                encoding="utf-8")
+            payload = run_cmd(repo, "new", "testrun", "00-root.02",
+                              "--file", str(candidate))
+            self.assertNotIn("error", payload)
+            self.assertNotIn("cohort", frontmatter(run_dir / "00-root.02.md"),
+                             "a v2 member is frozen by its seal, not a cohort")
+
+
+class TheGateCompletesUnderV2(unittest.TestCase):
+    """The capability half, end to end: gate, then the seal covers it."""
+
+    def test_the_family_is_sealed_at_the_next_generation(self):
+        with workspace() as (tmp, repo, head):
+            run_dir = place_root(head, v2=True)
+            first = seal_run(repo)
+            payload = run_cmd(repo, "gate", "testrun", "00-root")
+            self.assertNotIn("error", payload)
+            self.assertTrue(payload["gate"]["next"][0].startswith("draft-validate"),
+                            "a v2 family names its completing doors")
+            second = seal_run(repo)
+            self.assertNotEqual(first, second,
+                                "new members are a new generation, by design")
+            for stub_id in payload["gate"]["ids"]:
+                data = frontmatter(run_dir / f"{stub_id}.md")
+                self.assertEqual(second, data.get("cut_generation"),
+                                 f"{stub_id} is covered by the new seal")
+                self.assertTrue(data.get("assignment_seal", "").startswith("sha256:"))
+
+    def test_a_v1_root_still_issues_a_v1_gate(self):
+        with workspace() as (tmp, repo, head):
+            run_dir = place_root(head, v2=False)
+            payload = run_cmd(repo, "gate", "testrun", "00-root")
+            self.assertNotIn("error", payload)
+            self.assertNotIn("next", payload["gate"],
+                             "v1 completion is admission's, not the seal's")
+            for stub_id in payload["gate"]["ids"]:
+                data = frontmatter(run_dir / f"{stub_id}.md")
+                self.assertEqual("v1:pending", data.get("admission"))
+                self.assertEqual(f"v1:ticket:{stub_id}", data.get("cohort"))
+                self.assertNotIn("root_generation", data)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## The recorded instance

`tickets.py gate` wrote v1 admissions and cohorts by construction, so under a sealed v2 root every stub it emitted was one `ready`/`claim` refuse. The standing response was a per-door stopgap refusal (`_gate_version_refusal`) in front of that one builder — which meant a v2 root could never grow a gate at all, and a run that had opened the v2 lifecycle could not reach terminal.

## The class beneath it

Every door computed a ticket's admission version from **the ticket's own bytes**, and the bytes were whatever the door wrote. A self-consistent member at the wrong version therefore graded clean down its own version's path at every grader — `grade_admission` branches on the member alone — and only broke later, indirectly. The tree had already answered two instances of this class (`instantiate` deriving version from stub bytes, and the gate's bespoke door) and the class survived both, because no law named "member disagrees with its root".

## The fix, at the law and at the door

- **`tickets_transitions`** — already the version-keyed stamping law-owner — gains `declared_version` and `version_divergence`. `version-root-divergence` is a new finding, refusable at emission by `tickets_emission`'s fail-closed default.
- **`tickets_context.graded_admission`** — the one grade every grading *and* emitting site shares — asks it, so `lint`, `ready`, `claim`, `packet` and every emitting door refuse a divergent member while the flag is still in the caller's hand. A future lifecycle version changes the table, not five doors.
- **`tickets_dispatch_gate`** emits at the root's declared version. Under v2 the family lands as drafting members (v2 pending admission, the root's `root_generation`, no cohort — exactly what `stamp-generation` leaves), which the next `draft-validate` and `seal` cover at the next generation; the payload names those completing commands.
- **The stopgap door is deleted.**

## Evidence

`tests/test_v2_membership.py` (10 cases) holds both halves: the divergence law in both directions, root exemption, emission refusal and the pure halves; the recorded instance's class closed at a real door (`new --file` refusing before the write); the full end-to-end (gate on a sealed v2 root → re-seal at the next generation covers the family); and the v1-gate regression guard. `tests/test_tickets_emitters.py`'s gate case now proves the join instead of the refusal. Three new mutation owners classified `sharded-module-guard`.

`python tools/run_required.py` — all five green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)