### PR TITLE
The lock is the file's: one poll loop, one prior, one built runtime

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -1,10 +1,14 @@
 # The checks AGENTS.md requires, run on every supported boundary.
 #
-# Versions: 3.9 is the floor `install.py` enforces via MIN_PYTHON. 3.11 is
-# the first release with stdlib `tomllib`, so the two sides of the
-# install.py import guard both get exercised. 3.13 is current. 3.10 and
-# 3.12 add no distinct code path -- each sits on the same side of that
-# guard as a version already here.
+# Versions: 3.9 is the floor `install.py` enforces via MIN_PYTHON, and the
+# only leg where stdlib `tomllib` is absent; 3.13 is current and covers the
+# side where it is present. That import guard is this repository's only
+# version-gated code, so no third version adds a distinct path -- 3.10,
+# 3.11 and 3.12 each sit on the same side of it as a version already here.
+#
+# The OS axis carries the signal instead. Over 198 runs, every failure that
+# no other leg caught was OS-specific, and 3.11 was never once the only leg
+# to fail. Which is why all three operating systems stay, at full width.
 #
 # Two local checks are deliberately absent. `git diff --check` inspects the
 # working tree, which a fresh checkout leaves clean by construction. The
@@ -56,6 +60,15 @@ jobs:
       - name: verify reproducible frontend build
         run: uv run --no-project python tools/ui_frontend.py verify-build
 
+      # The download, not the `--with-deps` apt half, which needs root and
+      # reinstalls either way. Keyed on the lockfile because that is what
+      # pins the browser: @playwright/test moving is what must miss here.
+      - name: cache the pinned browser
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/ms-playwright
+          key: ms-playwright-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}
+
       - name: install browser
         run: pnpm exec playwright install --with-deps chromium
 
@@ -70,16 +83,12 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: ['3.9', '3.11', '3.13']
+        python-version: ['3.9', '3.13']
         exclude:
           - os: macos-latest
             python-version: '3.9'
-          - os: macos-latest
-            python-version: '3.11'
           - os: windows-latest
             python-version: '3.9'
-          - os: windows-latest
-            python-version: '3.11'
 
     steps:
       # Full history, not the default depth-1: tests/test_cutcheck.py grades
@@ -107,6 +116,22 @@ jobs:
 
       - name: install exact reader backend
         run: uv pip install --system --require-hashes -r requirements-runtime.txt
+
+      # Without this the runner cold-starts on a static prior every run, and
+      # the prior can only be right for one leg at a time: macOS's longest
+      # module ran alone for the final third of its job, 87s of a 284s wall.
+      # Keyed per leg because the long pole moves by OS and interpreter. The
+      # run_id suffix writes a fresh entry each run while the prefix restores
+      # the newest earlier one -- a fixed key would pin the first run's
+      # timings forever. A pull request reads its base branch's entry, which
+      # is the same matrix leg over nearly the same suite.
+      - name: restore this leg's suite timings
+        uses: actions/cache@v4
+        with:
+          path: .orch/run_tests_times.json
+          key: run-tests-times-${{ matrix.os }}-py${{ matrix.python-version }}-${{ github.run_id }}
+          restore-keys: |
+            run-tests-times-${{ matrix.os }}-py${{ matrix.python-version }}-
 
       # The suite, sharded one module per child interpreter. Thread
       # parallelism is unsound here -- the suite performs ~30

--- a/scripts/tickets_result.py
+++ b/scripts/tickets_result.py
@@ -15,9 +15,9 @@ if __package__:
 else:
     from tickets_format import EXECUTOR_SECTIONS, EXECUTOR_SECTIONS_BY_KEY, TERMINAL_STATES, TicketFormatError, _extract_flag, _parse_frontmatter, _read_utf8, _section_body, _sections, _write_section, count_return_text, parse_return_size
 if __package__:
-    from .tickets_store import DEFAULT_RUN_STATE_TREE, NO_SINK_ERROR, RUN_IDENTITY_NAME, RUN_NOTES_NAME, RUN_STATE_TREES, _identity_update, _run_lock, _run_state_root, _runs_root, _segment_error, _tickets_root, _waiting_out_windows, _write_identity, _write_text_atomically
+    from .tickets_store import DEFAULT_RUN_STATE_TREE, NO_SINK_ERROR, RUN_IDENTITY_NAME, RUN_NOTES_NAME, RUN_STATE_TREES, _identity_update, _lock_windows_byte, _run_lock, _run_state_root, _runs_root, _segment_error, _tickets_root, _waiting_out_windows, _write_identity, _write_text_atomically
 else:
-    from tickets_store import DEFAULT_RUN_STATE_TREE, NO_SINK_ERROR, RUN_IDENTITY_NAME, RUN_NOTES_NAME, RUN_STATE_TREES, _identity_update, _run_lock, _run_state_root, _runs_root, _segment_error, _tickets_root, _waiting_out_windows, _write_identity, _write_text_atomically
+    from tickets_store import DEFAULT_RUN_STATE_TREE, NO_SINK_ERROR, RUN_IDENTITY_NAME, RUN_NOTES_NAME, RUN_STATE_TREES, _identity_update, _lock_windows_byte, _run_lock, _run_state_root, _runs_root, _segment_error, _tickets_root, _waiting_out_windows, _write_identity, _write_text_atomically
 if __package__:
     from .tickets_markdown import SECTION_SENTINEL
 else:
