### PR TITLE
U8: enforce composition protocol admission

### DIFF
--- a/docs/custom-workflow-authoring.md
+++ b/docs/custom-workflow-authoring.md
@@ -63,6 +63,22 @@ scope, or at a broader custom scope than requested.
    adapter/routing/role tests when host surfaces change, and the full required
    checks before acceptance. Install only the accepted source identity.
 
+## Composition admission
+
+A composition carries only its manifest, ticket stubs, and placeholder values.
+It carries no schema, validator, fixture format, or script. Repository admission
+refuses those artifacts inside a composition, schema or fixture-format artifacts
+named for it under [shared references](../compositions/references/), and any
+composition-named module under scripts. Validation a composition needs instead
+belongs to pack data when it is domain craft or to a T0 contract when machinery
+branches on it; a composition that needs another shape exposes that missing
+owner.
+
+The already-shipped `browser-game` machinery is the sole exception, named in the
+validator's dated 2026-08-28 allowlist. The validator reports that exception as a
+warning; it admits neither another composition nor an unnamed compatibility
+mode.
+
 ## Authoring lens
 
 Review the fixed artifact independently against these owners:

--- a/tests/serial_compat_manifest.json
+++ b/tests/serial_compat_manifest.json
@@ -1,6 +1,6 @@
 {
  "discovery": {
-  "count": 2015,
+  "count": 2020,
   "identities": [
    "test_affected_tests.TestDiscoveryCache.test_a_new_commit_is_a_new_key_and_is_discovered_again",
    "test_affected_tests.TestDiscoveryCache.test_a_tree_that_cannot_answer_for_a_commit_falls_back_and_says_so",
@@ -766,6 +766,11 @@
    "test_validate.TestDocumentedPathsResolveInTheInstalledTree.test_the_exemption_is_one_live_site_and_not_a_blanket",
    "test_validate.TestDocumentedPathsResolveInTheInstalledTree.test_the_real_library_tree_carries_no_dead_documented_path",
    "test_validate.TestDocumentedPathsResolveInTheInstalledTree.test_the_test_directory_is_an_error",
+   "test_validator.TestCompositionProtocolAdmission.test_a_script_module_named_for_a_composition_is_refused_by_boundary",
+   "test_validator.TestCompositionProtocolAdmission.test_authoring_standard_states_the_protocol_boundary_and_exception",
+   "test_validator.TestCompositionProtocolAdmission.test_browser_game_is_the_one_dated_visible_exception",
+   "test_validator.TestCompositionProtocolAdmission.test_removing_the_browser_game_entry_exposes_its_protocol_artifacts",
+   "test_validator.TestCompositionProtocolAdmission.test_schema_fixture_format_and_script_are_refused",
    "test_validator.TestMarkdownAnchors.test_a_link_to_a_missing_heading_is_an_error",
    "test_validator.TestPrivateReferenceAdmission.test_cross_package_private_reference_is_an_error",
    "test_validator.TestRecursiveNameResolution.test_nested_shipped_prose_resolves_skill_names",
@@ -2018,7 +2023,7 @@
    "tests.test_workspace_cases.start_cases.TestTheStampPreservesTheTicketsByteDomain.test_only_the_three_stamped_lines_differ_from_the_prior_bytes",
    "tests.test_workspace_cases.start_cases.TestTicketsPayloadIsGradedNotItsExitStatus.test_an_error_payload_returned_at_exit_zero_is_a_failure"
   ],
-  "sha256": "0dae2a6019c53d48aea374e4fb80f15c3de0176ff6e56ffb2f372f8cc86ececf"
+  "sha256": "a06742f1b55bb2d6415491d131db04e439169e84a7762695fbce33a7f27a3156"
  },
  "mutation_owners": [
   {

--- a/tests/test_cell_linter_cases/warning_ratchets.py
+++ b/tests/test_cell_linter_cases/warning_ratchets.py
@@ -70,14 +70,19 @@ class WarningCeilingTest(unittest.TestCase):
     def test_the_two_ratchets_count_disjoint_findings(self):
         """Two ceilings over one report only mean anything if no finding is
         counted by both -- and if together they cover the report, so a WARN
-        of some third kind is visible as a kind with no ceiling rather than
-        as slack in one of these."""
+        of some third kind stays an explicit, separately identified finding
+        rather than becoming slack in one of these."""
 
         stdout = validate_the_real_tree().stdout
         near = set(warning_lines(stdout, NEAR))
         cross = set(warning_lines(stdout, CROSS_TIER))
+        composition = {
+            line for line in warning_lines(stdout)
+            if line.startswith("WARN compositions/browser-game: dated 2026-08-28 ")
+        }
         self.assertEqual(set(), near & cross)
-        self.assertEqual(set(warning_lines(stdout)), near | cross)
+        self.assertEqual(1, len(composition), composition)
+        self.assertEqual(set(warning_lines(stdout)), near | cross | composition)
 
     def test_a_count_above_the_ceiling_fails(self):
         tree_report = validate_the_real_tree().stdout

--- a/tests/test_validator.py
+++ b/tests/test_validator.py
@@ -349,6 +349,25 @@ class TestCompositionProtocolAdmission(_IsolatedTree):
         self.assertIn("composition 'probe'", errors[0])
         self.assertIn("composition-named script machinery", errors[0])
 
+    def test_authoring_standard_states_the_protocol_boundary_and_exception(self):
+        text = (ROOT / "docs" / "custom-workflow-authoring.md").read_text(
+            encoding="utf-8"
+        )
+        admission = text.split("## Composition admission", 1)
+
+        self.assertEqual(2, len(admission), "missing Composition admission section")
+        for term in (
+            "schema",
+            "fixture format",
+            "script",
+            "composition-named",
+            "browser-game",
+            "2026-08-28",
+            "warning",
+        ):
+            with self.subTest(term=term):
+                self.assertIn(term, admission[1])
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_validator.py
+++ b/tests/test_validator.py
@@ -302,6 +302,7 @@ class TestCompositionProtocolAdmission(_IsolatedTree):
         self._write(
             "compositions/references/browser-game-instance-fixtures.json", "{}\n"
         )
+        self._write("scripts/browser_game_validate.py", "# legacy validator\n")
 
         findings = self._findings()
 
@@ -317,6 +318,7 @@ class TestCompositionProtocolAdmission(_IsolatedTree):
         ]
         self.assertEqual(1, len(exception), findings)
         self.assertIn("2026-08-28", exception[0])
+        self.assertIn("script", exception[0])
 
     def test_removing_the_browser_game_entry_exposes_its_protocol_artifacts(self):
         self._write("compositions/browser-game/template.md")
@@ -326,12 +328,26 @@ class TestCompositionProtocolAdmission(_IsolatedTree):
         self._write(
             "compositions/references/browser-game-instance-fixtures.json", "{}\n"
         )
+        self._write("scripts/browser_game_validate.py", "# legacy validator\n")
 
         findings = self._findings(allowlist={})
 
         errors = [line for line in findings if line.startswith("ERROR ")]
-        self.assertEqual(2, len(errors), findings)
+        self.assertEqual(3, len(errors), findings)
         self.assertTrue(all("composition 'browser-game'" in line for line in errors))
+
+    def test_a_script_module_named_for_a_composition_is_refused_by_boundary(self):
+        self._write("compositions/probe/template.md")
+        self._write("scripts/probe_validate.py", "# composition machinery\n")
+        self._write("scripts/probeish.py", "# unrelated bounded stem\n")
+
+        findings = self._findings()
+
+        errors = [line for line in findings if line.startswith("ERROR ")]
+        self.assertEqual(1, len(errors), findings)
+        self.assertTrue(errors[0].startswith("ERROR scripts/probe_validate.py"), errors)
+        self.assertIn("composition 'probe'", errors[0])
+        self.assertIn("composition-named script machinery", errors[0])
 
 
 if __name__ == "__main__":

--- a/tests/test_validator.py
+++ b/tests/test_validator.py
@@ -249,6 +249,91 @@ class TestStructuralAdmissionMutants(_IsolatedTree):
         self.assertEqual(0, accepted.returncode, accepted.stdout)
 
 
+class TestCompositionProtocolAdmission(_IsolatedTree):
+    """A composition is ticket control flow, never a private protocol tier."""
+
+    def _write(self, relative: str, body: str = "fixture\n") -> None:
+        path = self.tmp_path / relative
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(body, encoding="utf-8")
+
+    def _findings(self, allowlist=None):
+        saved = validate.ROOT
+        try:
+            validate._bind_root(self.tmp_path)
+            diag = validate.Diagnostics()
+            if allowlist is None:
+                validate.validate_composition_admission(diag)
+            else:
+                validate.validate_composition_admission(diag, allowlist=allowlist)
+            return diag.lines()
+        finally:
+            validate._bind_root(saved)
+
+    def test_schema_fixture_format_and_script_are_refused(self):
+        self._write("compositions/probe/template.md")
+        self._write("compositions/probe/state.schema.json", "{}\n")
+        self._write("compositions/probe/replay-fixtures.json", "{}\n")
+        self._write("compositions/probe/validate.py", "# executable machinery\n")
+
+        findings = self._findings()
+
+        for relative, kind in (
+            ("compositions/probe/state.schema.json", "schema"),
+            ("compositions/probe/replay-fixtures.json", "fixture format"),
+            ("compositions/probe/validate.py", "script"),
+        ):
+            with self.subTest(relative=relative):
+                self.assertTrue(
+                    any(
+                        line.startswith("ERROR " + relative)
+                        and "composition 'probe'" in line
+                        and kind in line
+                        for line in findings
+                    ),
+                    findings,
+                )
+
+    def test_browser_game_is_the_one_dated_visible_exception(self):
+        self._write("compositions/browser-game/template.md")
+        self._write(
+            "compositions/references/browser-game-checkpoint.schema.json", "{}\n"
+        )
+        self._write(
+            "compositions/references/browser-game-instance-fixtures.json", "{}\n"
+        )
+
+        findings = self._findings()
+
+        self.assertEqual(
+            {"browser-game": "2026-08-28"},
+            validate.COMPOSITION_PROTOCOL_ALLOWLIST,
+        )
+        self.assertFalse(any(line.startswith("ERROR ") for line in findings), findings)
+        exception = [
+            line
+            for line in findings
+            if line.startswith("WARN ") and "browser-game" in line
+        ]
+        self.assertEqual(1, len(exception), findings)
+        self.assertIn("2026-08-28", exception[0])
+
+    def test_removing_the_browser_game_entry_exposes_its_protocol_artifacts(self):
+        self._write("compositions/browser-game/template.md")
+        self._write(
+            "compositions/references/browser-game-checkpoint.schema.json", "{}\n"
+        )
+        self._write(
+            "compositions/references/browser-game-instance-fixtures.json", "{}\n"
+        )
+
+        findings = self._findings(allowlist={})
+
+        errors = [line for line in findings if line.startswith("ERROR ")]
+        self.assertEqual(2, len(errors), findings)
+        self.assertTrue(all("composition 'browser-game'" in line for line in errors))
+
+
 if __name__ == "__main__":
     unittest.main()
 

--- a/tools/validate.py
+++ b/tools/validate.py
@@ -302,6 +302,7 @@ def _run_validation_impl() -> Diagnostics:
     validate_cell_duplication(packages, diag)
     validate_cross_tier_duplication(packages, diag)
     validate_envelope(packages, diag)
+    validate_composition_admission(diag)
     validate_templates(diag)
     validate_browser_game_traceability(diag, root=ROOT)
     validate_cross_package_links(packages, diag)

--- a/tools/validate_support/structure.py
+++ b/tools/validate_support/structure.py
@@ -29,6 +29,16 @@ ENVELOPE_CARRIER_RE = re.compile(
 )
 ENVELOPE_FIELD_LEAD_RE = re.compile(r"^\s*status\s*[,;—-]", re.IGNORECASE)
 
+# U8's sole legacy exception is data, not a relaxed classifier.  The date
+# names the review that admitted the already-shipped browser-game machinery;
+# every other composition, including every future one, takes the closed rule.
+COMPOSITION_PROTOCOL_ALLOWLIST = {"browser-game": "2026-08-28"}
+COMPOSITION_SCRIPT_SUFFIXES = frozenset({
+    ".bat", ".cmd", ".js", ".mjs", ".cjs", ".ps1", ".py", ".sh", ".ts",
+})
+COMPOSITION_SCHEMA_RE = re.compile(r"(?:^|[._-])schemas?(?:[._-]|$)", re.IGNORECASE)
+COMPOSITION_FIXTURE_RE = re.compile(r"(?:^|[._-])fixtures?(?:[._-]|$)", re.IGNORECASE)
+
 from tools.validate_support import packages as __dep_packages
 Diagnostics = __dep_packages.Diagnostics
 _read_source = __dep_packages._read_source
@@ -174,6 +184,82 @@ def discover_templates(manifest_name: str):
         d for d in comps_dir.iterdir()
         if d.is_dir() and (d / manifest_name).is_file()
     )
+
+
+def _composition_artifact_kind(path: Path):
+    """The forbidden protocol class carried by ``path``, if any."""
+
+    name = path.name
+    if COMPOSITION_SCHEMA_RE.search(name):
+        return "schema"
+    if COMPOSITION_FIXTURE_RE.search(name):
+        return "fixture format"
+    if path.suffix.lower() in COMPOSITION_SCRIPT_SUFFIXES:
+        return "script"
+    return None
+
+
+def _reference_owner(path: Path, composition_names):
+    """Resolve a shared reference's composition from its bounded filename."""
+
+    name = path.name.lower()
+    for composition in sorted(composition_names, key=lambda item: (-len(item), item)):
+        lowered = composition.lower()
+        if name.startswith(lowered + "-") or name.startswith(lowered + "_"):
+            return composition
+    return None
+
+
+def validate_composition_admission(
+    diag: Diagnostics, allowlist=COMPOSITION_PROTOCOL_ALLOWLIST
+) -> None:
+    """Reject protocol artifacts owned by composition templates.
+
+    Ownership is physical inside ``compositions/<name>/`` or explicit in the
+    bounded name of a shared ``compositions/references`` artifact.  The latter
+    is how the pre-existing browser-game schemas and fixture format ship.
+    """
+
+    compositions = ROOT / "compositions"
+    if not compositions.is_dir():
+        return
+    directories = sorted(
+        path for path in compositions.iterdir()
+        if path.is_dir() and path.name != "references"
+    )
+    names = {path.name for path in directories}
+    findings = []
+    for directory in directories:
+        for path in sorted(directory.rglob("*")):
+            kind = _composition_artifact_kind(path) if path.is_file() else None
+            if kind:
+                findings.append((directory.name, path, kind))
+    references = compositions / "references"
+    if references.is_dir():
+        for path in sorted(references.rglob("*")):
+            kind = _composition_artifact_kind(path) if path.is_file() else None
+            owner = _reference_owner(path, names) if kind else None
+            if owner:
+                findings.append((owner, path, kind))
+
+    excepted = {}
+    for composition, path, kind in findings:
+        if composition in allowlist:
+            excepted.setdefault(composition, []).append((path, kind))
+            continue
+        diag.error(
+            rel(path),
+            f"composition '{composition}' carries forbidden {kind}; "
+            "compositions contain only their manifest, ticket stubs, and placeholders",
+        )
+    for composition in sorted(excepted):
+        date = allowlist[composition]
+        kinds = ", ".join(sorted({kind for _, kind in excepted[composition]}))
+        diag.warn(
+            f"compositions/{composition}",
+            f"dated {date} composition-protocol exception admits existing {kinds}; "
+            "the allowlist grants no exception to another composition",
+        )
 
 
 def _doclint():
@@ -374,6 +460,9 @@ def validate_templates(diag: Diagnostics) -> None:
 __all__ = (
     'validate_craft_budget', 'validate_reference_links', 'build_call_graph', 'find_cycle',
     'validate_call_graph', '_envelope_first_clause', '_envelope_missing', 'validate_envelope',
-    'discover_templates', '_doclint', '_ticket_law', '_validate_template_manifest',
+    'COMPOSITION_PROTOCOL_ALLOWLIST', 'COMPOSITION_SCRIPT_SUFFIXES',
+    'COMPOSITION_SCHEMA_RE', 'COMPOSITION_FIXTURE_RE',
+    'discover_templates', '_composition_artifact_kind', '_reference_owner',
+    'validate_composition_admission', '_doclint', '_ticket_law', '_validate_template_manifest',
     '_validate_stub_executor', '_tree_skill_names', 'validate_templates',
 )

--- a/tools/validate_support/structure.py
+++ b/tools/validate_support/structure.py
@@ -210,6 +210,17 @@ def _reference_owner(path: Path, composition_names):
     return None
 
 
+def _script_owner(path: Path, composition_names):
+    """Resolve a script module's composition by a normalized stem boundary."""
+
+    stem = path.stem.lower()
+    for composition in sorted(composition_names, key=lambda item: (-len(item), item)):
+        normalized = composition.lower().replace("-", "_")
+        if stem == normalized or stem.startswith(normalized + "_"):
+            return composition
+    return None
+
+
 def validate_composition_admission(
     diag: Diagnostics, allowlist=COMPOSITION_PROTOCOL_ALLOWLIST
 ) -> None:
@@ -241,6 +252,14 @@ def validate_composition_admission(
             owner = _reference_owner(path, names) if kind else None
             if owner:
                 findings.append((owner, path, kind))
+    scripts = ROOT / "scripts"
+    if scripts.is_dir():
+        for path in sorted(scripts.rglob("*")):
+            if not path.is_file() or path.suffix.lower() not in COMPOSITION_SCRIPT_SUFFIXES:
+                continue
+            owner = _script_owner(path, names)
+            if owner:
+                findings.append((owner, path, "composition-named script machinery"))
 
     excepted = {}
     for composition, path, kind in findings:
@@ -462,7 +481,7 @@ __all__ = (
     'validate_call_graph', '_envelope_first_clause', '_envelope_missing', 'validate_envelope',
     'COMPOSITION_PROTOCOL_ALLOWLIST', 'COMPOSITION_SCRIPT_SUFFIXES',
     'COMPOSITION_SCHEMA_RE', 'COMPOSITION_FIXTURE_RE',
-    'discover_templates', '_composition_artifact_kind', '_reference_owner',
+    'discover_templates', '_composition_artifact_kind', '_reference_owner', '_script_owner',
     'validate_composition_admission', '_doclint', '_ticket_law', '_validate_template_manifest',
     '_validate_stub_executor', '_tree_skill_names', 'validate_templates',
 )


### PR DESCRIPTION
## Summary
- reject composition directories that introduce composition-named executable machinery, schemas, or private fixture formats
- retain the spec-mandated dated browser-game warning as the sole narrow allowlist entry
- document the composition admission boundary and cover it in validator/linter tests
- add no compatibility parser, migration path, or fallback admission

## Verification
- affected scope: 966 tests across 20 modules
- uv run --no-project python tools/run_required.py --no-cache
- serial discovery: 2,020 tests, 363 classified mutation owners