### PR TITLE
U2: key workspace behavior by adapter

### DIFF
--- a/scripts/tickets.py
+++ b/scripts/tickets.py
@@ -23,6 +23,7 @@ if _SIBLING_DIR not in _bootstrap_sys.path:
     _bootstrap_sys.path.append(_SIBLING_DIR)
 
 if __package__:
+    from . import tickets_adapters as _tickets_adapters_module
     from . import tickets_bound as _tickets_bound_module
     from . import tickets_format as _tickets_format_module
     from . import tickets_store as _tickets_store_module
@@ -41,6 +42,7 @@ if __package__:
 else:
     # By name, as `tickets_generations` is reached: the family's
     # module-level import census is pinned, and this module joined after it.
+    import tickets_adapters as _tickets_adapters_module
     _tickets_bound_module = __import__('tickets_bound')
     import tickets_format as _tickets_format_module
     import tickets_store as _tickets_store_module
@@ -128,9 +130,11 @@ _write_section = _tickets_format_module._write_section
 instruction_words = _tickets_format_module.instruction_words
 ticket_defects = _tickets_format_module.ticket_defects
 ADMISSION_PENDING = _tickets_admission_module.ADMISSION_PENDING
-ADAPTER_BY_PACK = _tickets_admission_module.ADAPTER_BY_PACK
 PACK_EXECUTOR_BINDINGS = _tickets_admission_module.PACK_EXECUTOR_BINDINGS
-adapter_id = _tickets_admission_module.adapter_id
+ADAPTER_REGISTRY = _tickets_adapters_module.ADAPTER_REGISTRY
+AdapterError = _tickets_adapters_module.AdapterError
+adapter_id = _tickets_adapters_module.adapter_id
+adapter_spec = _tickets_adapters_module.adapter_spec
 binding_findings = _tickets_admission_module.binding_findings
 grade_admission = _tickets_admission_module.grade_admission
 is_receipt = _tickets_admission_module.is_receipt

--- a/scripts/tickets.py
+++ b/scripts/tickets.py
@@ -73,7 +73,6 @@ DISPATCHING_EXECUTORS = _tickets_format_module.DISPATCHING_EXECUTORS
 DURATION_RE = _tickets_format_module.DURATION_RE
 EXECUTOR_SECTIONS = _tickets_format_module.EXECUTOR_SECTIONS
 EXECUTOR_SECTIONS_BY_KEY = _tickets_format_module.EXECUTOR_SECTIONS_BY_KEY
-GIT_WORKSPACE_MECHANISMS = _tickets_format_module.GIT_WORKSPACE_MECHANISMS
 INSTRUCTION_BUDGET = _tickets_format_module.INSTRUCTION_BUDGET
 INSTRUCTION_SECTIONS = _tickets_format_module.INSTRUCTION_SECTIONS
 LINK_TARGET_RE = _tickets_format_module.LINK_TARGET_RE
@@ -82,14 +81,6 @@ OPTIONAL_SECTIONS = _tickets_format_module.OPTIONAL_SECTIONS
 PACKS_DIR = _tickets_worklog_module.PACKS_DIR
 PACK_NAME_PREFIX = _tickets_format_module.PACK_NAME_PREFIX
 PACK_NAME_SUFFIX = _tickets_format_module.PACK_NAME_SUFFIX
-PACK_WORKSPACE_MECHANISMS = {
-    "orch-code-pack": "git",
-    "orch-content-pack": "document tree",
-    "orch-design-pack": "git plus render",
-    "orch-research-pack": "evidence store",
-}
-_tickets_format_module.PACK_WORKSPACE_MECHANISMS = PACK_WORKSPACE_MECHANISMS
-_tickets_store_module.PACK_WORKSPACE_MECHANISMS = PACK_WORKSPACE_MECHANISMS
 PLACEHOLDER_RE = _tickets_format_module.PLACEHOLDER_RE
 REQUIRED_ISOLATION = _tickets_format_module.REQUIRED_ISOLATION
 REQUIRED_LIFECYCLE_KEYS = _tickets_format_module.REQUIRED_LIFECYCLE_KEYS
@@ -132,6 +123,7 @@ ticket_defects = _tickets_format_module.ticket_defects
 ADMISSION_PENDING = _tickets_admission_module.ADMISSION_PENDING
 PACK_EXECUTOR_BINDINGS = _tickets_admission_module.PACK_EXECUTOR_BINDINGS
 ADAPTER_REGISTRY = _tickets_adapters_module.ADAPTER_REGISTRY
+Adapter = _tickets_adapters_module.Adapter
 AdapterError = _tickets_adapters_module.AdapterError
 adapter_id = _tickets_adapters_module.adapter_id
 adapter_spec = _tickets_adapters_module.adapter_spec
@@ -196,9 +188,6 @@ _workspace_root = _tickets_store_module._workspace_root
 _write_identity = _tickets_store_module._write_identity
 _write_text_atomically = _tickets_store_module._write_text_atomically
 _writer_identity = _tickets_store_module._writer_identity
-def establishes_a_git_workspace(name: str) -> bool:
-    _tickets_store_module.PACK_WORKSPACE_MECHANISMS = PACK_WORKSPACE_MECHANISMS
-    return _tickets_store_module.establishes_a_git_workspace(name)
 normalized_isolation = _tickets_store_module.normalized_isolation
 INDEPENDENCE_VALUES = _tickets_issue_module.INDEPENDENCE_VALUES
 ISOLATION_VALUES = _tickets_issue_module.ISOLATION_VALUES
@@ -324,8 +313,6 @@ contextmanager = _tickets_store_module.contextmanager
 Path = _tickets_store_module.Path
 
 def _sync_seams():
-    _tickets_format_module.PACK_WORKSPACE_MECHANISMS = PACK_WORKSPACE_MECHANISMS
-    _tickets_store_module.PACK_WORKSPACE_MECHANISMS = PACK_WORKSPACE_MECHANISMS
     _tickets_store_module.REPLACE_BUDGET_SECONDS = REPLACE_BUDGET_SECONDS
     _tickets_store_module.REPLACE_RETRY_SECONDS = REPLACE_RETRY_SECONDS
     _tickets_store_module._cwd = _cwd