@@ -282,8 +282,8 @@ def _append_one_line(path: Path, block: str) -> None:
     never ran.
 
     So Windows locks and POSIX does not, and byte zero is the mutex: every
-    appender contends on the same byte. ``LK_LOCK`` is a mandatory range
-    lock, not an advisory one, so an append blocks another append and also
+    appender contends on the same byte. Every ``msvcrt`` mode is a mandatory
+    range lock, not an advisory one, so an append blocks another append and
     any reader that touches byte zero -- which on this file is every reader,
     since they all read from the start. A reader refused here retries; it has
     not found the file unreadable. Nothing here read-modify-writes. The lock
@@ -294,7 +294,13 @@ def _append_one_line(path: Path, block: str) -> None:
             handle.write(block)
             return
         handle.seek(0)
-        msvcrt.locking(handle.fileno(), msvcrt.LK_LOCK, 1)
+        # `_lock_windows_byte`, not `LK_LOCK`: that mode stops retrying after
+        # ten attempts and then raises, and eight appenders contending on one
+        # runner outlast it -- a note refused as `unwritable run state:
+        # [Errno 13] Permission denied` on a job that had passed the run
+        # before. The run lock left this mode for the same reason; this was
+        # the last site still on it.
+        _lock_windows_byte(handle)
         try:
             handle.write(block)
             handle.flush()

