### PR TITLE
A T0 pin is a digest of the contract, not of its line endings

### DIFF
--- a/tests/serial_compat_manifest.json
+++ b/tests/serial_compat_manifest.json
@@ -1,6 +1,6 @@
 {
  "discovery": {
-  "count": 3135,
+  "count": 3137,
   "identities": [
    "test_affected_tests.TestDiscoveryCache.test_a_new_commit_is_a_new_key_and_is_discovered_again",
    "test_affected_tests.TestDiscoveryCache.test_a_tree_that_cannot_answer_for_a_commit_falls_back_and_says_so",
@@ -2748,6 +2748,8 @@
    "tests.test_ui_cases.workflows_projection.WorkflowProjectionTests.test_catalog_detail_and_source_are_closed_and_inventory_exact",
    "tests.test_ui_cases.workflows_projection.WorkflowProjectionTests.test_evolve_source_contract_delivers_the_selected_canonical_text",
    "tests.test_ui_cases.workflows_projection.WorkflowProjectionTests.test_unknown_workflow_and_source_are_generic_not_found",
+   "tests.test_validate_cases.contract_pins.ContractPinIsNewlineInsensitiveTest.test_a_changed_clause_still_moves_the_pin",
+   "tests.test_validate_cases.contract_pins.ContractPinIsNewlineInsensitiveTest.test_crlf_and_lf_pin_the_same_contract",
    "tests.test_validate_cases.sink_contracts.TestContractsNameTheSink.test_each_contract_states_its_sink_path",
    "tests.test_validate_cases.sink_contracts.TestContractsNameTheSink.test_no_contract_composes_a_run_state_path_from_the_repository",
    "tests.test_validate_cases.sink_contracts.TestWorkItemLocationInvariant.test_the_clause_names_the_resolver_rather_than_restating_the_root",
@@ -3138,7 +3140,7 @@
    "tests.test_workspace_cases.start_cases.TestTheStampPreservesTheTicketsByteDomain.test_only_the_two_stamped_lines_differ_from_the_prior_bytes",
    "tests.test_workspace_cases.start_cases.TestTicketsPayloadIsGradedNotItsExitStatus.test_an_error_payload_returned_at_exit_zero_is_a_failure"
   ],
-  "sha256": "2d7eaef9a251c91b73cd23adb4fa02ad6c45e835feffeacec64960a6e3b338e1"
+  "sha256": "31abe295fcfb2ba3239d9614f9d03b2a31adc40be2972569e9c677e74ec91a45"
  },
  "mutation_owners": [
   {
@@ -6217,6 +6219,14 @@
   },
   {
    "module": "tests.test_validate",
+   "owner": "<module>",
+   "restoration": "sharded-module-guard",
+   "seams": [
+    "import-path"
+   ]
+  },
+  {
+   "module": "tests.test_validate_cases.contract_pins",
    "owner": "<module>",
    "restoration": "sharded-module-guard",
    "seams": [

--- a/tests/test_carriage_cases/script_ownership.py
+++ b/tests/test_carriage_cases/script_ownership.py
@@ -1,11 +1,12 @@
 """Repository script ownership checks."""
 
-import hashlib
 import json
 import re
 import unittest
 
-from ._support import CONTRACTS, PINS, ROOT
+from tools.validate_support.lint import compute_pins
+
+from ._support import PINS, ROOT
 
 ARCHITECTURE = ROOT / "ARCHITECTURE.md"
 
@@ -100,10 +101,16 @@ class ScriptOwnershipTest(unittest.TestCase):
             for phrase in phrases:
                 self.assertIn(phrase, text, f"{relative} lost semantic pin {phrase!r}")
 
+        # Through the one hasher, never a second copy of it: this check
+        # held its own `sha256(read_bytes())` and so was blind to the same
+        # thing `compute_pins` was -- a CRLF working copy pinning a digest
+        # no CI leg reproduces. Two copies of a rule drift apart silently.
         pins = json.loads(PINS.read_text(encoding="utf-8"))
+        computed = compute_pins()
         for name in ("work-item.md", "worklog.md"):
-            actual = hashlib.sha256((CONTRACTS / name).read_bytes()).hexdigest()
-            self.assertEqual(actual, pins.get(name), f"{name} has no current T0 pin")
+            self.assertEqual(
+                computed[name], pins.get(name), f"{name} has no current T0 pin"
+            )
 
         flat_architecture = re.sub(
             r"\s+", " ", ARCHITECTURE.read_text(encoding="utf-8")

--- a/tests/test_validate.py
+++ b/tests/test_validate.py
@@ -11,6 +11,9 @@ if str(_ROOT) not in sys.path:
 
 import tools.validate as validate  # noqa: E402
 
+from tests.test_validate_cases.contract_pins import (  # noqa: F401
+    ContractPinIsNewlineInsensitiveTest,
+)
 from tests.test_validate_cases.sink_contracts import (
     TestContractsNameTheSink,
     TestWorkItemLocationInvariant,

--- a/tests/test_validate_cases/contract_pins.py
+++ b/tests/test_validate_cases/contract_pins.py
@@ -1,0 +1,63 @@
+"""The T0 contract pin: a digest of the contract, not of its bytes' shape.
+
+`compute_pins` hashed raw bytes, and the tree stores LF
+(`.gitattributes`), so a working copy a Windows tool rewrote as CRLF
+pinned a digest that host alone could reproduce: `--pin` green where it
+ran, `T0 contract changed` on every CI leg, and five test modules red
+behind it. The guard whose whole job is to report a changed contract
+reported one that had not changed.
+
+Both halves are pinned here -- the endings do not move the digest, and
+real content still does -- in their own module, because
+`validator_ownership.py` sits four lines under the source ceiling.
+"""
+
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from tools.validate_support.lint import compute_pins  # noqa: E402
+
+LF = bytes((10,))
+CRLF = bytes((13, 10))
+CONTRACT = b"# Sample" + LF + LF + b"One clause the pin covers." + LF
+
+
+class ContractPinIsNewlineInsensitiveTest(unittest.TestCase):
+    def pin_of(self, tmp, text):
+        """The digest `compute_pins` gives a contracts directory holding
+        exactly ``text``. The directory is a parameter rather than a
+        patched global: a test that mutates module state owes the serial
+        manifest a restoration, and this one has nothing to restore."""
+
+        contracts = Path(tmp) / "contracts"
+        contracts.mkdir()
+        (contracts / "sample.md").write_bytes(text)
+        return compute_pins(contracts)["sample.md"]
+
+    def test_crlf_and_lf_pin_the_same_contract(self):
+        with tempfile.TemporaryDirectory() as one, tempfile.TemporaryDirectory() as two:
+            self.assertEqual(
+                self.pin_of(one, CONTRACT),
+                self.pin_of(two, CONTRACT.replace(LF, CRLF)),
+                "the same contract pins two digests depending on the host "
+                "that last wrote it, which is the shape that reddened CI",
+            )
+
+    def test_a_changed_clause_still_moves_the_pin(self):
+        """Can-fail: normalizing must not flatten the check itself."""
+
+        with tempfile.TemporaryDirectory() as one, tempfile.TemporaryDirectory() as two:
+            self.assertNotEqual(
+                self.pin_of(one, CONTRACT),
+                self.pin_of(two, CONTRACT.replace(b"One", b"Two")),
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tools/validate_support/lint.py
+++ b/tools/validate_support/lint.py
@@ -65,10 +65,16 @@ def validate_cross_package_links(packages, diag: Diagnostics) -> None:
                     )
 
 
-def compute_pins() -> dict:
+def compute_pins(contracts_dir=None) -> dict:
+    # Newlines normalized before hashing, for the reason `write_pins` gives
+    # below: the tree stores LF (`.gitattributes`), so a working copy a
+    # Windows tool rewrote as CRLF is the same contract, and hashing its
+    # raw bytes pins a digest no other host can reproduce. That pin passes
+    # `--pin`'s own author and fails every CI leg, which is the worst shape
+    # a guard can have -- green where it is written, red where it is read.
     return {
-        f.name: hashlib.sha256(f.read_bytes()).hexdigest()
-        for f in sorted(CONTRACTS_DIR.glob("*.md"))
+        f.name: hashlib.sha256(f.read_bytes().replace(b"\r\n", b"\n")).hexdigest()
+        for f in sorted((contracts_dir or CONTRACTS_DIR).glob("*.md"))
     }
 
 


### PR DESCRIPTION
`compute_pins` hashes raw bytes. The tree stores LF (`.gitattributes` `* text=auto eol=lf`), so a working copy a Windows tool rewrote as CRLF is the same contract with a different digest — and `validate.py --pin` writes that digest into `tests/pins.json`. It passes on the host that wrote it and fails everywhere else.

That is exactly what happened to `main` at 440d022e: `T0 contract changed` on all five matrix legs, taking `test_carriage`, `test_validate`, `test_cell_linter`, `test_templates` and `test_validator` down behind one line of JSON. The guard whose whole job is to report a changed contract reported one that had not changed — green where it is written, red where it is read.

**The bad pin itself is already gone from `main`** — #101 re-pinned `work-item.md` at its LF digest on the way past. This PR removes the reason it could happen again.

## Changes

- `compute_pins` normalizes newlines before hashing, so a pin no longer depends on which host last wrote the file. LF trees hash exactly as before, so no existing pin moves. It also takes the contracts directory as a parameter, which lets a test exercise it without patching a module global (and so without owing the serial manifest a restoration).
- `tests/test_carriage_cases/script_ownership.py` carried a second copy of the hash and was blind to the same thing; it now calls the one hasher.
- `tests/test_validate_cases/contract_pins.py` pins both halves: line endings do not move the digest, and a changed clause still does.

## Checks

All five required checks exit 0 on this commit rebased onto `main` — `validate.py`, `run_tests.py` (86 modules, 3137 tests, 0 failures), `run_serial_compat.py`, `install.py --dry-run`, `git diff --check`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