--- a/scripts/tickets_adapters.py
+++ b/scripts/tickets_adapters.py
@@ -1,0 +1,151 @@
+"""Pack-declared workspace adapters and their closed mechanism registry."""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from pathlib import Path
+
+try:
+    from scripts import state_root
+except ImportError:
+    import state_root
+
+
+@dataclass(frozen=True)
+class Adapter:
+    """Properties machinery may branch on for one implemented mechanism."""
+
+    key: str
+    identity_form: str
+    establishes_isolation: bool
+    deterministic_gate: bool
+    conflict_semantics: str
+    workspace_strategy: str
+
+
+ADAPTER_REGISTRY = {
+    "document-tree": Adapter(
+        key="document-tree",
+        identity_form="document-revision",
+        establishes_isolation=False,
+        deterministic_gate=False,
+        conflict_semantics="section-overlap",
+        workspace_strategy="document-tree",
+    ),
+    "evidence-store": Adapter(
+        key="evidence-store",
+        identity_form="evidence-packet",
+        establishes_isolation=True,
+        deterministic_gate=False,
+        conflict_semantics="append-only-lanes",
+        workspace_strategy="evidence-store",
+    ),
+    "git": Adapter(
+        key="git",
+        identity_form="git-commit",
+        establishes_isolation=True,
+        deterministic_gate=True,
+        conflict_semantics="git-overlap",
+        workspace_strategy="git",
+    ),
+    "git-plus-render": Adapter(
+        key="git-plus-render",
+        identity_form="view-identity",
+        establishes_isolation=True,
+        deterministic_gate=True,
+        conflict_semantics="view-overlap",
+        workspace_strategy="git",
+    ),
+}
+
+_ADAPTER_DECLARATION = re.compile(r"ticket adapter:\s*`([^`]+)`")
+
+
+class AdapterError(ValueError):
+    """A pack cannot select one closed registered adapter."""
+
+    def __init__(self, code: str, detail: str):
+        super().__init__(detail)
+        self.code = code
+        self.detail = detail
+
+
+def _candidate_roots(root=None):
+    start = Path(root or Path.cwd()).resolve()
+    for directory in (start, *start.parents):
+        yield directory / "packs"
+        yield directory / ".orchflows" / "packs"
+    try:
+        yield state_root.state_root().parent / "lib" / "packs"
+    except OSError:
+        pass
+    source = Path(__file__).resolve().parent.parent / "packs"
+    yield source
+
+
+def pack_path(pack, *, root=None) -> Path:
+    """Resolve the stamped pack in project, installed, then source scope."""
+
+    name = str(pack or "").strip().strip("`").strip()
+    if not name:
+        raise AdapterError("pack-unresolved", "ticket names no pack")
+    seen = set()
+    for packs_root in _candidate_roots(root):
+        candidate = (packs_root / name / "SKILL.md").resolve()
+        if candidate in seen:
+            continue
+        seen.add(candidate)
+        if candidate.is_file():
+            return candidate
+    raise AdapterError("pack-unresolved", f"pack does not resolve: {name}")
+
+
+def declared_adapter(pack, *, root=None) -> str:
+    """Read the stable adapter key from the pack's workspace cell."""
+
+    path = pack_path(pack, root=root)
+    try:
+        text = path.read_text(encoding="utf-8")
+    except (OSError, UnicodeDecodeError) as error:
+        raise AdapterError("pack-unreadable", f"unreadable pack {path}: {error}") from error
+    matches = []
+    for line in text.splitlines():
+        stripped = line.strip()
+        if not stripped.startswith("|"):
+            continue
+        cells = [cell.strip() for cell in stripped.strip("|").split("|")]
+        if len(cells) >= 2 and cells[0] == "workspace":
+            matches.extend(_ADAPTER_DECLARATION.findall(cells[1]))
+    if len(matches) != 1 or not matches[0].strip():
+        raise AdapterError(
+            "adapter-declaration-invalid",
+            f"pack workspace cell must declare exactly one ticket adapter: {path}",
+        )
+    return matches[0].strip()
+
+
+def adapter_for_key(key: str) -> Adapter:
+    """Return one implemented adapter or fail closed on its declared key."""
+
+    normalized = str(key or "").strip()
+    adapter = ADAPTER_REGISTRY.get(normalized)
+    if adapter is None:
+        raise AdapterError(
+            "adapter-unregistered", f"pack declares unregistered adapter: {normalized or '<missing>'}",
+        )
+    return adapter
+
+
+def adapter_spec(pack, *, root=None) -> Adapter:
+    return adapter_for_key(declared_adapter(pack, root=root))
+
+
+def adapter_id(pack, *, root=None) -> str:
+    return adapter_spec(pack, root=root).key
+
+
+__all__ = (
+    "ADAPTER_REGISTRY", "Adapter", "AdapterError", "adapter_for_key",
+    "adapter_id", "adapter_spec", "declared_adapter", "pack_path",
+)

--- a/scripts/tickets_admission.py
+++ b/scripts/tickets_admission.py
@@ -7,14 +7,16 @@ import re
 from pathlib import Path
 
 if __package__:
+    from .tickets_adapters import AdapterError
     from .tickets_format import (
-        ADAPTER_BY_PACK, GATE_EXECUTORS, PACK_EXECUTOR_BINDINGS, PLAIN_ADAPTER,
+        GATE_EXECUTORS, PACK_EXECUTOR_BINDINGS,
         ROOT_EXECUTOR, SCRIPT_EXECUTOR_PREFIX, adapter_id, canonical_json,
         executor_bindings, _executor_of, _parse_frontmatter,
     )
 else:
+    from tickets_adapters import AdapterError
     from tickets_format import (
-        ADAPTER_BY_PACK, GATE_EXECUTORS, PACK_EXECUTOR_BINDINGS, PLAIN_ADAPTER,
+        GATE_EXECUTORS, PACK_EXECUTOR_BINDINGS,
         ROOT_EXECUTOR, SCRIPT_EXECUTOR_PREFIX, adapter_id, canonical_json,
         executor_bindings, _executor_of, _parse_frontmatter,
     )
