### PR TITLE
Windows is split because the pipeline waits on it, and only it

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -76,7 +76,7 @@ jobs:
         run: uv run --no-project python tools/ui_frontend.py smoke --browser chromium
 
   checks:
-    name: py${{ matrix.python-version }} / ${{ matrix.os }}
+    name: py${{ matrix.python-version }} / ${{ matrix.os }} / ${{ matrix.shard }}
     runs-on: ${{ matrix.os }}
     strategy:
       # Every leg reports. A red 3.9 must not hide the state of Windows.
@@ -84,11 +84,28 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
         python-version: ['3.9', '3.13']
+        # Windows alone is split, and only in two. It is the slowest leg, so
+        # it is the one the pipeline's wall clock waits on; splitting it costs
+        # nothing billed, because two half-length Windows jobs round to the
+        # same minutes as one whole. Splitting the others would buy no wall
+        # clock -- each already finishes inside macOS's whole-suite time --
+        # and macOS bills at ten times the rate. `1-of-1` is the whole suite.
+        shard: ['1-of-1', '1-of-2', '2-of-2']
         exclude:
           - os: macos-latest
             python-version: '3.9'
           - os: windows-latest
             python-version: '3.9'
+          - os: ubuntu-latest
+            shard: '1-of-2'
+          - os: ubuntu-latest
+            shard: '2-of-2'
+          - os: macos-latest
+            shard: '1-of-2'
+          - os: macos-latest
+            shard: '2-of-2'
+          - os: windows-latest
+            shard: '1-of-1'
 
     steps:
       # Full history, not the default depth-1: tests/test_cutcheck.py grades
@@ -129,9 +146,9 @@ jobs:
         uses: actions/cache@v4
         with:
           path: .orch/run_tests_times.json
-          key: run-tests-times-${{ matrix.os }}-py${{ matrix.python-version }}-${{ github.run_id }}
+          key: run-tests-times-${{ matrix.os }}-py${{ matrix.python-version }}-${{ matrix.shard }}-${{ github.run_id }}
           restore-keys: |
-            run-tests-times-${{ matrix.os }}-py${{ matrix.python-version }}-
+            run-tests-times-${{ matrix.os }}-py${{ matrix.python-version }}-${{ matrix.shard }}-
 
       # The suite, sharded one module per child interpreter. Thread
       # parallelism is unsound here -- the suite performs ~30
@@ -140,13 +157,13 @@ jobs:
       # TestValidatorAgainstRepo and DryRunOracleTest cases cover the
       # validator and installer dry run without repeating either command.
       - name: python tools/run_tests.py
-        run: python tools/run_tests.py --timing-file .orch/run-tests.json
+        run: python tools/run_tests.py --shard ${{ matrix.shard }} --timing-file .orch/run-tests.json
 
       - name: upload test timing
         if: ${{ always() }}
         uses: actions/upload-artifact@v4
         with:
-          name: test-timing-py${{ matrix.python-version }}-${{ matrix.os }}
+          name: test-timing-py${{ matrix.python-version }}-${{ matrix.os }}-${{ matrix.shard }}
           path: .orch/run-tests.json
           if-no-files-found: warn
           include-hidden-files: true

