### PR TITLE
Fix Codex role-profile fork isolation

### DIFF
--- a/installer/packages.py
+++ b/installer/packages.py
@@ -180,15 +180,17 @@ def by_name_pointer_text(frontmatter: str, role, lib_skill_md: Path) -> str:
     return frontmatter + "\n" + fork_arrival_preamble(role) + f"Read {lib_skill_md} and follow it exactly.\n"
 
 
-def codex_role_adapter_body(name: str, role: str, lib_skill_md: Path) -> str:
+def codex_role_adapter_body(name: str, profile: dict, lib_skill_md: Path) -> str:
     """Explicit Codex dispatch gate for one role-bearing named skill."""
 
-    agent_type = f"orch_{role}"
+    role = profile["role"]
+    binding = profile["codex"]
     return (
         f"`{name}` requires the matching role `orch-{role}`. If this context "
         f"is already that established child, read {lib_skill_md} and follow it exactly. Execute "
         "the exact named skill directly; never redispatch it. Otherwise root "
-        f"must dispatch one child with agent_type `{agent_type}`, passing the "
+        f"must dispatch one child with agent_type `{binding['agent_type']}` and "
+        f"fork_turns `{binding['fork_turns']}`, passing the "
         "complete packet and exact named skill; refuse execution when that "
         "matching role child is missing or mismatched; there is no inline "
         f"fallback.\n\n{FORK_ARRIVAL_CLAUSE}\n"
@@ -219,7 +221,9 @@ def load_role_profiles(profiles_md_path: Path = PROFILES_MD):
         raise ValueError(f"{profiles_md_path}: missing role profile row(s) for {', '.join(missing)}")
     codex_agent_types = set()
     for name, profile in profiles.items():
-        if not {"agent_type", "model", "model_reasoning_effort"} <= set(profile["codex"]):
+        if not {"agent_type", "fork_turns", "model", "model_reasoning_effort"} <= set(
+            profile["codex"]
+        ):
             raise ValueError(f"{profiles_md_path}: incomplete Codex binding for {name}")
         agent_type = profile["codex"]["agent_type"]
         if _CODEX_AGENT_TYPE_RE.fullmatch(agent_type) is None:
@@ -227,6 +231,11 @@ def load_role_profiles(profiles_md_path: Path = PROFILES_MD):
         if agent_type in codex_agent_types:
             raise ValueError(f"{profiles_md_path}: duplicate Codex agent_type: {agent_type}")
         codex_agent_types.add(agent_type)
+        fork_turns = profile["codex"]["fork_turns"]
+        if fork_turns != "none" and not (
+            fork_turns.isascii() and fork_turns.isdecimal() and not fork_turns.startswith("0")
+        ):
+            raise ValueError(f"{profiles_md_path}: invalid Codex fork_turns for {name}: {fork_turns}")
         if "model" not in profile["claude"]:
             raise ValueError(f"{profiles_md_path}: incomplete Claude binding for {name}")
     return profiles

--- a/installer/packages.py
+++ b/installer/packages.py
@@ -180,10 +180,14 @@ def by_name_pointer_text(frontmatter: str, role, lib_skill_md: Path) -> str:
     return frontmatter + "\n" + fork_arrival_preamble(role) + f"Read {lib_skill_md} and follow it exactly.\n"
 
 
-def codex_role_adapter_body(name: str, profile: dict, lib_skill_md: Path) -> str:
+def codex_role_adapter_body(name: str, role: str, profile: dict, lib_skill_md: Path) -> str:
     """Explicit Codex dispatch gate for one role-bearing named skill."""
 
-    role = profile["role"]
+    if profile["role"] != role:
+        raise ValueError(
+            f"cannot render {name}: declared role {role} does not match "
+            f"resolved profile role {profile['role']}"
+        )
     binding = profile["codex"]
     return (
         f"`{name}` requires the matching role `orch-{role}`. If this context "
@@ -219,6 +223,13 @@ def load_role_profiles(profiles_md_path: Path = PROFILES_MD):
     missing = [f"orch-{role}" for role in PROFILE_ROLES if f"orch-{role}" not in profiles]
     if missing:
         raise ValueError(f"{profiles_md_path}: missing role profile row(s) for {', '.join(missing)}")
+    for role in PROFILE_ROLES:
+        name = f"orch-{role}"
+        declared = profiles[name]["role"]
+        if declared != role:
+            raise ValueError(
+                f"{profiles_md_path}: role profile {name} must declare role {role}, got {declared}"
+            )
     codex_agent_types = set()
     for name, profile in profiles.items():
         if not {"agent_type", "fork_turns", "model", "model_reasoning_effort"} <= set(

--- a/installer/planning.py
+++ b/installer/planning.py
@@ -153,6 +153,7 @@ def _build_user_plan(
     codex_prompts = []
     codex_skills = []
     by_name = []
+    profiles = load_role_profiles()
     for skill_md in discover_packages():
         rel = skill_md.relative_to(REPO_ROOT)
         name = skill_md.parent.name
@@ -177,7 +178,7 @@ def _build_user_plan(
             )
         if codex_enabled:
             codex_body = (
-                codex_role_adapter_body(name, role, lib_skill_md)
+                codex_role_adapter_body(name, profiles[f"orch-{role}"], lib_skill_md)
                 if role in PROFILE_ROLES
                 else body.strip() + "\n"
             )
@@ -191,7 +192,9 @@ def _build_user_plan(
                         frontmatter
                         + "\n"
                         + (
-                            codex_role_adapter_body(name, role, lib_skill_md)
+                            codex_role_adapter_body(
+                                name, profiles[f"orch-{role}"], lib_skill_md
+                            )
                             if role in PROFILE_ROLES
                             else f"Read {lib_skill_md} and follow it exactly.\n"
                         ),
@@ -233,7 +236,6 @@ def _build_user_plan(
                     (codex_user_home / "skills" / name / "SKILL.md", pointer)
                 )
 
-    profiles = load_role_profiles()
     claude_agents = []
     codex_agents = []
     for name in (f"orch-{role}" for role in PROFILE_ROLES):

--- a/installer/planning.py
+++ b/installer/planning.py
@@ -178,7 +178,9 @@ def _build_user_plan(
             )
         if codex_enabled:
             codex_body = (
-                codex_role_adapter_body(name, profiles[f"orch-{role}"], lib_skill_md)
+                codex_role_adapter_body(
+                    name, role, profiles[f"orch-{role}"], lib_skill_md
+                )
                 if role in PROFILE_ROLES
                 else body.strip() + "\n"
             )
@@ -193,7 +195,7 @@ def _build_user_plan(
                         + "\n"
                         + (
                             codex_role_adapter_body(
-                                name, profiles[f"orch-{role}"], lib_skill_md
+                                name, role, profiles[f"orch-{role}"], lib_skill_md
                             )
                             if role in PROFILE_ROLES
                             else f"Read {lib_skill_md} and follow it exactly.\n"

--- a/skills/engines/orch-frontier/references/profiles.md
+++ b/skills/engines/orch-frontier/references/profiles.md
@@ -6,8 +6,8 @@ dispatch-surface mechanics, and lane watching.
 
 | Profile | Role | Codex | Claude Code |
 | --- | --- | --- | --- |
-| `orch-planner` | planner | agent_type `orch_planner`, model `gpt-5.6-sol`, model_reasoning_effort `ultra` | model `claude-opus-5`, effort `max` |
-| `orch-worker` | worker | agent_type `orch_worker`, model `gpt-5.6-sol`, model_reasoning_effort `high`, service_tier `fast` | model `claude-opus-5`, effort `high` |
+| `orch-planner` | planner | agent_type `orch_planner`, fork_turns `none`, model `gpt-5.6-sol`, model_reasoning_effort `ultra` | model `claude-opus-5`, effort `max` |
+| `orch-worker` | worker | agent_type `orch_worker`, fork_turns `none`, model `gpt-5.6-sol`, model_reasoning_effort `high`, service_tier `fast` | model `claude-opus-5`, effort `high` |
 
 Use native invocation fields when available; a prompt-only request is
 requested, not verified. An unsupported or blocked model binding stops

--- a/skills/workflows/orch-build/references/scopes.md
+++ b/skills/workflows/orch-build/references/scopes.md
@@ -30,7 +30,10 @@ scope. Canonical work happens in this repository itself and needs no install.
   machine that wrote it and nowhere else — never the orchflows-only
   `role`, which the item file itself keeps in full anatomy —
   and one routing line naming the item in the scope's AGENTS.md, which
-  is the Codex surface.
+  is the Codex surface. For a role-bearing item that line uses the
+  declared role to resolve its canonical profile, then carries both native
+  Codex dispatch fields, `agent_type` and `fork_turns`; it never reconstructs
+  either field from the role name.
 - The scope's named oracle (library lens) is the only oracle for a
   custom item.
 - Custom workflows instantiate from compositions: pick the nearest

--- a/skills/workflows/orch-build/references/scopes.md
+++ b/skills/workflows/orch-build/references/scopes.md
@@ -30,10 +30,9 @@ scope. Canonical work happens in this repository itself and needs no install.
   machine that wrote it and nowhere else — never the orchflows-only
   `role`, which the item file itself keeps in full anatomy —
   and one routing line naming the item in the scope's AGENTS.md, which
-  is the Codex surface. For a role-bearing item that line uses the
-  declared role to resolve its canonical profile, then carries both native
-  Codex dispatch fields, `agent_type` and `fork_turns`; it never reconstructs
-  either field from the role name.
+  is the Codex surface. At that routing call site, resolve the declared role
+  through [Role profiles](../../../engines/orch-frontier/references/profiles.md)
+  and use the native binding that owner returns.
 - The scope's named oracle (library lens) is the only oracle for a
   custom item.
 - Custom workflows instantiate from compositions: pick the nearest

--- a/tests/serial_compat_manifest.json
+++ b/tests/serial_compat_manifest.json
@@ -1,6 +1,6 @@
 {
  "discovery": {
-  "count": 3193,
+  "count": 3198,
   "identities": [
    "test_affected_tests.TestDiscoveryCache.test_a_new_commit_is_a_new_key_and_is_discovered_again",
    "test_affected_tests.TestDiscoveryCache.test_a_tree_that_cannot_answer_for_a_commit_falls_back_and_says_so",
@@ -165,10 +165,14 @@
    "test_installer.ProjectInstallBoundaryTest.test_cli_rejects_project_install_and_dry_run_but_keeps_legacy_uninstall",
    "test_installer.ProjectInstallBoundaryTest.test_legacy_project_uninstall_normalizes_in_boundary_receipt_paths",
    "test_installer.ProjectInstallBoundaryTest.test_public_facade_rejects_project_plans_before_planning_or_application",
+   "test_installer.RoleProfileRefusalTest.test_a_canonical_profile_name_must_match_its_declared_role",
+   "test_installer.RoleProfileRefusalTest.test_a_missing_codex_fork_binding_is_refused_and_the_row_is_named",
    "test_installer.RoleProfileRefusalTest.test_a_missing_role_row_is_refused_and_the_role_is_named",
    "test_installer.RoleProfileRefusalTest.test_a_row_whose_role_is_outside_the_closed_set_is_skipped",
    "test_installer.RoleProfileRefusalTest.test_an_incomplete_claude_binding_is_refused_and_the_row_is_named",
    "test_installer.RoleProfileRefusalTest.test_an_incomplete_codex_binding_is_refused_and_the_row_is_named",
+   "test_installer.RoleProfileRefusalTest.test_none_and_a_positive_decimal_are_valid_codex_fork_bindings",
+   "test_installer.RoleProfileRefusalTest.test_other_codex_fork_bindings_are_refused_and_the_row_is_named",
    "test_installer.RoleProfileRefusalTest.test_two_roles_may_not_claim_one_codex_agent_type",
    "test_installer.RuntimeVenvTests.test_dependency_install_ignores_project_and_pip_location_overrides",
    "test_installer.RuntimeVenvTests.test_dry_run_has_no_runtime_or_filesystem_effects",
@@ -647,6 +651,7 @@
    "test_thin_orchestrator.ThinOrchestratorContractTests.test_canonical_role_map_and_glue_only_contract",
    "test_thin_orchestrator.ThinOrchestratorContractTests.test_claude_role_skills_use_native_fork_and_matching_agent",
    "test_thin_orchestrator.ThinOrchestratorContractTests.test_codex_named_surfaces_dispatch_or_refuse_and_child_runs_directly",
+   "test_thin_orchestrator.ThinOrchestratorContractTests.test_custom_codex_routing_uses_the_resolved_native_binding",
    "test_tickets_bound.BoundCheckCommandTest.test_a_claim_exactly_at_its_bound_has_not_yet_passed_it",
    "test_tickets_bound.BoundCheckCommandTest.test_a_claim_whose_start_cannot_be_read_is_reported_not_measured",
    "test_tickets_bound.BoundCheckCommandTest.test_a_clock_it_cannot_read_is_refused_before_any_run_is_opened",
@@ -3196,7 +3201,7 @@
    "tests.test_workspace_cases.start_cases.TestTheStampPreservesTheTicketsByteDomain.test_only_the_two_stamped_lines_differ_from_the_prior_bytes",
    "tests.test_workspace_cases.start_cases.TestTicketsPayloadIsGradedNotItsExitStatus.test_an_error_payload_returned_at_exit_zero_is_a_failure"
   ],
-  "sha256": "3d196b3ba7f1b436b9b07b52e464909de4cbff639cf40cfb97af8465f61fa9ce"
+  "sha256": "d57eac3ed5c880d0dfd7ad5dfd555b5d165683954e7ecb4cbdfa5c1eb9677719"
  },
  "mutation_owners": [
   {

--- a/tests/test_installer_cases/planning/scoped_hosts.py
+++ b/tests/test_installer_cases/planning/scoped_hosts.py
@@ -18,7 +18,8 @@ class RoleProfileRefusalTest(unittest.TestCase):
 
     ROW = (
         "| `{name}` | {role} | agent_type `{agent}`, model `gpt-5.6-sol`, "
-        "model_reasoning_effort `high` | model `claude-opus-5`, effort `high` |\n"
+        "model_reasoning_effort `high`, fork_turns `none` | "
+        "model `claude-opus-5`, effort `high` |\n"
     )
 
     def table(self, *replacements, extra: str = "") -> Path:
@@ -59,6 +60,27 @@ class RoleProfileRefusalTest(unittest.TestCase):
         path = self.table((", model_reasoning_effort `ultra`", ""))
         with self.assertRaisesRegex(ValueError, "incomplete Codex binding for orch-planner"):
             install.load_role_profiles(path)
+
+    def test_a_missing_codex_fork_binding_is_refused_and_the_row_is_named(self):
+        path = self.table((", fork_turns `none`", ""))
+        with self.assertRaisesRegex(ValueError, "incomplete Codex binding for orch-planner"):
+            install.load_role_profiles(path)
+
+    def test_none_and_a_positive_decimal_are_valid_codex_fork_bindings(self):
+        self.assertEqual(
+            "none", install.load_role_profiles()["orch-planner"]["codex"]["fork_turns"]
+        )
+        path = self.table(("fork_turns `none`", "fork_turns `3`"))
+        self.assertEqual("3", install.load_role_profiles(path)["orch-planner"]["codex"]["fork_turns"])
+
+    def test_other_codex_fork_bindings_are_refused_and_the_row_is_named(self):
+        for value in ("all", "0", "01", "latest"):
+            with self.subTest(value=value):
+                path = self.table(("fork_turns `none`", f"fork_turns `{value}`"))
+                with self.assertRaisesRegex(
+                    ValueError, f"invalid Codex fork_turns for orch-planner: {value}"
+                ):
+                    install.load_role_profiles(path)
 
     def test_two_roles_may_not_claim_one_codex_agent_type(self):
         """The Codex agent_type is the spawn identifier and the installed

--- a/tests/test_installer_cases/planning/scoped_hosts.py
+++ b/tests/test_installer_cases/planning/scoped_hosts.py
@@ -56,6 +56,13 @@ class RoleProfileRefusalTest(unittest.TestCase):
                 ):
                     install.load_role_profiles(path)
 
+    def test_a_canonical_profile_name_must_match_its_declared_role(self):
+        path = self.table(("| `orch-planner` | planner |", "| `orch-planner` | worker |"))
+        with self.assertRaisesRegex(
+            ValueError, "role profile orch-planner must declare role planner, got worker"
+        ):
+            install.load_role_profiles(path)
+
     def test_an_incomplete_codex_binding_is_refused_and_the_row_is_named(self):
         path = self.table((", model_reasoning_effort `ultra`", ""))
         with self.assertRaisesRegex(ValueError, "incomplete Codex binding for orch-planner"):

--- a/tests/test_skill_fork_governance.py
+++ b/tests/test_skill_fork_governance.py
@@ -232,7 +232,9 @@ class TheInstallerIsTheClausesOneOwner(unittest.TestCase):
     def test_the_codex_gate_carries_it(self):
         self.assertIn(
             FORK_ARRIVAL_CLAUSE,
-            codex_role_adapter_body("orch-tdd", "worker", Path("X")),
+            codex_role_adapter_body(
+                "orch-tdd", install.load_role_profiles()["orch-worker"], Path("X")
+            ),
         )
 
     def test_the_built_plan_renders_it_on_every_role_bearing_surface(self):

--- a/tests/test_skill_fork_governance.py
+++ b/tests/test_skill_fork_governance.py
@@ -233,7 +233,7 @@ class TheInstallerIsTheClausesOneOwner(unittest.TestCase):
         self.assertIn(
             FORK_ARRIVAL_CLAUSE,
             codex_role_adapter_body(
-                "orch-tdd", install.load_role_profiles()["orch-worker"], Path("X")
+                "orch-tdd", "worker", install.load_role_profiles()["orch-worker"], Path("X")
             ),
         )
 

--- a/tests/test_thin_orchestrator.py
+++ b/tests/test_thin_orchestrator.py
@@ -14,6 +14,18 @@ from tools import validate
 
 
 ROOT = Path(__file__).resolve().parents[1]
+PROFILE_OWNER_LINK = (
+    "[Role profiles](../../../engines/orch-frontier/references/profiles.md)"
+)
+
+
+def _custom_routing_uses_profile_owner(text: str) -> bool:
+    return (
+        PROFILE_OWNER_LINK in text
+        and "resolve the declared role" in text
+        and "use the native binding that owner returns" in text
+        and not re.search(r"\b(?:derive|reconstruct|synthesize)\b", text)
+    )
 
 
 def _frontmatter(path: str) -> dict[str, str]:
@@ -159,6 +171,7 @@ class ThinOrchestratorContractTests(unittest.TestCase):
     def test_custom_codex_routing_uses_the_resolved_native_binding(self):
         rendered = codex_role_adapter_body(
             "custom-worker",
+            "worker",
             {
                 "role": "worker",
                 "codex": {"agent_type": "resolved_worker", "fork_turns": "3"},
@@ -167,12 +180,26 @@ class ThinOrchestratorContractTests(unittest.TestCase):
         )
         self.assertIn("agent_type `resolved_worker`", rendered)
         self.assertIn("fork_turns `3`", rendered)
+        with self.assertRaisesRegex(ValueError, "declared role planner.*profile role worker"):
+            codex_role_adapter_body(
+                "custom-planner",
+                "planner",
+                {
+                    "role": "worker",
+                    "codex": {"agent_type": "resolved_worker", "fork_turns": "3"},
+                },
+                Path("X"),
+            )
 
         scopes = (
             ROOT / "skills/workflows/orch-build/references/scopes.md"
         ).read_text(encoding="utf-8")
-        for anchor in ("declared role", "canonical profile", "agent_type", "fork_turns"):
-            self.assertIn(anchor, scopes)
+        self.assertTrue(_custom_routing_uses_profile_owner(scopes))
+        reconstructed = scopes.replace(
+            "use the native binding that owner returns",
+            "reconstruct agent_type and fork_turns from the role name",
+        )
+        self.assertFalse(_custom_routing_uses_profile_owner(reconstructed))
 
 
 if __name__ == "__main__":

--- a/tests/test_thin_orchestrator.py
+++ b/tests/test_thin_orchestrator.py
@@ -9,6 +9,7 @@ from pathlib import Path
 from unittest.mock import patch
 
 import install
+from installer.packages import codex_role_adapter_body
 from tools import validate
 
 
@@ -128,6 +129,7 @@ class ThinOrchestratorContractTests(unittest.TestCase):
                 prompt = prompts[name]
                 for anchor in (
                     f"agent_type `orch_{role}`",
+                    "fork_turns `none`",
                     f"`{name}`",
                     "complete packet",
                     "matching role",
@@ -144,6 +146,7 @@ class ThinOrchestratorContractTests(unittest.TestCase):
                 content = redirects[name]
                 role = self.WORKFLOW_ROLES[name]
                 self.assertIn(f"agent_type `orch_{role}`", content)
+                self.assertIn("fork_turns `none`", content)
                 self.assertIn("matching role", content)
                 self.assertIn("refuse", content)
 
@@ -152,6 +155,24 @@ class ThinOrchestratorContractTests(unittest.TestCase):
         )
         for anchor in ("exact named skill", "directly", "never redispatch", "mismatched"):
             self.assertIn(anchor, role_agent)
+
+    def test_custom_codex_routing_uses_the_resolved_native_binding(self):
+        rendered = codex_role_adapter_body(
+            "custom-worker",
+            {
+                "role": "worker",
+                "codex": {"agent_type": "resolved_worker", "fork_turns": "3"},
+            },
+            Path("X"),
+        )
+        self.assertIn("agent_type `resolved_worker`", rendered)
+        self.assertIn("fork_turns `3`", rendered)
+
+        scopes = (
+            ROOT / "skills/workflows/orch-build/references/scopes.md"
+        ).read_text(encoding="utf-8")
+        for anchor in ("declared role", "canonical profile", "agent_type", "fork_turns"):
+            self.assertIn(anchor, scopes)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Fixes the Codex dispatch defect where role-bearing subagents could inherit full parent history despite the profile contract requiring a non-full-history fork.

- validates fork_turns as a native Codex profile binding
- threads resolved agent_type and fork_turns into generated role dispatches
- adds regression coverage and updates the serial compatibility manifest
- preserves main's combined-skill chain behavior unchanged

Verification: uv run --no-project python tools/run_required.py (pass)