@@ -37,6 +39,17 @@ def _ordered(findings) -> list:
         for item in findings
     }
     return [finding(*row) for row in sorted(rows)]
+
+
+def adapter_resolution(pack):
+    """Resolve one declared pack adapter as data, never as a traceback."""
+
+    if not str(pack or "").strip():
+        return None, None
+    try:
+        return adapter_id(pack), None
+    except AdapterError as error:
+        return None, finding(error.code, "pack", error.detail)
 
 
 def binding_findings(ticket_id: str, data: dict) -> list:
@@ -64,7 +77,10 @@ def binding_findings(ticket_id: str, data: dict) -> list:
                 f"executor names script '{target or '<missing>'}', which does not resolve in the tree",
             ))
     if executor == "orch-tdd":
-        if adapter_id(pack) != "git":
+        adapter, adapter_failure = adapter_resolution(pack)
+        if adapter_failure is not None:
+            findings.append(adapter_failure)
+        elif adapter != "git":
             findings.append(finding("vcs-adapter-required", "pack", "orch-tdd requires the git adapter"))
         if str(data.get("isolation") or "none").strip() != "required":
             findings.append(finding(
@@ -128,6 +144,9 @@ def grade_admission(ticket_id: str, text: str, siblings: dict, context=None) -> 
         assignment_digest = module.assignment_digest
         seal_findings = module.seal_findings
     findings = list(seal_findings(ticket_id, text))
+    adapter, adapter_failure = adapter_resolution(data.get("pack"))
+    if adapter_failure is not None:
+        findings.append(adapter_failure)
     dependencies = [str(value) for value in (data.get("depends_on") or [])]
     for dependency in dependencies:
         if dependency not in siblings:
@@ -199,10 +218,9 @@ def grade_admission(ticket_id: str, text: str, siblings: dict, context=None) -> 
                 findings.append(finding("sealed-assignment-mismatch", "assignment_seal", "sealed state does not bind this assignment"))
     ordered = _ordered(findings)
     receipt = ADMISSION_PENDING
-    adapter = adapter_id(data.get("pack"))
     if not ordered:
         payload = {"assignment": assignment_digest(ticket_id, text), "sealed_state": sealed_record}
-        receipt = f"{adapter}:sha256:{hashlib.sha256(_canonical_json(payload)).hexdigest()}"
+        receipt = f"{adapter or 'ticket'}:sha256:{hashlib.sha256(_canonical_json(payload)).hexdigest()}"
     return {
         "adapter": adapter, "findings": ordered, "receipt": receipt,
         "snapshot_ids": sorted({ticket_id, *dependencies}),
@@ -210,7 +228,7 @@ def grade_admission(ticket_id: str, text: str, siblings: dict, context=None) -> 
 
 
 __all__ = (
-    "ADMISSION_PENDING", "ADAPTER_BY_PACK", "PACK_EXECUTOR_BINDINGS",
-    "PLAIN_ADAPTER", "adapter_id", "binding_findings", "finding",
+    "ADMISSION_PENDING", "PACK_EXECUTOR_BINDINGS", "adapter_id",
+    "binding_findings", "finding",
     "grade_admission", "is_receipt",
 )

--- a/scripts/tickets_format.py
+++ b/scripts/tickets_format.py
@@ -66,11 +66,6 @@ SUCCESSOR_CONTEXT_PREFIXES = ('- state:', '- watch:')
 # twin and the issue refusal cannot drift apart. Re-exported here because
 # this module is where the family and the `tickets` facade already read it.
 REQUIRED_ISOLATION = 'required'
-# Each pack's `workspace` cell names its mechanism. This literal mirrors
-# packs/ because an installed copy has no library tree to read; the matching
-# table assertion in tests/test_validate.py keeps the workspace map in sync.
-PACK_WORKSPACE_MECHANISMS = None  # bound by the public tickets facade
-GIT_WORKSPACE_MECHANISMS = frozenset({'git', 'git plus render'})
 TERMINAL_STATES = ('complete', 'blocked', 'stalled', 'limited', 'failed')
 PACK_NAME_PREFIX = 'orch-'
 PACK_NAME_SUFFIX = '-pack'

--- a/scripts/tickets_format.py
+++ b/scripts/tickets_format.py
@@ -5,6 +5,7 @@ import re
 from pathlib import Path
 from datetime import datetime, timezone
 if __package__:
+    from .tickets_adapters import adapter_id
     from .tickets_markdown import (
         CUT_SECTIONS, CUT_SECTIONS_BY_KEY, EXECUTOR_SECTIONS,
         EXECUTOR_SECTIONS_BY_KEY, OPTIONAL_SECTIONS, REQUIRED_SECTIONS,
@@ -19,6 +20,7 @@ if __package__:
         instruction_breakdown, instruction_words,
     )
 else:
+    from tickets_adapters import adapter_id
     from tickets_markdown import (
         CUT_SECTIONS, CUT_SECTIONS_BY_KEY, EXECUTOR_SECTIONS,
         EXECUTOR_SECTIONS_BY_KEY, OPTIONAL_SECTIONS, REQUIRED_SECTIONS,
@@ -78,20 +80,12 @@ GATE_ID_MARKER = '.gate.'
 GATE_EXECUTORS = {'critique': 'orch-critique', 'repair': 'orch-repair', 'verify': 'orch-verify'}
 TEMPLATE_FILE = 'template.md'
 PLACEHOLDER_RE = re.compile('\\{\\{\\s*([^{}]*?)\\s*\\}\\}')
-ADAPTER_BY_PACK = {
-    'orch-code-pack': 'git',
-    'orch-content-pack': 'document-tree',
-    'orch-design-pack': 'git-plus-render',
-    'orch-research-pack': 'evidence-store',
-}
-PLAIN_ADAPTER = 'plain-artifact'
 PACK_EXECUTOR_BINDINGS = {
     'orch-code-pack': frozenset({'orch-tdd'}),
     'orch-content-pack': frozenset({'orch-draft', 'orch-edit'}),
     'orch-design-pack': frozenset({'orch-render'}),
     'orch-research-pack': frozenset({'orch-investigate', 'orch-synthesize'}),
 }
-def adapter_id(pack) -> str: return ADAPTER_BY_PACK.get(str(pack or '').strip(), PLAIN_ADAPTER)
 def executor_bindings(pack) -> set: return set(PACK_EXECUTOR_BINDINGS.get(str(pack or '').strip(), ()))
 class DuplicateJsonKey(ValueError):
     """A canonical JSON object repeated one key."""

--- a/scripts/tickets_packet.py
+++ b/scripts/tickets_packet.py
@@ -8,10 +8,10 @@ from datetime import datetime, timedelta, timezone
 from pathlib import Path
 
 if __package__:
-    from .tickets_adapters import AdapterError
+    from .tickets_adapters import AdapterError, adapter_spec
     from .tickets_context import graded_admission, run_snapshot
     from .tickets_format import (
-        CHECKED_BY_KEY, DISPATCHING_EXECUTORS, EXECUTOR_SECTIONS, adapter_id,
+        CHECKED_BY_KEY, DISPATCHING_EXECUTORS, EXECUTOR_SECTIONS,
         LOOP_EXECUTOR, ROOT_EXECUTOR, _executor_of,
         _extract_flag, _parse_bound_minutes, _parse_iso, _read_utf8, _sections,
         canonical_json,
@@ -22,10 +22,10 @@ if __package__:
         _segment_error, _tickets_root, normalized_isolation,
     )
 else:
-    from tickets_adapters import AdapterError
+    from tickets_adapters import AdapterError, adapter_spec
     from tickets_context import graded_admission, run_snapshot
     from tickets_format import (
-        CHECKED_BY_KEY, DISPATCHING_EXECUTORS, EXECUTOR_SECTIONS, adapter_id,
+        CHECKED_BY_KEY, DISPATCHING_EXECUTORS, EXECUTOR_SECTIONS,
         LOOP_EXECUTOR, ROOT_EXECUTOR, _executor_of,
         _extract_flag, _parse_bound_minutes, _parse_iso, _read_utf8, _sections,
         canonical_json,
@@ -66,11 +66,12 @@ def workspace_establishment_finding(data: dict, workspace):
     if not str(pack or "").strip():
         return None
     try:
-        adapter = adapter_id(pack)
+        adapter = adapter_spec(pack)
     except AdapterError as error:
         return error.code, error.detail
-    required = adapter == "evidence-store" or (
-        adapter == "git" and normalized_isolation(data.get("isolation")) == "required"
+    required = (
+        adapter.establishes_isolation
+        and normalized_isolation(data.get("isolation")) == "required"
     )
     if not required:
         return None
@@ -85,7 +86,7 @@ def workspace_establishment_finding(data: dict, workspace):
             "workspace-mismatch",
             "dispatch workspace does not equal the recorded candidate workspace",
         )
-    if adapter == "git" and any(
+    if adapter.workspace_strategy == "git" and any(
         not str(data.get(key) or "").strip()
         for key in ("workspace_branch", "workspace_baseline")
     ):
@@ -93,7 +94,7 @@ def workspace_establishment_finding(data: dict, workspace):
             "workspace-unestablished",
             "Git candidate lacks its pre-dispatch branch or baseline record",
         )
-    if adapter == "evidence-store" and not Path(recorded).is_dir():
+    if adapter.workspace_strategy == "evidence-store" and not Path(recorded).is_dir():
         return (
             "workspace-unestablished",
             "recorded evidence-store workspace is unavailable",

--- a/scripts/tickets_packet.py
+++ b/scripts/tickets_packet.py
@@ -8,6 +8,7 @@ from datetime import datetime, timedelta, timezone
 from pathlib import Path
 
 if __package__:
+    from .tickets_adapters import AdapterError
     from .tickets_context import graded_admission, run_snapshot
     from .tickets_format import (
         CHECKED_BY_KEY, DISPATCHING_EXECUTORS, EXECUTOR_SECTIONS, adapter_id,
@@ -21,6 +22,7 @@ if __package__:
         _segment_error, _tickets_root, normalized_isolation,
     )
 else:
+    from tickets_adapters import AdapterError
     from tickets_context import graded_admission, run_snapshot
     from tickets_format import (
         CHECKED_BY_KEY, DISPATCHING_EXECUTORS, EXECUTOR_SECTIONS, adapter_id,
@@ -60,7 +62,13 @@ def _command_text(*arguments) -> str:
 def workspace_establishment_finding(data: dict, workspace):
     """Return the refusal code/detail for a non-established packet workspace."""
 
-    adapter = adapter_id(data.get("pack"))
+    pack = data.get("pack")
+    if not str(pack or "").strip():
+        return None
+    try:
+        adapter = adapter_id(pack)
+    except AdapterError as error:
+        return error.code, error.detail
     required = adapter == "evidence-store" or (
         adapter == "git" and normalized_isolation(data.get("isolation")) == "required"
     )

--- a/scripts/tickets_review.py
+++ b/scripts/tickets_review.py
@@ -7,8 +7,9 @@ import re
 import subprocess
 
 if __package__:
+    from .tickets_adapters import AdapterError, adapter_spec
     from .tickets_format import (
-        GATE_EXECUTORS, _executor_of, _parse_frontmatter, _set_frontmatter_field, adapter_id, canonical_json,
+        GATE_EXECUTORS, _executor_of, _parse_frontmatter, _set_frontmatter_field, canonical_json,
         parse_canonical_json,
     )
     from .tickets_store import _load_ticket
@@ -17,8 +18,9 @@ if __package__:
         nonempty as _nonempty, validate_records,
     )
 else:
+    from tickets_adapters import AdapterError, adapter_spec
     from tickets_format import (
-        GATE_EXECUTORS, _executor_of, _parse_frontmatter, _set_frontmatter_field, adapter_id, canonical_json,
+        GATE_EXECUTORS, _executor_of, _parse_frontmatter, _set_frontmatter_field, canonical_json,
         parse_canonical_json,
     )
     from tickets_store import _load_ticket
@@ -86,13 +88,17 @@ def _workspace_identity(workspace) -> str:
 
 def validate_fixed_artifact(pack, artifact: str, workspace) -> tuple[str, str]:
     normalized_workspace = _workspace_identity(workspace)
-    if adapter_id(pack) != "git":
+    try:
+        adapter = adapter_spec(pack)
+    except AdapterError as error:
+        raise ReviewError(error.detail) from error
+    if adapter.identity_form != "git-commit":
         if not _nonempty(artifact):
             raise ReviewError("review requires --artifact <fixed-identity>")
         return artifact.strip(), normalized_workspace
     match = GIT_ARTIFACT_RE.fullmatch(str(artifact or "").strip())
     if match is None:
-        raise ReviewError("code review artifact must be git:<full-commit-id>")
+        raise ReviewError("git review artifact must be git:<full-commit-id>")
     expected = match.group(1)
     commands = (
         ("rev-parse", "--verify", f"{expected}^{{commit}}"),
@@ -106,11 +112,11 @@ def validate_fixed_artifact(pack, artifact: str, workspace) -> tuple[str, str]:
         )
         if completed.returncode != 0:
             detail = completed.stderr.strip() or completed.stdout.strip()
-            raise ReviewError(f"code review artifact does not resolve: {detail}")
+            raise ReviewError(f"git review artifact does not resolve: {detail}")
         observed.append(completed.stdout.strip().lower())
     if observed[0] != expected or observed[1] != expected:
         raise ReviewError(
-            "code review artifact does not equal the established workspace HEAD"
+            "git review artifact does not equal the established workspace HEAD"
         )
     return f"git:{expected}", normalized_workspace
 

--- a/scripts/tickets_store.py
+++ b/scripts/tickets_store.py
@@ -20,9 +20,9 @@ try:
 except ImportError:
     fcntl = None
 if __package__:
-    from .tickets_format import GIT_WORKSPACE_MECHANISMS, PACK_WORKSPACE_MECHANISMS, SCRIPT_EXECUTOR_PREFIX, _parse_frontmatter, _read_utf8
+    from .tickets_format import SCRIPT_EXECUTOR_PREFIX, _parse_frontmatter, _read_utf8
 else:
-    from tickets_format import GIT_WORKSPACE_MECHANISMS, PACK_WORKSPACE_MECHANISMS, SCRIPT_EXECUTOR_PREFIX, _parse_frontmatter, _read_utf8
+    from tickets_format import SCRIPT_EXECUTOR_PREFIX, _parse_frontmatter, _read_utf8
 
 UTC_STAMP = '%Y-%m-%dT%H:%M:%SZ'
 RUN_IDENTITY_NAME = 'run.json'
@@ -73,29 +73,6 @@ def _executor_script(executor: str):
     if not text.startswith(SCRIPT_EXECUTOR_PREFIX):
         return None
     return text[len(SCRIPT_EXECUTOR_PREFIX):].strip() or None
-def establishes_a_git_workspace(pack) -> bool:
-    """Whether `pack`'s workspace cell names a mechanism this script can
-    establish a workspace in.
-
-    A pack absent from the table answers yes. The table is only as current as
-    its last sync, and the two mistakes are not equal: a child handed a step
-    its mechanism has no meaning for fails at its first act, in the open,
-    while a child not handed one it needed works in the shared tree and loses
-    that work at the join with nothing to see.
-    """
-    name = str(pack or '').strip().strip('`').strip()
-    if PACK_WORKSPACE_MECHANISMS is None:
-        # The table is `None` in `tickets_format` until `scripts/tickets.py`
-        # binds it, and this module took its copy by `from`-import at load, so
-        # an importer that never touches the facade reaches here unbound. Not
-        # degraded into the absent-pack fallback below: that answers yes for
-        # every pack, which is the safe answer to a question the table could
-        # not answer and the wrong answer to one nobody asked it.
-        raise RuntimeError(
-            'PACK_WORKSPACE_MECHANISMS is unbound: import scripts/tickets.py, '
-            'which owns the table, before reaching establishes_a_git_workspace')
-    mechanism = PACK_WORKSPACE_MECHANISMS.get(name)
-    return mechanism is None or mechanism in GIT_WORKSPACE_MECHANISMS
 _main_checkout_root = state_root.main_checkout_root
 _find_repo_root = state_root.find_repo_root
 def _cwd() -> Path:

--- a/scripts/workspace.py
+++ b/scripts/workspace.py
@@ -216,8 +216,13 @@ def _cmd_start(rest):
     # `set-status` lands in, and a snapshot taken past them absorbs the write
     # this guard exists to report
     prior_text = path.read_text(encoding="utf-8")
-    mechanism = tickets.adapter_id(data.get("pack"))
-    if mechanism == "evidence-store":
+    try:
+        adapter = tickets.adapter_spec(data.get("pack"))
+    except tickets.AdapterError as error:
+        raise Refused(f"{error.code}: {error.detail}") from error
+    mechanism = adapter.key
+    workspace_strategy = adapter.workspace_strategy
+    if workspace_strategy == "evidence-store":
         store = (state_root.state_root() / "research" / run).resolve()
         store.mkdir(parents=True, exist_ok=True)
         outcome = _record(path, prior_text, None, None, str(store))
@@ -233,6 +238,10 @@ def _cmd_start(rest):
                 "workspace_root": str(store),
             }
         }, EXIT_OK
+    if workspace_strategy != "git":
+        raise Refused(
+            f"adapter-not-establishable: {mechanism} does not establish a candidate workspace"
+        )
     root, located = _locate(run, ticket_id)
     if located != path:
         raise Refused(f"ticket identity changed while locating {run}/{ticket_id}")

--- a/tests/serial_compat_manifest.json
+++ b/tests/serial_compat_manifest.json
@@ -1,6 +1,6 @@
 {
  "discovery": {
-  "count": 1999,
+  "count": 2003,
   "identities": [
    "test_affected_tests.TestDiscoveryCache.test_a_new_commit_is_a_new_key_and_is_discovered_again",
    "test_affected_tests.TestDiscoveryCache.test_a_tree_that_cannot_answer_for_a_commit_falls_back_and_says_so",
@@ -687,6 +687,10 @@
    "test_ticket_semantic_contract.SemanticTicketContractTest.test_tdd_executor_owns_test_choice",
    "test_ticket_semantic_contract.SemanticTicketContractTest.test_the_over_ceiling_exemption_reserves_the_only_stampable_root",
    "test_ticket_semantic_contract.SemanticTicketContractTest.test_two_executor_members_cannot_validate_or_seal_without_the_composite_gate",
+   "test_tickets.AdapterRegistryTest.test_a_project_pack_selects_git_without_a_pack_name_registration",
+   "test_tickets.AdapterRegistryTest.test_admission_reports_exactly_adapter_unregistered_for_the_pack_key",
+   "test_tickets.AdapterRegistryTest.test_an_unregistered_declared_key_fails_closed",
+   "test_tickets.AdapterRegistryTest.test_consumers_branch_on_properties_not_the_adapter_key",
    "test_tickets.ResultAttributionTest.test_ambiguous_overwrite_lifecycle_and_forged_paths_are_refused",
    "test_tickets.ResultAttributionTest.test_each_append_records_and_returns_exactly_one_current_claim_writer",
    "test_tickets_bound.BoundCheckCommandTest.test_a_claim_exactly_at_its_bound_has_not_yet_passed_it",
@@ -808,6 +812,7 @@
    "test_windows_semantics.TestTheGuardRefusesDeletingTheCwd.test_the_message_names_the_tree_the_cwd_and_the_way_out",
    "test_windows_semantics.TestTheGuardRefusesDeletingTheCwd.test_the_refusal_is_not_an_oserror",
    "test_workspace.WorkspaceTest.test_actual_mutations_include_every_changed_and_new_path",
+   "test_workspace.WorkspaceTest.test_start_dispatches_on_the_registered_workspace_strategy",
    "test_workspace.WorkspaceTest.test_workspace_does_not_import_scope_authority",
    "tests.test_affected_tests_cases.fixture_tree.TestCommandLineFormats.test_a_no_match_scope_prints_a_no_tests_line_and_exits_zero",
    "tests.test_affected_tests_cases.fixture_tree.TestCommandLineFormats.test_an_unreadable_test_file_is_named_on_the_error_stream",
@@ -1734,10 +1739,9 @@
    "tests.test_validate_cases.validator_ownership.FrictionLocationSyncTest.test_the_location_is_read_from_its_owner",
    "tests.test_validate_cases.validator_ownership.FrictionLocationSyncTest.test_the_term_entry_names_the_location_the_logger_resolves",
    "tests.test_validate_cases.validator_ownership.TestPackAdmissionRegistryAgainstPacks.test_stable_registry_covers_and_matches_every_pack",
-   "tests.test_validate_cases.validator_ownership.TestPackWorkspaceTableAgainstPacks.test_every_entry_matches_its_cell",
-   "tests.test_validate_cases.validator_ownership.TestPackWorkspaceTableAgainstPacks.test_the_git_set_names_only_mechanisms_the_cells_name",
-   "tests.test_validate_cases.validator_ownership.TestPackWorkspaceTableAgainstPacks.test_the_table_covers_exactly_the_packs_that_exist",
-   "tests.test_validate_cases.validator_ownership.TestPackWorkspaceTableAgainstPacks.test_the_table_is_a_literal_not_a_read_of_the_tree",
+   "tests.test_validate_cases.validator_ownership.TestPackWorkspaceTableAgainstPacks.test_every_adapter_owns_the_properties_machinery_reads",
+   "tests.test_validate_cases.validator_ownership.TestPackWorkspaceTableAgainstPacks.test_every_pack_declares_a_registered_adapter",
+   "tests.test_validate_cases.validator_ownership.TestPackWorkspaceTableAgainstPacks.test_no_pack_keyed_workspace_registry_survives",
    "tests.test_validate_cases.validator_ownership.TestSyncCheckIsGone.test_no_sync_helper_survives_in_the_source",
    "tests.test_validate_cases.validator_ownership.TestSyncCheckIsGone.test_the_module_exposes_no_sync_check",
    "tests.test_validate_cases.validator_ownership.TestSyncCheckIsGone.test_the_module_that_tested_it_is_gone_too",
@@ -2002,7 +2006,7 @@
    "tests.test_workspace_cases.start_cases.TestTheStampPreservesTheTicketsByteDomain.test_only_the_three_stamped_lines_differ_from_the_prior_bytes",
    "tests.test_workspace_cases.start_cases.TestTicketsPayloadIsGradedNotItsExitStatus.test_an_error_payload_returned_at_exit_zero_is_a_failure"
   ],
-  "sha256": "cb76a7bec7baefc8a05e8d92e2adae297dc5b616eae2e853cf54178248babbf9"
+  "sha256": "4d83253200df5cf1a1c1ae2f2b863db7ca3f38dd918b7af26c653b76ce7566d6"
  },
  "mutation_owners": [
   {
@@ -3959,6 +3963,14 @@
    "seams": [
     "environment",
     "threads"
+   ]
+  },
+  {
+   "module": "tests.test_tickets",
+   "owner": "AdapterRegistryTest.test_consumers_branch_on_properties_not_the_adapter_key",
+   "restoration": "selected-module-boundary",
+   "seams": [
+    "monkeypatch"
    ]
   },
   {

--- a/tests/test_dispatch_packet_v1.py
+++ b/tests/test_dispatch_packet_v1.py
@@ -299,6 +299,7 @@ class DispatchPacketV1Test(unittest.TestCase):
         with tempfile.TemporaryDirectory() as store:
             data = {
                 "pack": "orch-research-pack",
+                "isolation": "required",
                 "workspace_path": store,
             }
             self.assertIsNone(workspace_establishment_finding(data, store))

--- a/tests/test_tickets.py
+++ b/tests/test_tickets.py
@@ -10,7 +10,44 @@ from tests.test_tickets_cases.common import run_cmd, use_sink
 
 import scripts.tickets as tickets_mod
 
-__all__ = ("SemanticTicketContractTest", "ResultAttributionTest")
+__all__ = (
+    "AdapterRegistryTest", "SemanticTicketContractTest", "ResultAttributionTest",
+)
+
+
+class AdapterRegistryTest(unittest.TestCase):
+    """A pack selects one registered mechanism through its workspace cell."""
+
+    def _pack(self, root: Path, adapter: str):
+        pack = root / "packs" / "widget-pack"
+        pack.mkdir(parents=True)
+        (pack / "SKILL.md").write_text(
+            "---\nname: widget-pack\ndescription: Synthetic project pack.\n---\n\n"
+            "| cell | binding |\n| --- | --- |\n"
+            f"| workspace | widget records; ticket adapter: `{adapter}`; conflicts are ordinary overlaps |\n",
+            encoding="utf-8",
+        )
+
+    def test_a_project_pack_selects_git_without_a_pack_name_registration(self):
+        with tempfile.TemporaryDirectory() as raw:
+            root = Path(raw)
+            self._pack(root, "git")
+
+            self.assertEqual("git", tickets_mod.adapter_id("widget-pack", root=root))
+            adapter = tickets_mod.adapter_spec("widget-pack", root=root)
+            self.assertEqual("git-commit", adapter.identity_form)
+            self.assertTrue(adapter.establishes_isolation)
+            self.assertTrue(adapter.deterministic_gate)
+            self.assertEqual("git-overlap", adapter.conflict_semantics)
+
+    def test_an_unregistered_declared_key_fails_closed(self):
+        with tempfile.TemporaryDirectory() as raw:
+            root = Path(raw)
+            self._pack(root, "no-such-adapter")
+
+            with self.assertRaises(tickets_mod.AdapterError) as caught:
+                tickets_mod.adapter_id("widget-pack", root=root)
+            self.assertEqual("adapter-unregistered", caught.exception.code)
 
 
 def _result_ticket(tmp: Path, *, status="claimed", claimed_by="agent-a"):

--- a/tests/test_tickets.py
+++ b/tests/test_tickets.py
@@ -4,11 +4,14 @@ import tempfile
 import unittest
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
+from unittest import mock
 
 from tests.test_ticket_semantic_contract import SemanticTicketContractTest
 from tests.test_tickets_cases.common import run_cmd, use_sink
 
 import scripts.tickets as tickets_mod
+import scripts.tickets_packet as tickets_packet
+import scripts.tickets_review as tickets_review
 
 __all__ = (
     "AdapterRegistryTest", "SemanticTicketContractTest", "ResultAttributionTest",
@@ -48,6 +51,48 @@ class AdapterRegistryTest(unittest.TestCase):
             with self.assertRaises(tickets_mod.AdapterError) as caught:
                 tickets_mod.adapter_id("widget-pack", root=root)
             self.assertEqual("adapter-unregistered", caught.exception.code)
+
+    def test_admission_reports_exactly_adapter_unregistered_for_the_pack_key(self):
+        with tempfile.TemporaryDirectory() as raw:
+            root = Path(raw)
+            self._pack(root, "no-such-adapter")
+            ticket = (
+                "---\nid: T1\nrun: testrun\nstatus: pending\n"
+                "executor: orch-tdd\ndepends_on: []\nbound: 30m\n"
+                "pack: widget-pack\nisolation: required\n---\n\n"
+                "## Goal\n\nDeliver the widget.\n\n## Context\n\n[]\n"
+            )
+            with mock.patch("scripts.tickets_adapters.Path.cwd", return_value=root):
+                grade = tickets_mod.grade_admission("T1", ticket, {}, context={})
+            adapter_codes = [
+                item["code"] for item in grade["findings"]
+                if item["code"].startswith("adapter-")
+            ]
+            self.assertEqual(["adapter-unregistered"], adapter_codes)
+
+    def test_consumers_branch_on_properties_not_the_adapter_key(self):
+        adapter = tickets_mod.Adapter(
+            key="synthetic",
+            identity_form="git-commit",
+            establishes_isolation=True,
+            deterministic_gate=True,
+            conflict_semantics="synthetic-overlap",
+            workspace_strategy="git",
+        )
+        with tempfile.TemporaryDirectory() as raw:
+            root = Path(raw)
+            with mock.patch.object(tickets_packet, "adapter_spec", return_value=adapter):
+                finding = tickets_packet.workspace_establishment_finding(
+                    {"pack": "widget-pack", "isolation": "required"}, None,
+                )
+            self.assertEqual("workspace-unestablished", finding[0])
+
+            with mock.patch.object(tickets_review, "adapter_spec", return_value=adapter):
+                with self.assertRaises(tickets_review.ReviewError) as caught:
+                    tickets_review.validate_fixed_artifact(
+                        "widget-pack", "not-a-git-identity", str(root),
+                    )
+            self.assertIn("git:<full-commit-id>", str(caught.exception))
 
 
 def _result_ticket(tmp: Path, *, status="claimed", claimed_by="agent-a"):

--- a/tests/test_validate_cases/validator_ownership.py
+++ b/tests/test_validate_cases/validator_ownership.py
@@ -69,9 +69,8 @@ class TestSyncCheckIsGone(unittest.TestCase):
         self.assertFalse((ROOT / "tests" / "test_sync.py").exists())
 
 
-def workspace_mechanism(skill_md: Path) -> str:
-    """The mechanism a pack's `workspace` cell names: the text before that
-    cell's first colon, which is where every pack states it."""
+def workspace_adapter(skill_md: Path) -> str:
+    """The registered adapter key declared by one pack workspace cell."""
 
     for line in skill_md.read_text(encoding="utf-8").splitlines():
         stripped = line.strip()
@@ -81,57 +80,36 @@ def workspace_mechanism(skill_md: Path) -> str:
         if len(parts) < 4 or parts[1].strip() != "workspace":
             continue
         cell = parts[2].strip()
-        head, sep, _ = cell.partition(":")
-        if not sep:
-            raise AssertionError(f"{skill_md}: workspace cell names no mechanism: {cell}")
-        return head.strip()
+        matches = re.findall(r"ticket adapter:\s*`([^`]+)`", cell)
+        if len(matches) != 1:
+            raise AssertionError(f"{skill_md}: workspace cell names no one adapter: {cell}")
+        return matches[0]
     raise AssertionError(f"{skill_md}: no `workspace` row")
 
 
 class TestPackWorkspaceTableAgainstPacks(unittest.TestCase):
-    """scripts/tickets.py's PACK_WORKSPACE_MECHANISMS against its owners, the
-    packs' own `workspace` cells. Packet projection and workspace start use
-    the mechanism to gate the host-established identity, so a cell that
-    changes without the table silently changes which record is required. The one
-    literal copy that was never validate.py's, and so outlives the check that
-    was."""
+    """Pack data selects only mechanisms the adapter registry implements."""
 
-    def test_the_table_covers_exactly_the_packs_that_exist(self):
-        packs = {path.name for path in PACKS.iterdir() if (path / "SKILL.md").is_file()}
-        self.assertEqual(packs, set(tickets_mod.PACK_WORKSPACE_MECHANISMS))
+    def test_every_pack_declares_a_registered_adapter(self):
+        declared = {
+            workspace_adapter(path / "SKILL.md")
+            for path in PACKS.iterdir() if (path / "SKILL.md").is_file()
+        }
+        self.assertLessEqual(declared, set(tickets_mod.ADAPTER_REGISTRY))
 
-    def test_every_entry_matches_its_cell(self):
-        for pack, mechanism in sorted(tickets_mod.PACK_WORKSPACE_MECHANISMS.items()):
-            self.assertEqual(
-                mechanism,
-                workspace_mechanism(PACKS / pack / "SKILL.md"),
-                f"{pack}: table and workspace cell disagree",
-            )
+    def test_every_adapter_owns_the_properties_machinery_reads(self):
+        for key, adapter in sorted(tickets_mod.ADAPTER_REGISTRY.items()):
+            self.assertEqual(key, adapter.key)
+            self.assertTrue(adapter.identity_form)
+            self.assertIsInstance(adapter.establishes_isolation, bool)
+            self.assertIsInstance(adapter.deterministic_gate, bool)
+            self.assertTrue(adapter.conflict_semantics)
+            self.assertIn(adapter.workspace_strategy, {"git", "evidence-store", "document-tree"})
 
-    def test_the_git_set_names_only_mechanisms_the_cells_name(self):
-        named = set(tickets_mod.PACK_WORKSPACE_MECHANISMS.values())
-        self.assertLessEqual(set(tickets_mod.GIT_WORKSPACE_MECHANISMS), named)
-
-    def test_the_table_is_a_literal_not_a_read_of_the_tree(self):
-        """Without this the two checks above are vacuous: a table computed
-        from `packs/` matches `packs/` by construction, and the installed
-        script that has no `packs/` is the one that breaks."""
-
-        tree = ast.parse(TICKETS_PY.read_text(encoding="utf-8"))
-        found = [
-            node.value
-            for node in tree.body
-            if isinstance(node, ast.Assign)
-            and any(
-                isinstance(target, ast.Name)
-                and target.id == "PACK_WORKSPACE_MECHANISMS"
-                for target in node.targets
-            )
-        ]
-        self.assertEqual(1, len(found), "expected one module-level assignment")
-        self.assertIsInstance(found[0], ast.Dict)
-        for node in [*found[0].keys, *found[0].values]:
-            self.assertIsInstance(node, ast.Constant, ast.dump(node))
+    def test_no_pack_keyed_workspace_registry_survives(self):
+        source = TICKETS_PY.read_text(encoding="utf-8")
+        self.assertNotIn("ADAPTER_BY_PACK", source)
+        self.assertNotIn("PACK_WORKSPACE_MECHANISMS", source)
 
 
 class TestPackAdmissionRegistryAgainstPacks(unittest.TestCase):

--- a/tests/test_workspace.py
+++ b/tests/test_workspace.py
@@ -22,3 +22,9 @@ class WorkspaceTest(unittest.TestCase):
         source = Path(workspace.__file__).read_text(encoding="utf-8")
         self.assertNotIn("workspace_scope", source)
         self.assertNotIn("tickets_scope", source)
+
+    def test_start_dispatches_on_the_registered_workspace_strategy(self):
+        source = Path(workspace.__file__).read_text(encoding="utf-8")
+        self.assertIn("workspace_strategy", source)
+        self.assertNotIn('mechanism == "evidence-store"', source)
+        self.assertIn("adapter-not-establishable", source)

--- a/tests/test_workspace_cases/common.py
+++ b/tests/test_workspace_cases/common.py
@@ -96,6 +96,7 @@ def make_ticket(run_dir: Path, tid: str, *, scope=("scratch",), extra=()) -> Pat
         "run: testrun",
         "status: claimed",
         "executor: orch-tdd",
+        "pack: orch-code-pack",
         "depends_on: []",
         "write_scope:",
     ]


### PR DESCRIPTION
## Unit\n\nU2 of the cohesion refactor. Packs now declare registered workspace adapter keys; machinery consumes adapter properties rather than canonical pack names.\n\n## Cutover\n\n- Deletes ADAPTER_BY_PACK and PLAIN_ADAPTER from production code\n- Adds the closed adapter registry and exact adapter-unregistered refusal\n- Drives artifact identity, isolation establishment, and workspace strategy from registry properties\n- Removes duplicate adapter ownership/re-exports; no pack-name fallback or dual path remains\n\n## Evidence\n\n- 61 independent focused registry/workspace tests: green\n- Affected suite: 1,309 tests green\n- Full uncached gate: 2,003 tests plus all five required checks green\n- Production deletion invariant: clean\n\nOne first full run reported a transient module-level tests.test_installer_runtime error; the unchanged tree immediately passed that module 27/27 alone and 27/27 in the exact full rerun. The incident is friction-logged and preserved in the ticket evidence; this PR's six fresh CI jobs are the acceptance boundary.