### PR TITLE
U7: prove multi-pack adapter topology

### DIFF
--- a/rules/topology.md
+++ b/rules/topology.md
@@ -23,7 +23,9 @@ connects this law to the admission-owned state transition.
    runs keep their ordinary path. Additional review is a named lens feeding
    that same gate.
 6. A pack belongs to a ticket, not a run. Incompatible workspace semantics use
-   successor roots rather than pretending to share a candidate.
+   successor roots rather than pretending to share a candidate. Adapters meet
+   only at the join: identities may cross dependency edges, but candidate bytes
+   may not.
 7. Multi-run work links successor roots by durable accepted results. A semantic
    successor opens only after the accepted predecessor result identity resolves
    and cites it in the successor root's Context. The predecessor state is not

--- a/tests/fixtures/multi_pack_run.json
+++ b/tests/fixtures/multi_pack_run.json
@@ -1,0 +1,55 @@
+{
+  "run": "multi-pack-run",
+  "tickets": [
+    {
+      "id": "01-research",
+      "pack": "orch-research-pack",
+      "adapter": "evidence-store",
+      "identity_form": "evidence-packet",
+      "workspace": "research/multi-pack-run",
+      "artifact_identity": "evidence-packet:multi-pack-run:01-research",
+      "depends_on": [],
+      "context_identities": []
+    },
+    {
+      "id": "02-draft",
+      "pack": "orch-content-pack",
+      "adapter": "document-tree",
+      "identity_form": "document-revision",
+      "workspace": "documents/multi-pack-run/draft.md",
+      "artifact_identity": "document-revision:multi-pack-run:02-draft",
+      "depends_on": ["01-research"],
+      "context_identities": ["evidence-packet:multi-pack-run:01-research"]
+    },
+    {
+      "id": "03-render",
+      "pack": "orch-design-pack",
+      "adapter": "git-plus-render",
+      "identity_form": "view-identity",
+      "workspace": "candidates/multi-pack-run/render",
+      "artifact_identity": "view-identity:multi-pack-run:03-render:dashboard@desktop",
+      "depends_on": ["02-draft"],
+      "context_identities": ["document-revision:multi-pack-run:02-draft"]
+    }
+  ],
+  "joins": [
+    {
+      "id": "01-research",
+      "adapter": "evidence-store",
+      "identity_form": "evidence-packet",
+      "artifact_identity": "evidence-packet:multi-pack-run:01-research"
+    },
+    {
+      "id": "02-draft",
+      "adapter": "document-tree",
+      "identity_form": "document-revision",
+      "artifact_identity": "document-revision:multi-pack-run:02-draft"
+    },
+    {
+      "id": "03-render",
+      "adapter": "git-plus-render",
+      "identity_form": "view-identity",
+      "artifact_identity": "view-identity:multi-pack-run:03-render:dashboard@desktop"
+    }
+  ]
+}

