### PR TITLE
Preview binds a literal address, so it must not resolve a name

### DIFF
--- a/skills/utilities/orch-visualize/scripts/preview.py
+++ b/skills/utilities/orch-visualize/scripts/preview.py
@@ -2,6 +2,7 @@
 """Serve one rendered visualization once on an ephemeral loopback port."""
 
 import json
+import socketserver
 import sys
 import time
 import urllib.parse
@@ -13,6 +14,22 @@ TIMEOUT_SECONDS = 60
 
 
 class _PreviewServer(HTTPServer):
+    def server_bind(self):
+        """Bind without the reverse lookup ``HTTPServer`` does for its name.
+
+        ``HTTPServer.server_bind`` calls ``socket.getfqdn`` on the address it
+        binds. That is a reverse DNS query, and where the resolver does not
+        answer from a hosts file it blocks: on a macOS runner the preview
+        cases cost 141s against 1.0s on Linux and 1.4s on Windows, one stall
+        per server built. The address here is a literal loopback one and
+        nothing reads ``server_name``, so the query buys nothing at any
+        speed. Preview holds the port for one GET; a resolver's timeout is
+        not a cost it can carry.
+        """
+
+        socketserver.TCPServer.server_bind(self)
+        self.server_name, self.server_port = self.server_address[:2]
+
     def __init__(self, address, handler):
         super().__init__(address, handler)
         self.successful_get = False