--- a/tests/serial_compat_manifest.json
+++ b/tests/serial_compat_manifest.json
@@ -1,6 +1,6 @@
 {
  "discovery": {
-  "count": 3201,
+  "count": 3204,
   "identities": [
    "test_affected_tests.TestDiscoveryCache.test_a_new_commit_is_a_new_key_and_is_discovered_again",
    "test_affected_tests.TestDiscoveryCache.test_a_tree_that_cannot_answer_for_a_commit_falls_back_and_says_so",
@@ -541,8 +541,11 @@
    "test_run_tests.TestSchedule.test_a_cold_custom_directory_remains_alphabetical",
    "test_run_tests.TestSchedule.test_a_cold_prior_covers_the_long_pole_of_every_matrix_leg",
    "test_run_tests.TestSchedule.test_a_cold_repository_starts_known_slow_modules_first",
+   "test_run_tests.TestSchedule.test_a_shard_is_round_robin_over_the_longest_first_order",
+   "test_run_tests.TestSchedule.test_an_absent_shard_is_the_whole_order_and_a_bad_one_is_refused",
    "test_run_tests.TestSchedule.test_expected_failures_are_preserved_as_outcomes",
    "test_run_tests.TestSchedule.test_installer_cases_are_exactly_once_across_process_visible_shards",
+   "test_run_tests.TestSchedule.test_shards_partition_the_schedule_exactly",
    "test_run_tests.TestSchedule.test_timing_record_carries_context_occupancy_modules_and_outcomes",
    "test_run_tests_scope.TestNothingSelectedStillOwesItsAdmission.test_an_empty_selection_still_admits_the_paths_it_named",
    "test_run_tests_scope.TestNothingSelectedStillOwesItsAdmission.test_the_admission_precedes_the_selections_own_exit",
@@ -1727,8 +1730,8 @@
    "tests.test_run_report_cases.tickets.TicketDurationTest.test_a_ticket_that_was_never_claimed_has_no_duration_to_report",
    "tests.test_run_report_cases.tickets.TicketDurationTest.test_each_executor_reports_its_median_p90_and_max",
    "tests.test_run_report_cases.tickets.TicketDurationTest.test_top_bounds_the_longest_list_and_leaves_the_executor_summary_whole",
+   "tests.test_run_tests_cases.workflow_contract.TestWorkflowContract.test_ci_covers_four_boundaries_whole_and_splits_only_windows",
    "tests.test_run_tests_cases.workflow_contract.TestWorkflowContract.test_ci_does_not_repeat_oracles_already_in_the_sharded_suite",
-   "tests.test_run_tests_cases.workflow_contract.TestWorkflowContract.test_ci_has_exactly_the_four_supported_boundary_legs",
    "tests.test_run_tests_cases.workflow_contract.TestWorkflowContract.test_ci_restores_a_timing_cache_scoped_to_the_leg_that_wrote_it",
    "tests.test_run_tests_cases.workflow_contract.TestWorkflowContract.test_ci_runs_the_regression_suite_once_through_the_parallel_runner",
    "tests.test_run_tests_cases.workflow_contract.TestWorkflowContract.test_ci_uploads_each_python_legs_timing_even_after_failure",
@@ -3204,7 +3207,7 @@
    "tests.test_workspace_cases.start_cases.TestTheStampPreservesTheTicketsByteDomain.test_only_the_two_stamped_lines_differ_from_the_prior_bytes",
    "tests.test_workspace_cases.start_cases.TestTicketsPayloadIsGradedNotItsExitStatus.test_an_error_payload_returned_at_exit_zero_is_a_failure"
   ],
-  "sha256": "a516cd9b1a6625e4e84ed9828f13875ea09e29483fe18d317f21070a1b75bc6e"
+  "sha256": "cd9f7107650472a48152101f9f8defda1ab79263efcad59a8e4fb833c78f7e86"
  },
  "mutation_owners": [
   {

--- a/tests/test_run_tests.py
+++ b/tests/test_run_tests.py
@@ -18,6 +18,7 @@ if str(REPO_ROOT) not in sys.path:
     sys.path.insert(0, str(REPO_ROOT))
 
 from tools import run_tests  # noqa: E402
+from tools import run_tests_scope  # noqa: E402
 from tests.test_run_tests_cases.workflow_contract import (  # noqa: E402,F401
     TestWorkflowContract,
 )
@@ -293,6 +294,33 @@ class TestSchedule(unittest.TestCase):
             ["tests.test_visualize_scripts", "tests.test_serial_compat"],
             run_tests.schedule(modules, {}, run_tests.DEFAULT_TESTS_DIR)[:2],
         )
+
+    def test_shards_partition_the_schedule_exactly(self):
+        """Every module in exactly one shard. A shard that drops one runs a
+        green half-suite, and a shard that repeats one pays for it twice."""
+        order = ["tests.test_%02d" % index for index in range(23)]
+        for count in range(1, 6):
+            shards = [
+                run_tests_scope.shard("%d-of-%d" % (index, count), order)
+                for index in range(1, count + 1)
+            ]
+            union = [module for shard in shards for module in shard]
+            self.assertEqual(sorted(order), sorted(union), "count=%d" % count)
+            self.assertEqual(len(union), len(set(union)), "count=%d" % count)
+
+    def test_a_shard_is_round_robin_over_the_longest_first_order(self):
+        """Contiguous halves would take every long module into the first one,
+        which finishes no sooner than the unsharded suite did."""
+        order = ["a", "b", "c", "d", "e"]
+        self.assertEqual(["a", "c", "e"], run_tests_scope.shard("1-of-2", order))
+        self.assertEqual(["b", "d"], run_tests_scope.shard("2-of-2", order))
+
+    def test_an_absent_shard_is_the_whole_order_and_a_bad_one_is_refused(self):
+        order = ["a", "b"]
+        self.assertEqual(order, run_tests_scope.shard(None, order))
+        for bad in ("3-of-2", "0-of-2", "2-of-0", "1/2", "two-of-three", "2"):
+            with self.assertRaises(SystemExit, msg=bad):
+                run_tests_scope.shard(bad, order)
 
     def test_a_cold_custom_directory_remains_alphabetical(self):
         with tempfile.TemporaryDirectory() as tmp:

--- a/tests/test_run_tests_cases/workflow_contract.py
+++ b/tests/test_run_tests_cases/workflow_contract.py
@@ -44,18 +44,20 @@ class TestWorkflowContract(unittest.TestCase):
             )
         self.assertEqual([], offenders)
 
-    def test_ci_has_exactly_the_four_supported_boundary_legs(self):
+    def test_ci_covers_four_boundaries_whole_and_splits_only_windows(self):
         workflow = CHECKS_YML.read_text(encoding="utf-8")
         matrix = workflow.split("      matrix:\n", 1)[1].split("\n    steps:", 1)[0]
         os_axis = re.search(r"^        os: \[([^]]+)\]$", matrix, re.MULTILINE)
         python_axis = re.search(
             r"^        python-version: \[([^]]+)\]$", matrix, re.MULTILINE
         )
+        shard_axis = re.search(r"^        shard: \[([^]]+)\]$", matrix, re.MULTILINE)
         self.assertIsNotNone(os_axis)
         self.assertIsNotNone(python_axis)
+        self.assertIsNotNone(shard_axis)
         self.assertNotRegex(matrix, re.compile(r"^        include:", re.MULTILINE))
         self.assertEqual(
-            {"os", "python-version", "exclude"},
+            {"os", "python-version", "shard", "exclude"},
             set(re.findall(r"^        ([a-z][a-z0-9-]*):", matrix, re.MULTILINE)),
         )
         self.assertEqual(
@@ -76,25 +78,54 @@ class TestWorkflowContract(unittest.TestCase):
         def values(match):
             return [value.strip(" '\"") for value in match.group(1).split(",")]
 
-        excluded = set(re.findall(
-            r"- os: ([a-z-]+)\s+python-version: ['\"]([0-9.]+)['\"]",
-            matrix,
-        ))
-        legs = [
-            (os_name, python_version)
+        # An exclude entry names only the keys it constrains, so it is read as
+        # a dict and applied as a subset -- `- os: ubuntu-latest / shard: 1-of-2`
+        # drops that shard on every interpreter without naming one.
+        excludes, entry = [], None
+        for line in matrix.splitlines():
+            opened = re.match(r"^          - ([a-z-]+): '?([^'\s]+)'?$", line)
+            if opened:
+                entry = {opened.group(1): opened.group(2)}
+                excludes.append(entry)
+                continue
+            carried = re.match(r"^            ([a-z-]+): '?([^'\s]+)'?$", line)
+            if carried and entry is not None:
+                entry[carried.group(1)] = carried.group(2)
+
+        def dropped(job):
+            return any(all(job[key] == value for key, value in e.items()) for e in excludes)
+
+        jobs = [
+            (os_name, python_version, shard)
             for os_name in values(os_axis)
             for python_version in values(python_axis)
-            if (os_name, python_version) not in excluded
+            for shard in values(shard_axis)
+            if not dropped(
+                {"os": os_name, "python-version": python_version, "shard": shard})
         ]
         self.assertEqual(
             [
-                ("ubuntu-latest", "3.9"),
-                ("ubuntu-latest", "3.13"),
-                ("macos-latest", "3.13"),
-                ("windows-latest", "3.13"),
+                ("ubuntu-latest", "3.9", "1-of-1"),
+                ("ubuntu-latest", "3.13", "1-of-1"),
+                ("macos-latest", "3.13", "1-of-1"),
+                ("windows-latest", "3.13", "1-of-2"),
+                ("windows-latest", "3.13", "2-of-2"),
             ],
-            legs,
+            jobs,
         )
+        # The invariant a leg list alone cannot hold: every boundary's shards
+        # must be a *complete* cover. Excluding one half of a split leg leaves
+        # a green job that ran a hand-picked half of the suite.
+        covers = {}
+        for os_name, python_version, shard in jobs:
+            covers.setdefault((os_name, python_version), set()).add(shard)
+        for boundary, shards in covers.items():
+            count = int(next(iter(shards)).split("-of-")[1])
+            self.assertEqual(
+                {"%d-of-%d" % (index, count) for index in range(1, count + 1)},
+                shards,
+                "%s runs a partial suite" % (boundary,),
+            )
         # Both sides of the one version-gated import, and no third copy of
         # either side: 3.9 has no `tomllib`, every other supported version
         # has it, and which side a leg is on is all this axis can grade.
@@ -119,7 +150,10 @@ class TestWorkflowContract(unittest.TestCase):
         workflow = CHECKS_YML.read_text(encoding="utf-8")
         self.assertIn("uses: actions/cache@v4", workflow)
         self.assertIn("path: .orch/run_tests_times.json", workflow)
-        leg = "${{ matrix.os }}-py${{ matrix.python-version }}"
+        # The shard is part of the leg's identity: two shards of one leg run
+        # different modules, so one cache would answer the other with timings
+        # for modules it never runs, and they would race to save it.
+        leg = "${{ matrix.os }}-py${{ matrix.python-version }}-${{ matrix.shard }}"
         self.assertIn("key: run-tests-times-" + leg + "-${{ github.run_id }}", workflow)
         self.assertIn("restore-keys: |", workflow)
         # Twelve spaces of indent: the key line above already holds the

--- a/tools/run_tests.py
+++ b/tools/run_tests.py
@@ -405,14 +405,12 @@ def build_parser() -> argparse.ArgumentParser:
         help="worker processes (default: CPU count); -j 1 runs modules one at a time in order",
     )
     parser.add_argument("-v", "--verbose", action="store_true", help="verbose child test output")
-    parser.add_argument(
-        "--no-cache",
-        action="store_true",
-        help="ignore the duration cache: use cold-checkout scheduling",
-    )
+    parser.add_argument("--no-cache", action="store_true",
+                        help="ignore the duration cache: use cold-checkout scheduling")
     parser.add_argument(
         "--tests-dir", default=str(DEFAULT_TESTS_DIR), help="directory of test_*.py (default: tests/)"
     )
+    parser.add_argument("--shard", metavar="K-of-N", help="run only this shard of the scheduled order")
     parser.add_argument("--scope", help="run only the modules PATH[,PATH] affects (affected_tests.py)")
     parser.add_argument("--timing-file", help="write a machine-readable suite timing record")
     child = parser.add_argument_group("child mode (internal)")
@@ -462,7 +460,8 @@ def main(argv=None) -> int:
     # The cache is gitignored, so CI uses the repository's cold-start priors
     # while a local checkout that has run once schedules from measured time.
     # `--no-cache` is how a local run reproduces CI's co-scheduling.
-    ordered = schedule(selected, {} if args.no_cache else load_times(), tests_dir)
+    ordered = run_tests_scope.shard(
+        args.shard, schedule(selected, {} if args.no_cache else load_times(), tests_dir))
     jobs = min(args.jobs, len(ordered))
     print("running %d modules across %d workers" % (len(ordered), jobs))
     started = time.monotonic()

--- a/tools/run_tests_scope.py
+++ b/tools/run_tests_scope.py
@@ -143,3 +143,25 @@ def select(scope: str, tests_dir, discovered) -> list:
     if not selected:
         raise SystemExit(0)
     return selected
+def shard(selector, ordered: list) -> list:
+    """Return the ``K-of-N`` slice of an already-scheduled order, or all of it.
+
+    Round-robin over the schedule, never a contiguous block. The order this
+    receives is longest-first, so every N-th module hands each shard one of
+    each size class and the shards land together; a contiguous half would
+    take every long module into the first one and finish no sooner than the
+    whole suite did.
+
+    ``K-of-N`` and not ``K/N`` because CI carries this value into a cache key
+    and an artifact name, and an artifact name cannot hold a slash.
+    """
+
+    if not selector:
+        return ordered
+    parts = str(selector).split("-of-")
+    if len(parts) != 2 or not all(part.isdigit() for part in parts):
+        raise SystemExit("run_tests: --shard wants K-of-N, for example 2-of-3")
+    index, count = int(parts[0]), int(parts[1])
+    if count < 1 or not 1 <= index <= count:
+        raise SystemExit("run_tests: --shard %s names no shard of %d" % (selector, count))
+    return ordered[index - 1::count]


### PR DESCRIPTION
Follow-up to #103, which left this as the biggest remaining wall lever.

## What moves

The slowest leg sets the wall clock every other leg finishes inside, so that is
the one worth halving. `--shard K-of-N` takes every N-th module of the schedule,
which is already longest-first — round-robin hands each shard one of each size
class, where a contiguous half would take every long module into the first one
and finish no sooner than the whole suite did.

Measured against the last Windows run's real module durations, the split is
**629s / 550s of 1179s CPU**, four workers each.

| | wall | billed |
|---|---|---|
| windows leg today | ~332s | 6 min |
| windows, split in two | **~175s** | 6 min (3 + 3) |
| pipeline wall | 332s | → **~217s**, now macOS-bound |

## Why only Windows

Splitting the others buys no wall clock — each already finishes inside macOS's
whole-suite time — and macOS bills at ten times the rate. Two half-length
Windows jobs round to the same billed minutes as one whole, so wall clock is the
only thing that moves. Past this point the critical path is macOS's 217s, of
which 141s is the unexplained `test_visualize_scripts` anomaly; that is the next
thing to fix, not more shards.

`1-of-1` is the whole suite, so the matrix stays a product of its axes and the
leg list stays derivable — `include:` remains refused, as its contract test
requires.

## Where it lives

`tools/run_tests_scope.py`, whose module docstring already says it exists
because `tools/run_tests.py` stands at the 510-line ceiling. It owns what the
invocation admits, and a shard is that question. `run_tests.py` ends at 507.

The spelling is `K-of-N`, not `K/N`: the value names a cache key and an artifact,
and an artifact name cannot hold a slash. The shard also joins the cache key —
two shards of one leg run different modules, so one shared entry would answer
each with timings for modules it never runs, and they would race to save it.

## Verification

`python tools/run_required.py` green (all five, full unsharded suite). 3,204
tests. Every new test checked against a mutant:

- contiguous split instead of round-robin → red
- drop one module per shard (a silent half-suite) → red
- exclude one Windows shard in the workflow → red, `windows-latest runs a partial suite`

That last one is the invariant a leg list cannot hold: every boundary's shards
must be a **complete cover**, or a green job ran a hand-picked half of the suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)