--- a/tests/serial_compat_manifest.json
+++ b/tests/serial_compat_manifest.json
@@ -1,6 +1,6 @@
 {
  "discovery": {
-  "count": 2020,
+  "count": 2025,
   "identities": [
    "test_affected_tests.TestDiscoveryCache.test_a_new_commit_is_a_new_key_and_is_discovered_again",
    "test_affected_tests.TestDiscoveryCache.test_a_tree_that_cannot_answer_for_a_commit_falls_back_and_says_so",
@@ -484,6 +484,11 @@
    "test_migrate_state_cases.plan.TestUsage.test_no_source_is_a_usage_error",
    "test_minimal_acceptance.MinimalAcceptanceTests.test_acceptance_contract_discriminates_extra_or_self_acceptance",
    "test_minimal_acceptance.MinimalAcceptanceTests.test_single_and_decomposed_runs_take_only_their_minimum_path",
+   "test_multi_pack.MultiPackRunFixtureTest.test_fixture_carries_three_closed_adapters_and_distinct_workspaces",
+   "test_multi_pack.MultiPackRunFixtureTest.test_fixture_dependency_edges_carry_identities_not_candidate_bytes",
+   "test_multi_pack.MultiPackRunFixtureTest.test_fixture_join_uses_each_adapter_identity_form",
+   "test_multi_pack.MultiPackTopologyTest.test_topology_names_the_join_as_the_only_adapter_boundary",
+   "test_multi_pack.MultiPackWorkspaceTest.test_different_adapters_cannot_record_one_candidate_workspace",
    "test_preflight.PreflightDocumentationTest.test_module_docstring_names_the_active_ci_topology",
    "test_project_binding.TestAttribution.test_a_root_ticket_naming_no_workspace_leaves_the_writer_owning_it",
    "test_project_binding.TestAttribution.test_run_creation_stamps_the_issuing_project",
@@ -2023,7 +2028,7 @@
    "tests.test_workspace_cases.start_cases.TestTheStampPreservesTheTicketsByteDomain.test_only_the_three_stamped_lines_differ_from_the_prior_bytes",
    "tests.test_workspace_cases.start_cases.TestTicketsPayloadIsGradedNotItsExitStatus.test_an_error_payload_returned_at_exit_zero_is_a_failure"
   ],
-  "sha256": "a06742f1b55bb2d6415491d131db04e439169e84a7762695fbce33a7f27a3156"
+  "sha256": "983f805b3162621ef0dbc0eee8e4182df74d4fd84b8f198ac9ffed1e9535f8a9"
  },
  "mutation_owners": [
   {

--- a/tests/test_multi_pack.py
+++ b/tests/test_multi_pack.py
@@ -1,0 +1,105 @@
+"""Deterministic proof that one run can span isolated pack adapters."""
+
+import json
+import re
+import tempfile
+import unittest
+from pathlib import Path
+
+from scripts import tickets
+from tests.test_workspace_cases.common import (
+    add_worktree,
+    git_available,
+    make_repo,
+    make_ticket,
+    payload_of,
+    run_workspace,
+)
+
+
+ROOT = Path(__file__).resolve().parent.parent
+FIXTURE = ROOT / "tests" / "fixtures" / "multi_pack_run.json"
+
+
+class MultiPackTopologyTest(unittest.TestCase):
+    def test_topology_names_the_join_as_the_only_adapter_boundary(self):
+        topology = (ROOT / "rules" / "topology.md").read_text(encoding="utf-8")
+        self.assertIn(
+            "Adapters meet only at the join: identities may cross dependency edges, "
+            "but candidate bytes may not.",
+            re.sub(r"\s+", " ", topology),
+        )
+
+
+class MultiPackRunFixtureTest(unittest.TestCase):
+    def test_fixture_carries_three_closed_adapters_and_distinct_workspaces(self):
+        fixture = json.loads(FIXTURE.read_text(encoding="utf-8"))
+        self.assertEqual("multi-pack-run", fixture["run"])
+        entries = fixture["tickets"]
+        self.assertEqual(3, len(entries))
+        self.assertEqual(
+            {"document-tree", "evidence-store", "git-plus-render"},
+            {item["adapter"] for item in entries},
+        )
+        self.assertEqual(3, len({item["workspace"] for item in entries}))
+        for item in entries:
+            adapter = tickets.adapter_spec(item["pack"])
+            self.assertEqual(adapter.key, item["adapter"])
+            self.assertEqual(adapter.identity_form, item["identity_form"])
+
+    def test_fixture_dependency_edges_carry_identities_not_candidate_bytes(self):
+        fixture = json.loads(FIXTURE.read_text(encoding="utf-8"))
+        by_id = {item["id"]: item for item in fixture["tickets"]}
+        for item in fixture["tickets"]:
+            for dependency in item["depends_on"]:
+                predecessor = by_id[dependency]
+                self.assertIn(
+                    predecessor["artifact_identity"], item["context_identities"]
+                )
+                self.assertNotIn("workspace", item["context_identities"])
+                self.assertNotIn("bytes", item["context_identities"])
+
+    def test_fixture_join_uses_each_adapter_identity_form(self):
+        fixture = json.loads(FIXTURE.read_text(encoding="utf-8"))
+        by_id = {item["id"]: item for item in fixture["tickets"]}
+        expected = {
+            item["id"]: item["identity_form"] for item in fixture["joins"]
+        }
+        self.assertEqual(
+            {"01-research": "evidence-packet",
+             "02-draft": "document-revision",
+             "03-render": "view-identity"},
+            expected,
+        )
+        self.assertEqual(
+            {item["id"]: item["adapter"] for item in fixture["tickets"]},
+            {item["id"]: item["adapter"] for item in fixture["joins"]},
+        )
+        for item in fixture["joins"]:
+            self.assertEqual(
+                by_id[item["id"]]["artifact_identity"], item["artifact_identity"]
+            )
+            self.assertTrue(
+                item["artifact_identity"].startswith(item["identity_form"] + ":"),
+                item,
+            )
+
+
+@unittest.skipUnless(git_available(), "git is required for a real worktree fixture")
+class MultiPackWorkspaceTest(unittest.TestCase):
+    def test_different_adapters_cannot_record_one_candidate_workspace(self):
+        with tempfile.TemporaryDirectory() as raw:
+            tmp = Path(raw)
+            main, run_dir = make_repo(tmp)
+            make_ticket(run_dir, "T-code", pack="orch-code-pack")
+            make_ticket(run_dir, "T-render", pack="orch-design-pack")
+            candidate = add_worktree(main, "candidate", tmp / "candidate")
+
+            first = run_workspace(candidate, "start", "testrun", "T-code")
+            self.assertEqual(0, first.returncode, first.stdout + first.stderr)
+            second = run_workspace(candidate, "start", "testrun", "T-render")
+
+            self.assertEqual(7, second.returncode, second.stdout + second.stderr)
+            body = payload_of(second)["start"]
+            self.assertEqual(["T-code"], body["shared_with"])
+            self.assertFalse(body["isolated"])

--- a/tests/test_workspace_cases/common.py
+++ b/tests/test_workspace_cases/common.py
@@ -85,7 +85,10 @@ def payload_of(completed) -> dict:
         )
 
 
-def make_ticket(run_dir: Path, tid: str, *, scope=("scratch",), extra=()) -> Path:
+def make_ticket(
+    run_dir: Path, tid: str, *, scope=("scratch",), extra=(),
+    pack="orch-code-pack",
+) -> Path:
     """A fixture work item. Never this run's own ticket: the base revision of
     this run does not contain ``workspace.py``, so no ticket of it declares
     ``isolation`` and none may be graded by it."""
@@ -96,7 +99,7 @@ def make_ticket(run_dir: Path, tid: str, *, scope=("scratch",), extra=()) -> Pat
         "run: testrun",
         "status: claimed",
         "executor: orch-tdd",
-        "pack: orch-code-pack",
+        f"pack: {pack}",
         "depends_on: []",
         "write_scope:",
     ]


### PR DESCRIPTION
## Summary
- add a deterministic run fixture spanning evidence-store, document-tree, and git-plus-render adapters
- prove dependency edges carry artifact identities instead of candidate bytes
- prove each adapter joins in its own identity form and Git-backed adapter tickets cannot share one candidate workspace
- state the topology invariant that adapters meet only at the join

## Verification
- uv run --no-project python tools/run_tests.py tests.test_multi_pack
- uv run --no-project python tools/run_required.py --no-cache
- 2,025 discovered tests; no new mutation owners