--- a/tests/serial_compat_manifest.json
+++ b/tests/serial_compat_manifest.json
@@ -1,6 +1,6 @@
 {
  "discovery": {
-  "count": 3198,
+  "count": 3201,
   "identities": [
    "test_affected_tests.TestDiscoveryCache.test_a_new_commit_is_a_new_key_and_is_discovered_again",
    "test_affected_tests.TestDiscoveryCache.test_a_tree_that_cannot_answer_for_a_commit_falls_back_and_says_so",
@@ -539,16 +539,11 @@
    "test_run_tests.TestGuardedSeams.test_each_import_time_whole_interpreter_leak_is_rejected_and_named",
    "test_run_tests.TestGuardedSeams.test_each_whole_interpreter_leak_is_rejected_and_named",
    "test_run_tests.TestSchedule.test_a_cold_custom_directory_remains_alphabetical",
+   "test_run_tests.TestSchedule.test_a_cold_prior_covers_the_long_pole_of_every_matrix_leg",
    "test_run_tests.TestSchedule.test_a_cold_repository_starts_known_slow_modules_first",
    "test_run_tests.TestSchedule.test_expected_failures_are_preserved_as_outcomes",
    "test_run_tests.TestSchedule.test_installer_cases_are_exactly_once_across_process_visible_shards",
    "test_run_tests.TestSchedule.test_timing_record_carries_context_occupancy_modules_and_outcomes",
-   "test_run_tests.TestWorkflowContract.test_ci_does_not_repeat_oracles_already_in_the_sharded_suite",
-   "test_run_tests.TestWorkflowContract.test_ci_has_exactly_the_five_supported_boundary_legs",
-   "test_run_tests.TestWorkflowContract.test_ci_runs_the_regression_suite_once_through_the_parallel_runner",
-   "test_run_tests.TestWorkflowContract.test_ci_uploads_each_python_legs_timing_even_after_failure",
-   "test_run_tests.TestWorkflowContract.test_selected_serial_is_routine_and_exhaustive_is_the_fallback",
-   "test_run_tests.TestWorkflowContract.test_star_imported_facades_do_not_export_test_cases",
    "test_run_tests_scope.TestNothingSelectedStillOwesItsAdmission.test_an_empty_selection_still_admits_the_paths_it_named",
    "test_run_tests_scope.TestNothingSelectedStillOwesItsAdmission.test_the_admission_precedes_the_selections_own_exit",
    "test_run_tests_scope.TestScopeSpelling.test_a_scope_by_itself_is_accepted",
@@ -1732,6 +1727,13 @@
    "tests.test_run_report_cases.tickets.TicketDurationTest.test_a_ticket_that_was_never_claimed_has_no_duration_to_report",
    "tests.test_run_report_cases.tickets.TicketDurationTest.test_each_executor_reports_its_median_p90_and_max",
    "tests.test_run_report_cases.tickets.TicketDurationTest.test_top_bounds_the_longest_list_and_leaves_the_executor_summary_whole",
+   "tests.test_run_tests_cases.workflow_contract.TestWorkflowContract.test_ci_does_not_repeat_oracles_already_in_the_sharded_suite",
+   "tests.test_run_tests_cases.workflow_contract.TestWorkflowContract.test_ci_has_exactly_the_four_supported_boundary_legs",
+   "tests.test_run_tests_cases.workflow_contract.TestWorkflowContract.test_ci_restores_a_timing_cache_scoped_to_the_leg_that_wrote_it",
+   "tests.test_run_tests_cases.workflow_contract.TestWorkflowContract.test_ci_runs_the_regression_suite_once_through_the_parallel_runner",
+   "tests.test_run_tests_cases.workflow_contract.TestWorkflowContract.test_ci_uploads_each_python_legs_timing_even_after_failure",
+   "tests.test_run_tests_cases.workflow_contract.TestWorkflowContract.test_selected_serial_is_routine_and_exhaustive_is_the_fallback",
+   "tests.test_run_tests_cases.workflow_contract.TestWorkflowContract.test_star_imported_facades_do_not_export_test_cases",
    "tests.test_search_plan_cases.archive.TestMergeLineage.test_complementary_merge_and_complete_fresh_lineage",
    "tests.test_search_plan_cases.archive.TestMergeLineage.test_cycle_dangling_reuse_and_inherited_score_are_rejected",
    "tests.test_search_plan_cases.archive.TestMergeLineage.test_settlement_is_exact_and_atomic",
@@ -2190,6 +2192,7 @@
    "tests.test_tickets_cases.run_state_artifacts.TestRunStateWorklog.test_a_note_from_a_worktree_appends_in_the_sink",
    "tests.test_tickets_cases.run_state_artifacts.TestRunStateWorklog.test_a_note_waits_past_the_windows_finite_lock_window",
    "tests.test_tickets_cases.run_state_artifacts.TestRunStateWorklog.test_a_prior_line_and_an_outside_writer_both_survive",
+   "tests.test_tickets_cases.run_state_artifacts.TestRunStateWorklog.test_an_append_waits_past_a_refusal_longer_than_the_finite_window",
    "tests.test_tickets_cases.run_state_artifacts.TestRunStateWorklog.test_concurrent_notes_all_land_whole",
    "tests.test_tickets_cases.run_state_resolution.TestFenceRepairHoldsBothDirections.test_the_repair_holds_in_both_directions",
    "tests.test_tickets_cases.run_state_resolution.TestIndentedFenceIsNotAFence.test_a_four_space_indented_fence_is_not_a_fence",
@@ -3201,7 +3204,7 @@
    "tests.test_workspace_cases.start_cases.TestTheStampPreservesTheTicketsByteDomain.test_only_the_two_stamped_lines_differ_from_the_prior_bytes",
    "tests.test_workspace_cases.start_cases.TestTicketsPayloadIsGradedNotItsExitStatus.test_an_error_payload_returned_at_exit_zero_is_a_failure"
   ],
-  "sha256": "d57eac3ed5c880d0dfd7ad5dfd555b5d165683954e7ecb4cbdfa5c1eb9677719"
+  "sha256": "a516cd9b1a6625e4e84ed9828f13875ea09e29483fe18d317f21070a1b75bc6e"
  },
  "mutation_owners": [
   {
@@ -4173,6 +4176,14 @@
    ]
   },
   {
+   "module": "tests.test_installer_cases.planning.private_runtime",
+   "owner": "RuntimeVenvTests.use_copied_runtime_builds",
+   "restoration": "sharded-module-guard",
+   "seams": [
+    "threads"
+   ]
+  },
+  {
    "module": "tests.test_installer_cases.planning.runtime",
    "owner": "TestClaudeAdapterSet._plan",
    "restoration": "sharded-module-guard",
@@ -4359,6 +4370,14 @@
    "restoration": "sharded-module-guard",
    "seams": [
     "environment"
+   ]
+  },
+  {
+   "module": "tests.test_installer_cases.support",
+   "owner": "copied_runtime_builds",
+   "restoration": "sharded-module-guard",
+   "seams": [
+    "monkeypatch"
    ]
   },
   {
@@ -5642,6 +5661,14 @@
    "restoration": "sharded-module-guard",
    "seams": [
     "environment"
+   ]
+  },
+  {
+   "module": "tests.test_tickets_cases.run_state_artifacts",
+   "owner": "TestRunStateWorklog.test_an_append_waits_past_a_refusal_longer_than_the_finite_window",
+   "restoration": "sharded-module-guard",
+   "seams": [
+    "monkeypatch"
    ]
   },
   {

--- a/tests/test_installer_cases/planning/private_runtime.py
+++ b/tests/test_installer_cases/planning/private_runtime.py
@@ -14,6 +14,17 @@ class RuntimeVenvTests(unittest.TestCase):
         self.home.mkdir()
         self.project_runtime = self.root / "project" / ".venv"
 
+    def use_copied_runtime_builds(self):
+        """Grade lifecycle policy over a copy of a real runtime, not a build.
+
+        Every case that calls this asks the installer for a runtime only so
+        that it has one to reuse, repair, refuse or retain. See the helper.
+        """
+
+        patcher = copied_runtime_builds()
+        patcher.start()
+        self.addCleanup(patcher.stop)
+
     def test_user_install_uses_private_runtime_when_project_venv_is_active(self):
         install.venv.EnvBuilder(symlinks=os.name != "nt", with_pip=False).create(
             self.project_runtime
@@ -51,6 +62,7 @@ class RuntimeVenvTests(unittest.TestCase):
         self.assertNotIn(str(self.project_runtime), rendered)
 
     def test_user_install_reuses_healthy_private_runtime(self):
+        self.use_copied_runtime_builds()
         with patch.object(install.Path, "home", return_value=self.home), mock_host_clis("codex"):
             install.apply_plan(install.build_plan("user", None))
             marker = install.private_runtime_home() / "reuse-marker"
@@ -79,6 +91,7 @@ class RuntimeVenvTests(unittest.TestCase):
         self.assertFalse(runtime_python.resolve().is_relative_to(runtime_home.resolve()))
 
     def test_user_install_repairs_an_unhealthy_private_runtime(self):
+        self.use_copied_runtime_builds()
         with patch.object(install.Path, "home", return_value=self.home), mock_host_clis("codex"):
             install.apply_plan(install.build_plan("user", None))
             runtime_home = install.private_runtime_home()
@@ -107,6 +120,7 @@ class RuntimeVenvTests(unittest.TestCase):
         self.assertEqual([], list(self.home.iterdir()))
 
     def test_failed_repair_preserves_the_previous_runtime(self):
+        self.use_copied_runtime_builds()
         with patch.object(install.Path, "home", return_value=self.home), mock_host_clis("codex"):
             install.apply_plan(install.build_plan("user", None))
             runtime_home = install.private_runtime_home()
@@ -137,6 +151,7 @@ class RuntimeVenvTests(unittest.TestCase):
         self.assertEqual("keep", marker.read_text(encoding="utf-8"))
 
     def test_rendered_friction_command_executes_from_a_spaced_home(self):
+        self.use_copied_runtime_builds()
         spaced_home = self.root / "home with spaces"
         spaced_home.mkdir()
         with patch.object(install.Path, "home", return_value=spaced_home), mock_host_clis("codex"):
@@ -170,6 +185,7 @@ class RuntimeVenvTests(unittest.TestCase):
         self.assertEqual("friction logged", completed.stdout.strip())
 
     def test_dry_run_reports_create_reuse_and_repair(self):
+        self.use_copied_runtime_builds()
         with patch.object(install.Path, "home", return_value=self.home), mock_host_clis("codex"):
             self.assertEqual("create", install.build_plan("user", None).runtime_action)
             install.apply_plan(install.build_plan("user", None))
@@ -182,6 +198,7 @@ class RuntimeVenvTests(unittest.TestCase):
             self.assertEqual("repair", install.build_plan("user", None).runtime_action)
 
     def test_failed_first_install_leaves_runtime_discoverable_to_uninstall(self):
+        self.use_copied_runtime_builds()
         with patch.object(install.Path, "home", return_value=self.home), mock_host_clis("codex"):
             plan = install.build_plan("user", None)
             real_create = install._create_private_runtime
@@ -202,6 +219,7 @@ class RuntimeVenvTests(unittest.TestCase):
         self.assertIn("retained", manual[str(runtime_home)])
 
     def test_update_and_uninstall_follow_the_private_runtime_policy(self):
+        self.use_copied_runtime_builds()
         with patch.object(install.Path, "home", return_value=self.home), mock_host_clis("codex"):
             first = install.apply_plan(install.build_plan("user", None))
             runtime_home = install.private_runtime_home()

--- a/tests/test_installer_cases/support.py
+++ b/tests/test_installer_cases/support.py
@@ -40,14 +40,70 @@ _SHARED: dict = {}
 
 def tearDownModule():
     _ENV_GUARD.stop()
-    for key in ("root", "uninstall_root"):
+    # Each root is dropped with the value cached out of it. Dropping the root
+    # alone would leave the cache answering a later caller with a path this
+    # just deleted -- the builders below all treat a present key as a hit.
+    for key, cached in (
+        ("root", "value"),
+        ("uninstall_root", "uninstalled"),
+        ("runtime_template_root", "runtime_template"),
+    ):
+        _SHARED.pop(cached, None)
         root = _SHARED.pop(key, None)
         if root is not None:
             # Strict, like every other removal in this suite: a root that
-            # cannot be removed is a failure worth hearing, and neither shared
+            # cannot be removed is a failure worth hearing, and no shared
             # root can hold a repository, so `tree_removal.remove_repo_tree`
             # is not the owner here (see its docstring's scope clause).
             shutil.rmtree(root)
+
+
+def built_runtime_template() -> Path:
+    """One really-built private runtime, kept for this process to copy from.
+
+    A build is ``ensurepip`` plus a hash-locked dependency install -- 14s on
+    the author's host, 8s per test on the Windows leg -- and the lifecycle
+    cases asked for ten of them. What those cases grade is policy: reuse,
+    repair, refuse, uninstall retention, receipt state. None of it is about
+    how the runtime was made, and a copy of a real one satisfies the same
+    health probe at any path, which is asserted here before any copy is made.
+
+    The builder's own output stays covered by the two cases that grade it:
+    the symlinked base interpreter, and the end-to-end install run out of an
+    active project venv. Both keep calling the real builder.
+    """
+
+    if "runtime_template" not in _SHARED:
+        root = Path(tempfile.mkdtemp(prefix="orchflows-runtime-template-"))
+        _SHARED["runtime_template_root"] = root
+        template = root / "runtime"
+        install._build_private_runtime(template)
+        if not install.private_runtime_is_healthy(template):
+            raise RuntimeError("runtime template is unhealthy; refusing to seed copies")
+        _SHARED["runtime_template"] = template
+    return _SHARED["runtime_template"]
+
+
+def copied_runtime_builds():
+    """Patch the runtime builder to copy `built_runtime_template` into place.
+
+    ``_create_private_runtime`` reads the builder off ``install`` at call
+    time, so patching the module attribute reaches the staging build inside
+    it. ``dirs_exist_ok``: that staging directory is an existing mkdtemp.
+
+    The template is resolved here, before the patch exists. Resolving it
+    inside ``build`` would route the template's own build back through the
+    patch that build is meant to satisfy, and recur until the stack ends.
+    """
+
+    template = built_runtime_template()
+
+    def build(runtime_home):
+        home = Path(runtime_home)
+        shutil.copytree(template, home, symlinks=True, dirs_exist_ok=True)
+        return install.private_runtime_python(home)
+
+    return patch.object(install, "_build_private_runtime", new=build)
 
 
 def relocated_user_install():

--- a/tests/test_run_tests.py
+++ b/tests/test_run_tests.py
@@ -18,6 +18,9 @@ if str(REPO_ROOT) not in sys.path:
     sys.path.insert(0, str(REPO_ROOT))
 
 from tools import run_tests  # noqa: E402
+from tests.test_run_tests_cases.workflow_contract import (  # noqa: E402,F401
+    TestWorkflowContract,
+)
 RUN_TESTS_PY = REPO_ROOT / "tools" / "run_tests.py"
 CHECKS_YML = REPO_ROOT / ".github" / "workflows" / "checks.yml"
 AGENTS_MD = REPO_ROOT / "AGENTS.md"
@@ -207,114 +210,6 @@ class TestGuardedSeams(unittest.TestCase):
         self.assertIn("FAILED MODULE: test_fixture (exit 7)", report)
 
 
-class TestWorkflowContract(unittest.TestCase):
-    def test_star_imported_facades_do_not_export_test_cases(self):
-        facade_pattern = re.compile(
-            r"^from (tests\.test_[^. ]+) import \*", re.MULTILINE
-        )
-        facades = {
-            match.group(1)
-            for path in (REPO_ROOT / "tests").rglob("*.py")
-            for match in facade_pattern.finditer(path.read_text(encoding="utf-8"))
-        }
-        offenders = []
-        for module_name in sorted(facades):
-            module = importlib.import_module(module_name)
-            exported = getattr(
-                module,
-                "__all__",
-                tuple(name for name in vars(module) if not name.startswith("_")),
-            )
-            offenders.extend(
-                "{}.{}".format(module_name, name)
-                for name in exported
-                if isinstance(getattr(module, name), type)
-                and issubclass(getattr(module, name), unittest.TestCase)
-            )
-        self.assertEqual([], offenders)
-
-    def test_ci_has_exactly_the_five_supported_boundary_legs(self):
-        workflow = CHECKS_YML.read_text(encoding="utf-8")
-        matrix = workflow.split("      matrix:\n", 1)[1].split("\n    steps:", 1)[0]
-        os_axis = re.search(r"^        os: \[([^]]+)\]$", matrix, re.MULTILINE)
-        python_axis = re.search(
-            r"^        python-version: \[([^]]+)\]$", matrix, re.MULTILINE
-        )
-        self.assertIsNotNone(os_axis)
-        self.assertIsNotNone(python_axis)
-        self.assertNotRegex(matrix, re.compile(r"^        include:", re.MULTILINE))
-        self.assertEqual(
-            {"os", "python-version", "exclude"},
-            set(re.findall(r"^        ([a-z][a-z0-9-]*):", matrix, re.MULTILINE)),
-        )
-        self.assertEqual(
-            1,
-            len(re.findall(
-                r"^    runs-on: \$\{\{ matrix\.os \}\}$", workflow, re.MULTILINE
-            )),
-        )
-        self.assertEqual(
-            1,
-            len(re.findall(
-                r"^          python-version: \$\{\{ matrix\.python-version \}\}$",
-                workflow,
-                re.MULTILINE,
-            )),
-        )
-
-        def values(match):
-            return [value.strip(" '\"") for value in match.group(1).split(",")]
-
-        excluded = set(re.findall(
-            r"- os: ([a-z-]+)\s+python-version: ['\"]([0-9.]+)['\"]",
-            matrix,
-        ))
-        legs = [
-            (os_name, python_version)
-            for os_name in values(os_axis)
-            for python_version in values(python_axis)
-            if (os_name, python_version) not in excluded
-        ]
-        self.assertEqual(
-            [
-                ("ubuntu-latest", "3.9"),
-                ("ubuntu-latest", "3.11"),
-                ("ubuntu-latest", "3.13"),
-                ("macos-latest", "3.13"),
-                ("windows-latest", "3.13"),
-            ],
-            legs,
-        )
-
-    def test_ci_runs_the_regression_suite_once_through_the_parallel_runner(self):
-        workflow = CHECKS_YML.read_text(encoding="utf-8")
-        self.assertEqual(1, workflow.count("run: python tools/run_tests.py"))
-        self.assertNotIn("run: python -m unittest discover", workflow)
-
-    def test_ci_uploads_each_python_legs_timing_even_after_failure(self):
-        workflow = CHECKS_YML.read_text(encoding="utf-8")
-        self.assertIn("--timing-file .orch/run-tests.json", workflow)
-        self.assertIn("uses: actions/upload-artifact@v4", workflow)
-        self.assertIn("if: ${{ always() }}", workflow)
-        self.assertIn("path: .orch/run-tests.json", workflow)
-        self.assertIn("include-hidden-files: true", workflow)
-
-    def test_ci_does_not_repeat_oracles_already_in_the_sharded_suite(self):
-        workflow = CHECKS_YML.read_text(encoding="utf-8")
-        # TestValidatorAgainstRepo and DryRunOracleTest cover these commands
-        # inside the one sharded suite invocation above.
-        self.assertNotIn("run: python tools/validate.py", workflow)
-        self.assertNotIn("run: python install.py --dry-run", workflow)
-
-    def test_selected_serial_is_routine_and_exhaustive_is_the_fallback(self):
-        guidance = AGENTS_MD.read_text(encoding="utf-8")
-        self.assertIn("python tools/run_serial_compat.py", guidance)
-        self.assertIn("python -m unittest discover -s tests -v", guidance)
-        self.assertIn("routinely", guidance)
-        self.assertIn("scheduled/manual", guidance)
-        self.assertIn("pre-release", guidance)
-
-
 class TestSchedule(unittest.TestCase):
     def test_installer_cases_are_exactly_once_across_process_visible_shards(self):
         modules = [
@@ -386,6 +281,17 @@ class TestSchedule(unittest.TestCase):
             ["tests.test_installer_planning", "tests.test_installer_shared",
              "tests.test_cutcheck", "tests.test_tickets", "tests.test_alpha"],
             run_tests.schedule(modules, {}, run_tests.DEFAULT_TESTS_DIR),
+        )
+
+    def test_a_cold_prior_covers_the_long_pole_of_every_matrix_leg(self):
+        """The prior was read off Linux, where these two are cheap. Each was
+        its own leg's longest module, sorted last, and ran alone to the end:
+        141s of macOS's 284s wall, 120s of py3.9's 207s."""
+        modules = ["tests.test_alpha", "tests.test_serial_compat",
+                   "tests.test_visualize_scripts", "tests.test_zeta"]
+        self.assertEqual(
+            ["tests.test_visualize_scripts", "tests.test_serial_compat"],
+            run_tests.schedule(modules, {}, run_tests.DEFAULT_TESTS_DIR)[:2],
         )
 
     def test_a_cold_custom_directory_remains_alphabetical(self):

--- a/tests/test_run_tests_cases/__init__.py
+++ b/tests/test_run_tests_cases/__init__.py
@@ -1,0 +1,1 @@
+"""Runner cases by seam; ``tests.test_run_tests`` stays the discovery target."""

--- a/tests/test_run_tests_cases/workflow_contract.py
+++ b/tests/test_run_tests_cases/workflow_contract.py
@@ -1,0 +1,142 @@
+"""What CI must invoke, and what it must not invoke twice.
+
+The matrix, the one sharded suite command, the per-leg timing artifact and
+the per-leg timing cache are all asserted against the workflow file itself.
+"""
+
+from __future__ import annotations
+import importlib
+import re
+import unittest
+from pathlib import Path
+
+# No sys.path guard: this module is reached only through
+# ``tests.test_run_tests``, so the repository root is already importable,
+# and mutating the path here would make the module an import-path seam owner.
+REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+CHECKS_YML = REPO_ROOT / ".github" / "workflows" / "checks.yml"
+AGENTS_MD = REPO_ROOT / "AGENTS.md"
+
+
+class TestWorkflowContract(unittest.TestCase):
+    def test_star_imported_facades_do_not_export_test_cases(self):
+        facade_pattern = re.compile(
+            r"^from (tests\.test_[^. ]+) import \*", re.MULTILINE
+        )
+        facades = {
+            match.group(1)
+            for path in (REPO_ROOT / "tests").rglob("*.py")
+            for match in facade_pattern.finditer(path.read_text(encoding="utf-8"))
+        }
+        offenders = []
+        for module_name in sorted(facades):
+            module = importlib.import_module(module_name)
+            exported = getattr(
+                module,
+                "__all__",
+                tuple(name for name in vars(module) if not name.startswith("_")),
+            )
+            offenders.extend(
+                "{}.{}".format(module_name, name)
+                for name in exported
+                if isinstance(getattr(module, name), type)
+                and issubclass(getattr(module, name), unittest.TestCase)
+            )
+        self.assertEqual([], offenders)
+
+    def test_ci_has_exactly_the_four_supported_boundary_legs(self):
+        workflow = CHECKS_YML.read_text(encoding="utf-8")
+        matrix = workflow.split("      matrix:\n", 1)[1].split("\n    steps:", 1)[0]
+        os_axis = re.search(r"^        os: \[([^]]+)\]$", matrix, re.MULTILINE)
+        python_axis = re.search(
+            r"^        python-version: \[([^]]+)\]$", matrix, re.MULTILINE
+        )
+        self.assertIsNotNone(os_axis)
+        self.assertIsNotNone(python_axis)
+        self.assertNotRegex(matrix, re.compile(r"^        include:", re.MULTILINE))
+        self.assertEqual(
+            {"os", "python-version", "exclude"},
+            set(re.findall(r"^        ([a-z][a-z0-9-]*):", matrix, re.MULTILINE)),
+        )
+        self.assertEqual(
+            1,
+            len(re.findall(
+                r"^    runs-on: \$\{\{ matrix\.os \}\}$", workflow, re.MULTILINE
+            )),
+        )
+        self.assertEqual(
+            1,
+            len(re.findall(
+                r"^          python-version: \$\{\{ matrix\.python-version \}\}$",
+                workflow,
+                re.MULTILINE,
+            )),
+        )
+
+        def values(match):
+            return [value.strip(" '\"") for value in match.group(1).split(",")]
+
+        excluded = set(re.findall(
+            r"- os: ([a-z-]+)\s+python-version: ['\"]([0-9.]+)['\"]",
+            matrix,
+        ))
+        legs = [
+            (os_name, python_version)
+            for os_name in values(os_axis)
+            for python_version in values(python_axis)
+            if (os_name, python_version) not in excluded
+        ]
+        self.assertEqual(
+            [
+                ("ubuntu-latest", "3.9"),
+                ("ubuntu-latest", "3.13"),
+                ("macos-latest", "3.13"),
+                ("windows-latest", "3.13"),
+            ],
+            legs,
+        )
+        # Both sides of the one version-gated import, and no third copy of
+        # either side: 3.9 has no `tomllib`, every other supported version
+        # has it, and which side a leg is on is all this axis can grade.
+        self.assertEqual({"3.9", "3.13"}, set(values(python_axis)))
+
+    def test_ci_runs_the_regression_suite_once_through_the_parallel_runner(self):
+        workflow = CHECKS_YML.read_text(encoding="utf-8")
+        self.assertEqual(1, workflow.count("run: python tools/run_tests.py"))
+        self.assertNotIn("run: python -m unittest discover", workflow)
+
+    def test_ci_uploads_each_python_legs_timing_even_after_failure(self):
+        workflow = CHECKS_YML.read_text(encoding="utf-8")
+        self.assertIn("--timing-file .orch/run-tests.json", workflow)
+        self.assertIn("uses: actions/upload-artifact@v4", workflow)
+        self.assertIn("if: ${{ always() }}", workflow)
+        self.assertIn("path: .orch/run-tests.json", workflow)
+        self.assertIn("include-hidden-files: true", workflow)
+
+    def test_ci_restores_a_timing_cache_scoped_to_the_leg_that_wrote_it(self):
+        """A shared or fixed key is worse than none: it would schedule every
+        leg by another leg's long pole, or freeze the first run's timings."""
+        workflow = CHECKS_YML.read_text(encoding="utf-8")
+        self.assertIn("uses: actions/cache@v4", workflow)
+        self.assertIn("path: .orch/run_tests_times.json", workflow)
+        leg = "${{ matrix.os }}-py${{ matrix.python-version }}"
+        self.assertIn("key: run-tests-times-" + leg + "-${{ github.run_id }}", workflow)
+        self.assertIn("restore-keys: |", workflow)
+        # Twelve spaces of indent: the key line above already holds the
+        # bare prefix, so only the restore-keys entry can satisfy this.
+        self.assertIn("            run-tests-times-" + leg + "-", workflow)
+
+    def test_ci_does_not_repeat_oracles_already_in_the_sharded_suite(self):
+        workflow = CHECKS_YML.read_text(encoding="utf-8")
+        # TestValidatorAgainstRepo and DryRunOracleTest cover these commands
+        # inside the one sharded suite invocation above.
+        self.assertNotIn("run: python tools/validate.py", workflow)
+        self.assertNotIn("run: python install.py --dry-run", workflow)
+
+    def test_selected_serial_is_routine_and_exhaustive_is_the_fallback(self):
+        guidance = AGENTS_MD.read_text(encoding="utf-8")
+        self.assertIn("python tools/run_serial_compat.py", guidance)
+        self.assertIn("python -m unittest discover -s tests -v", guidance)
+        self.assertIn("routinely", guidance)
+        self.assertIn("scheduled/manual", guidance)
+        self.assertIn("pre-release", guidance)

--- a/tests/test_tickets_cases/run_state_artifacts.py
+++ b/tests/test_tickets_cases/run_state_artifacts.py
@@ -3,6 +3,7 @@
 import time
 
 from .result_sections import *  # noqa: F401,F403
+from scripts import tickets_result as tickets_result_mod
 from scripts import tickets_store as tickets_store_mod
 
 def run_dir_of(run: str = "testrun") -> Path:
@@ -163,6 +164,40 @@ class TestRunStateWorklog(unittest.TestCase):
             )
             self.assertEqual(0, process.returncode, stdout or stderr)
             self.assertEqual([note], notes_of().read_text(encoding="utf-8").splitlines())
+
+
+    def test_an_append_waits_past_a_refusal_longer_than_the_finite_window(self):
+        """The sibling case above holds the *run* lock, so its child blocks
+        there and never reaches this one. `LK_LOCK` stops retrying after ten
+        attempts and raises; byte zero here is contended by every appender,
+        and eight of them on one runner outlast that -- reported as
+        `unwritable run state: [Errno 13] Permission denied`.
+        """
+
+        if tickets_store_mod.msvcrt is None:
+            self.skipTest("the finite retry window is Windows-only")
+        with tempfile.TemporaryDirectory() as tmp:
+            path = Path(tmp) / "notes.md"
+            path.write_text("first\n", encoding="utf-8")
+            real = tickets_store_mod.msvcrt.locking
+            refusals = {"count": 0}
+
+            def refusing(descriptor, mode, size):
+                # Both lock modes, never the unlock: a mode that gives up at
+                # ten must fail this, and one that waits must clear it.
+                if mode != tickets_store_mod.msvcrt.LK_UNLCK and refusals["count"] < 25:
+                    refusals["count"] += 1
+                    raise PermissionError(13, "Permission denied")
+                return real(descriptor, mode, size)
+
+            with mock.patch.object(
+                tickets_store_mod.msvcrt, "locking", refusing
+            ), mock.patch.object(
+                tickets_store_mod, "WINDOWS_LOCK_RETRY_SECONDS", 0.001
+            ):
+                tickets_result_mod._append_one_line(path, "second\n")
+            self.assertEqual(25, refusals["count"], "the appender stopped waiting early")
+            self.assertEqual("first\nsecond\n", path.read_text(encoding="utf-8"))
 
 
 class TestRunStateArtifact(unittest.TestCase):

--- a/tools/run_tests.py
+++ b/tools/run_tests.py
@@ -34,12 +34,16 @@ ROOT = Path(__file__).resolve().parent.parent
 DEFAULT_TESTS_DIR = ROOT / "tests"
 CACHE_PATH = ROOT / ".orch" / "run_tests_times.json"
 TIMING_PATH = ROOT / ".orch" / "run_tests_record.json"
-DEFAULT_COLD_ORDER = (
-    "tests.test_installer_planning", "tests.test_installer_shared",
-    "tests.test_cutcheck", "tests.test_tickets",
-    "tests.test_workspace", "tests.test_installer_hosts",
-    "tests.test_installer_receipt", "tests.test_validate",
-)
+# Cold-checkout order: the modules whose *worst* matrix leg is expensive,
+# that leg's duration descending. Worst and not typical -- the long pole
+# moves by leg (visualize_scripts on macOS, serial_compat on 3.9) and
+# starting a module early costs nothing on a leg where it is cheap. Read
+# off the timing artifacts CI uploads; a leg with a cache never reads it.
+DEFAULT_COLD_ORDER = tuple("tests.test_" + _name for _name in (
+    "visualize_scripts", "installer_planning", "workspace", "serial_compat",
+    "installer_shared", "cutcheck", "tickets", "validate", "ui",
+    "run_required", "affected_tests", "cell_linter",
+))
 IMPORT_BOOTSTRAP_ROOTS = frozenset(
     os.path.normcase(os.path.abspath(str(ROOT / relative)))
     for relative in (".", "scripts", "benchmarks/benchmaker/tools",


### PR DESCRIPTION
## The bug

Three Windows lock-acquisition sites; two use a poll loop, one did not.

```
friction.py:353          LK_NBLCK   ← poll loop
tickets_store.py:49      LK_NBLCK   ← poll loop  (_lock_windows_byte)
tickets_result.py:297    LK_LOCK    ← gives up after ten attempts, then raises
```

`msvcrt.LK_LOCK` raises `PermissionError: [Errno 13] Permission denied` when its
finite retry window expires. That is verbatim the failure that took the
3.13/windows leg on 2026-08-24:

```
{'error': 'unwritable run state: [Errno 13] Permission denied'}
```

Under contention — eight appenders on one saturated runner — a note is refused
rather than recorded. `_lock_windows_byte` exists precisely because `LK_LOCK`
"stops retrying after ten attempts, unlike the blocking `flock` used on POSIX";
`_append_one_line` was the one site the fix never reached.

The existing guard could not see it. `test_a_note_waits_past_the_windows_finite_lock_window`
holds the **run** lock — already on the poll loop — so its child blocks there and
never reaches the append. It passed against the exact hazard it was written for.
The new case reaches the append path and fails against `LK_LOCK`.

## The speed work

Measured from the timing artifacts CI already uploads.

**Scheduling.** The cold-start prior was read off Linux, where the longest
modules on other legs are cheap. macOS ran `visualize_scripts` alone for the
final 141s of a 284s wall; py3.9 ran `serial_compat` alone for 120s of 207s.
The prior is now each module's worst leg descending, and CI restores a per-leg
timing cache so the prior is only consulted on a miss.

**Runtime builds.** `RuntimeVenvTests` asked the installer for ten real
`ensurepip`-plus-hash-locked-install builds. Two cases grade the builder; seven
grade lifecycle policy over whatever runtime happens to exist. One template is
built per process, asserted healthy through the installer's own probe, then
copied — 12.04s vs 0.94s locally. Module: **174.8s → 87.5s**.

**Matrix.** 3.11 is dropped. The `tomllib` import guard is this repository's only
version-gated code, 3.11 sits on the same side of it as 3.13, and over 198 runs
it was never once the only leg to fail. Every failure no other leg caught was
OS-specific, so all three operating systems stay at full width.

| | wall | machine | billable |
|---|---|---|---|
| before | 5m07s | 19.0 min | ~23 |
| after | ~4m04s | ~12.6 min | ~16 |

## Verification

`python tools/run_required.py` green (all five). 3,138 tests; manifest
regenerated, newly detected owners ruled `sharded-module-guard`.

Every new test was checked against a mutant: reverting `LK_LOCK`, reverting the
cold order, deleting the cache step, and deleting only `restore-keys` while
keeping `key:` each turn their guard red.

## Known, not addressed here

`test_visualize_scripts` costs **141.1s on macOS and 1.0s on Linux**. All ten of
its subprocess/socket cases are in `preview.py`; `npx`, DNS and browser launching
are ruled out. `TIMEOUT_SECONDS = 60` with a CLI that takes exactly one argument
is the available mechanism. Needs per-test timings from a macOS runner.

🤖 Generated with [Claude Code](https://claude.com/claude-code)