--- a/tests/serial_compat_manifest.json
+++ b/tests/serial_compat_manifest.json
@@ -1,6 +1,6 @@
 {
  "discovery": {
-  "count": 3204,
+  "count": 3205,
   "identities": [
    "test_affected_tests.TestDiscoveryCache.test_a_new_commit_is_a_new_key_and_is_discovered_again",
    "test_affected_tests.TestDiscoveryCache.test_a_tree_that_cannot_answer_for_a_commit_falls_back_and_says_so",
@@ -3052,6 +3052,7 @@
    "tests.test_validator_cases.repo_and_frontmatter.TestValidatorAgainstRepo.test_repo_passes_clean",
    "tests.test_visualize_scripts_cases.command_line.TestCommandLineEntry.test_non_codepage_unicode_never_crashes_the_verifier",
    "tests.test_visualize_scripts_cases.command_line.TestCommandLineEntry.test_renderer_without_the_cli_writes_no_page_and_exits_two",
+   "tests.test_visualize_scripts_cases.preview.TestPreviewBindsWithoutResolving.test_building_the_server_performs_no_reverse_lookup",
    "tests.test_visualize_scripts_cases.preview.TestPreviewFailureCleanup.test_accept_socket_error_is_immediate_and_closes_server",
    "tests.test_visualize_scripts_cases.preview.TestPreviewFailureCleanup.test_connected_client_that_sends_no_request_is_bounded_by_deadline",
    "tests.test_visualize_scripts_cases.preview.TestPreviewFailureCleanup.test_read_and_bind_failures_emit_no_readiness",
@@ -3207,7 +3208,7 @@
    "tests.test_workspace_cases.start_cases.TestTheStampPreservesTheTicketsByteDomain.test_only_the_two_stamped_lines_differ_from_the_prior_bytes",
    "tests.test_workspace_cases.start_cases.TestTicketsPayloadIsGradedNotItsExitStatus.test_an_error_payload_returned_at_exit_zero_is_a_failure"
   ],
-  "sha256": "cd9f7107650472a48152101f9f8defda1ab79263efcad59a8e4fb833c78f7e86"
+  "sha256": "7758e42bfc1540145398b2a87e3804fd44b6a6231ae15422abd9e4d37968df22"
  },
  "mutation_owners": [
   {
@@ -6437,6 +6438,14 @@
    "restoration": "sharded-module-guard",
    "seams": [
     "environment"
+   ]
+  },
+  {
+   "module": "tests.test_visualize_scripts_cases.preview",
+   "owner": "TestPreviewBindsWithoutResolving.test_building_the_server_performs_no_reverse_lookup",
+   "restoration": "sharded-module-guard",
+   "seams": [
+    "monkeypatch"
    ]
   },
   {

--- a/tests/test_visualize_scripts.py
+++ b/tests/test_visualize_scripts.py
@@ -9,6 +9,7 @@ from tests.test_visualize_scripts_cases.command_line import (  # noqa: F401
     TestCommandLineEntry,
 )
 from tests.test_visualize_scripts_cases.preview import (  # noqa: F401
+    TestPreviewBindsWithoutResolving,
     TestPreviewFailureCleanup,
     TestPreviewReadinessAndExactFile,
     TestPreviewSkillContract,

--- a/tests/test_visualize_scripts_cases/preview.py
+++ b/tests/test_visualize_scripts_cases/preview.py
@@ -49,6 +49,29 @@ class _PreviewProcess:
             self.process.communicate()
 
 
+class TestPreviewBindsWithoutResolving(unittest.TestCase):
+    def test_building_the_server_performs_no_reverse_lookup(self):
+        """``HTTPServer.server_bind`` reverse-resolves the address it binds,
+        once per server built. Where the resolver does not answer from a hosts
+        file it blocks: these cases cost 141s on a macOS runner against 1.0s
+        on Linux. The address is a literal and nothing reads the name it
+        would produce, so the query is pure latency.
+        """
+
+        def refuse(*_args, **_kwargs):
+            raise AssertionError("preview resolved a name while binding")
+
+        with mock.patch.object(socket, "getfqdn", refuse):
+            server = preview._PreviewServer(
+                ("127.0.0.1", 0), preview._handler_for("/page.html", b"<p>x</p>")
+            )
+            try:
+                self.assertEqual("127.0.0.1", server.server_address[0])
+                self.assertEqual(server.server_address[1], server.server_port)
+            finally:
+                server.server_close()
+
+
 class TestPreviewReadinessAndExactFile(unittest.TestCase):
     def test_missing_input_is_refused_before_readiness(self):
         with tempfile.TemporaryDirectory() as tmp:


### PR DESCRIPTION
The last item from the CI work in #103 and #104, and the one that had stayed
unexplained: `tests.test_visualize_scripts` costs **141.1s on macOS against
1.0s on Linux and 1.4s on Windows** — 143x, one module.

## Cause

`http.server.HTTPServer.server_bind` is:

```python
def server_bind(self):
    """Override server_bind to store the server name."""
    socketserver.TCPServer.server_bind(self)
    host, port = self.server_address[:2]
    self.server_name = socket.getfqdn(host)      # <-- reverse DNS, per server
    self.server_port = port
```

`socket.getfqdn` is a reverse DNS query, run once per server built. Where the
resolver answers from a hosts file it is free — Linux, and 9ms on the author's
Windows host. Where it does not, it blocks in the system resolver. That file
builds a server eight times in process plus once per preview subprocess, which
is the shape of 141s.

Since #104 split Windows, macOS is the pipeline's critical path, and this module
is half the macOS job.

## Fix

Preview binds a literal loopback address and nothing reads `server_name`, so the
query cannot answer anything the caller did not already supply. It binds through
`socketserver.TCPServer` and names itself from the address it got. A one-shot
server that holds a port for a single GET cannot carry a resolver's timeout.

## Verification

`python tools/run_required.py` green (all five). 3,205 tests.

The guard patches `socket.getfqdn` to **refuse**, so an unfixed bind fails rather
than merely slows — restoring `HTTPServer`'s own `server_bind` turns it red with
`preview resolved a name while binding`.

Worth noting how the guard was nearly useless: added as a new case class it ran
**nowhere**, because `tests/test_visualize_scripts.py` names its case classes
explicitly and I had not added it. The module stayed a 45-test module after a
case was added to it. #102's registration check is what makes that visible; the
class is now registered and the count is 46.

The macOS magnitude is the one thing local verification cannot show — this PR's
own CI run measures it, and the timing artifacts make it checkable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)