### PR TITLE
U3: enforce domain-blind pack machinery

### DIFF
--- a/scripts/tickets.py
+++ b/scripts/tickets.py
@@ -121,7 +121,6 @@ _write_section = _tickets_format_module._write_section
 instruction_words = _tickets_format_module.instruction_words
 ticket_defects = _tickets_format_module.ticket_defects
 ADMISSION_PENDING = _tickets_admission_module.ADMISSION_PENDING
-PACK_EXECUTOR_BINDINGS = _tickets_admission_module.PACK_EXECUTOR_BINDINGS
 ADAPTER_REGISTRY = _tickets_adapters_module.ADAPTER_REGISTRY
 Adapter = _tickets_adapters_module.Adapter
 AdapterError = _tickets_adapters_module.AdapterError

--- a/scripts/tickets_admission.py
+++ b/scripts/tickets_admission.py
@@ -7,18 +7,18 @@ import re
 from pathlib import Path
 
 if __package__:
-    from .tickets_adapters import AdapterError
+    from .tickets_adapters import AdapterError, adapter_spec
     from .tickets_format import (
-        GATE_EXECUTORS, PACK_EXECUTOR_BINDINGS,
+        GATE_EXECUTORS,
         ROOT_EXECUTOR, SCRIPT_EXECUTOR_PREFIX, adapter_id, canonical_json,
-        executor_bindings, _executor_of, _parse_frontmatter,
+        _executor_of, _parse_frontmatter,
     )
 else:
-    from tickets_adapters import AdapterError
+    from tickets_adapters import AdapterError, adapter_spec
     from tickets_format import (
-        GATE_EXECUTORS, PACK_EXECUTOR_BINDINGS,
+        GATE_EXECUTORS,
         ROOT_EXECUTOR, SCRIPT_EXECUTOR_PREFIX, adapter_id, canonical_json,
-        executor_bindings, _executor_of, _parse_frontmatter,
+        _executor_of, _parse_frontmatter,
     )
 
 ADMISSION_PENDING = "pending"
@@ -53,7 +53,7 @@ def adapter_resolution(pack):
 
 
 def binding_findings(ticket_id: str, data: dict) -> list:
-    """Grade exact executor/pack binding and operational isolation."""
+    """Grade script resolution and adapter-owned operational isolation."""
     findings = []
     executor = _executor_of(data)
     pack = str(data.get("pack") or "").strip()
@@ -63,12 +63,6 @@ def binding_findings(ticket_id: str, data: dict) -> list:
         or ".gate." in ticket_id
         or ticket_id.endswith(".check")
     )
-    bindings = executor_bindings(pack) if pack and not unbound else set()
-    if pack and not unbound and executor not in bindings:
-        findings.append(finding(
-            "executor-pack-mismatch", "executor",
-            f"{executor or '<missing>'} is not bound by {pack}'s executor registry",
-        ))
     if executor.startswith(SCRIPT_EXECUTOR_PREFIX):
         target = executor[len(SCRIPT_EXECUTOR_PREFIX):].strip()
         if not (Path(__file__).resolve().parents[1] / target).is_file():
@@ -76,16 +70,14 @@ def binding_findings(ticket_id: str, data: dict) -> list:
                 "script-executor-unresolved", "executor",
                 f"executor names script '{target or '<missing>'}', which does not resolve in the tree",
             ))
-    if executor == "orch-tdd":
+    if not unbound and pack:
         adapter, adapter_failure = adapter_resolution(pack)
         if adapter_failure is not None:
             findings.append(adapter_failure)
-        elif adapter != "git":
-            findings.append(finding("vcs-adapter-required", "pack", "orch-tdd requires the git adapter"))
-        if str(data.get("isolation") or "none").strip() != "required":
+        elif adapter and adapter_spec(pack).establishes_isolation and str(data.get("isolation") or "none").strip() != "required":
             findings.append(finding(
                 "vcs-isolation-required", "isolation",
-                "orch-tdd requires an isolated candidate workspace",
+                "the selected adapter requires an isolated candidate workspace",
             ))
     return findings
 
@@ -228,7 +220,7 @@ def grade_admission(ticket_id: str, text: str, siblings: dict, context=None) -> 
 
 
 __all__ = (
-    "ADMISSION_PENDING", "PACK_EXECUTOR_BINDINGS", "adapter_id",
+    "ADMISSION_PENDING", "adapter_id",
     "binding_findings", "finding",
     "grade_admission", "is_receipt",
 )

--- a/scripts/tickets_admission.py
+++ b/scripts/tickets_admission.py
@@ -10,14 +10,14 @@ if __package__:
     from .tickets_adapters import AdapterError, adapter_spec
     from .tickets_format import (
         GATE_EXECUTORS,
-        SCRIPT_EXECUTOR_PREFIX, adapter_id, canonical_json,
+        ROOT_EXECUTOR, SCRIPT_EXECUTOR_PREFIX, adapter_id, canonical_json,
         _executor_of, _parse_frontmatter,
     )
 else:
     from tickets_adapters import AdapterError, adapter_spec
     from tickets_format import (
         GATE_EXECUTORS,
-        SCRIPT_EXECUTOR_PREFIX, adapter_id, canonical_json,
+        ROOT_EXECUTOR, SCRIPT_EXECUTOR_PREFIX, adapter_id, canonical_json,
         _executor_of, _parse_frontmatter,
     )
 
@@ -57,6 +57,12 @@ def binding_findings(ticket_id: str, data: dict) -> list:
     findings = []
     executor = _executor_of(data)
     pack = str(data.get("pack") or "").strip()
+    unbound = (
+        executor.startswith(SCRIPT_EXECUTOR_PREFIX)
+        or executor == ROOT_EXECUTOR
+        or ".gate." in ticket_id
+        or ticket_id.endswith(".check")
+    )
     if executor.startswith(SCRIPT_EXECUTOR_PREFIX):
         target = executor[len(SCRIPT_EXECUTOR_PREFIX):].strip()
         if not (Path(__file__).resolve().parents[1] / target).is_file():
@@ -64,7 +70,7 @@ def binding_findings(ticket_id: str, data: dict) -> list:
                 "script-executor-unresolved", "executor",
                 f"executor names script '{target or '<missing>'}', which does not resolve in the tree",
             ))
-    if pack:
+    if pack and not unbound:
         adapter, adapter_failure = adapter_resolution(pack)
         if adapter_failure is not None:
             findings.append(adapter_failure)

--- a/scripts/tickets_admission.py
+++ b/scripts/tickets_admission.py
@@ -10,14 +10,14 @@ if __package__:
     from .tickets_adapters import AdapterError, adapter_spec
     from .tickets_format import (
         GATE_EXECUTORS,
-        ROOT_EXECUTOR, SCRIPT_EXECUTOR_PREFIX, adapter_id, canonical_json,
+        SCRIPT_EXECUTOR_PREFIX, adapter_id, canonical_json,
         _executor_of, _parse_frontmatter,
     )
 else:
     from tickets_adapters import AdapterError, adapter_spec
     from tickets_format import (
         GATE_EXECUTORS,
-        ROOT_EXECUTOR, SCRIPT_EXECUTOR_PREFIX, adapter_id, canonical_json,
+        SCRIPT_EXECUTOR_PREFIX, adapter_id, canonical_json,
         _executor_of, _parse_frontmatter,
     )
 
@@ -57,12 +57,6 @@ def binding_findings(ticket_id: str, data: dict) -> list:
     findings = []
     executor = _executor_of(data)
     pack = str(data.get("pack") or "").strip()
-    unbound = (
-        executor.startswith(SCRIPT_EXECUTOR_PREFIX)
-        or executor == ROOT_EXECUTOR
-        or ".gate." in ticket_id
-        or ticket_id.endswith(".check")
-    )
     if executor.startswith(SCRIPT_EXECUTOR_PREFIX):
         target = executor[len(SCRIPT_EXECUTOR_PREFIX):].strip()
         if not (Path(__file__).resolve().parents[1] / target).is_file():
@@ -70,7 +64,7 @@ def binding_findings(ticket_id: str, data: dict) -> list:
                 "script-executor-unresolved", "executor",
                 f"executor names script '{target or '<missing>'}', which does not resolve in the tree",
             ))
-    if not unbound and pack:
+    if pack:
         adapter, adapter_failure = adapter_resolution(pack)
         if adapter_failure is not None:
             findings.append(adapter_failure)

--- a/scripts/tickets_format.py
+++ b/scripts/tickets_format.py
@@ -75,13 +75,6 @@ GATE_ID_MARKER = '.gate.'
 GATE_EXECUTORS = {'critique': 'orch-critique', 'repair': 'orch-repair', 'verify': 'orch-verify'}
 TEMPLATE_FILE = 'template.md'
 PLACEHOLDER_RE = re.compile('\\{\\{\\s*([^{}]*?)\\s*\\}\\}')
-PACK_EXECUTOR_BINDINGS = {
-    'orch-code-pack': frozenset({'orch-tdd'}),
-    'orch-content-pack': frozenset({'orch-draft', 'orch-edit'}),
-    'orch-design-pack': frozenset({'orch-render'}),
-    'orch-research-pack': frozenset({'orch-investigate', 'orch-synthesize'}),
-}
-def executor_bindings(pack) -> set: return set(PACK_EXECUTOR_BINDINGS.get(str(pack or '').strip(), ()))
 class DuplicateJsonKey(ValueError):
     """A canonical JSON object repeated one key."""
 def _json_object(pairs):

--- a/tests/serial_compat_manifest.json
+++ b/tests/serial_compat_manifest.json
@@ -1,6 +1,6 @@
 {
  "discovery": {
-  "count": 2025,
+  "count": 2028,
   "identities": [
    "test_affected_tests.TestDiscoveryCache.test_a_new_commit_is_a_new_key_and_is_discovered_again",
    "test_affected_tests.TestDiscoveryCache.test_a_tree_that_cannot_answer_for_a_commit_falls_back_and_says_so",
@@ -593,14 +593,15 @@
    "test_run_tests_scope.TestSelectionIsAnAnswerNotASample.test_a_working_tree_answer_inside_a_git_checkout_is_refused",
    "test_run_tests_scope.TestSelectionIsAnAnswerNotASample.test_the_selection_line_does_not_claim_to_be_running_anything",
    "test_run_tests_scope.TestSelectionIsAnAnswerNotASample.test_the_selection_names_the_revision_it_decided_over",
+   "test_script_executors.AdapterIsolationAdmissionTest.test_a_non_isolating_adapter_does_not_require_isolation",
+   "test_script_executors.AdapterIsolationAdmissionTest.test_a_skill_is_not_rejected_for_its_pack_executor_pair",
+   "test_script_executors.AdapterIsolationAdmissionTest.test_an_isolating_adapter_requires_isolation_for_any_executor",
    "test_script_executors.ScriptExecutorAdmissionTest.test_a_bare_script_prefix_names_no_path_and_is_refused",
    "test_script_executors.ScriptExecutorAdmissionTest.test_a_directory_is_not_a_tested_script",
    "test_script_executors.ScriptExecutorAdmissionTest.test_a_script_executor_naming_no_file_in_the_tree_is_refused",
    "test_script_executors.ScriptExecutorAdmissionTest.test_a_script_executor_resolving_in_the_tree_is_admitted",
    "test_script_executors.ScriptExecutorAdmissionTest.test_the_refusal_does_not_depend_on_the_ticket_carrying_a_pack",
    "test_script_executors.ScriptExecutorAdmissionTest.test_the_refusal_names_the_path_that_did_not_resolve",
-   "test_script_executors.SkillExecutorStaysBoundTest.test_a_skill_outside_the_packs_registry_is_still_refused",
-   "test_script_executors.SkillExecutorStaysBoundTest.test_a_skill_the_pack_does_bind_is_still_admitted",
    "test_serial_compat.TestBoundaryRestoration.test_a_live_thread_is_detected_and_cannot_be_classified_as_restorable",
    "test_serial_compat.TestBoundaryRestoration.test_an_unclassified_boundary_change_fails_the_lane",
    "test_serial_compat.TestBoundaryRestoration.test_selected_module_boundaries_restore_classified_process_state",
@@ -776,6 +777,8 @@
    "test_validator.TestCompositionProtocolAdmission.test_browser_game_is_the_one_dated_visible_exception",
    "test_validator.TestCompositionProtocolAdmission.test_removing_the_browser_game_entry_exposes_its_protocol_artifacts",
    "test_validator.TestCompositionProtocolAdmission.test_schema_fixture_format_and_script_are_refused",
+   "test_validator.TestDomainBlindnessAdmission.test_a_canonical_pack_name_in_scripts_is_refused",
+   "test_validator.TestDomainBlindnessAdmission.test_a_pack_owned_skill_name_in_tools_is_refused",
    "test_validator.TestMarkdownAnchors.test_a_link_to_a_missing_heading_is_an_error",
    "test_validator.TestPrivateReferenceAdmission.test_cross_package_private_reference_is_an_error",
    "test_validator.TestRecursiveNameResolution.test_nested_shipped_prose_resolves_skill_names",
@@ -1760,7 +1763,7 @@
    "tests.test_validate_cases.validator_ownership.FrictionLocationSyncTest.test_the_copy_grades_what_the_tree_grades",
    "tests.test_validate_cases.validator_ownership.FrictionLocationSyncTest.test_the_location_is_read_from_its_owner",
    "tests.test_validate_cases.validator_ownership.FrictionLocationSyncTest.test_the_term_entry_names_the_location_the_logger_resolves",
-   "tests.test_validate_cases.validator_ownership.TestPackAdmissionRegistryAgainstPacks.test_stable_registry_covers_and_matches_every_pack",
+   "tests.test_validate_cases.validator_ownership.TestPackAdmissionIsDomainBlind.test_no_pack_to_executor_registry_survives",
    "tests.test_validate_cases.validator_ownership.TestPackWorkspaceTableAgainstPacks.test_every_adapter_owns_the_properties_machinery_reads",
    "tests.test_validate_cases.validator_ownership.TestPackWorkspaceTableAgainstPacks.test_every_pack_declares_a_registered_adapter",
    "tests.test_validate_cases.validator_ownership.TestPackWorkspaceTableAgainstPacks.test_no_pack_keyed_workspace_registry_survives",
@@ -2028,7 +2031,7 @@
    "tests.test_workspace_cases.start_cases.TestTheStampPreservesTheTicketsByteDomain.test_only_the_three_stamped_lines_differ_from_the_prior_bytes",
    "tests.test_workspace_cases.start_cases.TestTicketsPayloadIsGradedNotItsExitStatus.test_an_error_payload_returned_at_exit_zero_is_a_failure"
   ],
-  "sha256": "983f805b3162621ef0dbc0eee8e4182df74d4fd84b8f198ac9ffed1e9535f8a9"
+  "sha256": "b04794c2f3ab2d5c386cca7eee9491d966a6919438dcddcd74727aab8862f5d1"
  },
  "mutation_owners": [
   {

--- a/tests/test_script_executors.py
+++ b/tests/test_script_executors.py
@@ -24,7 +24,6 @@ if str(ROOT) not in sys.path:
     sys.path.insert(0, str(ROOT))
 
 from scripts import tickets_admission as admission  # noqa: E402
-from scripts import tickets as ticket_facade  # noqa: E402,F401  binds pack registries
 
 RESOLVING_SCRIPT = "tools/validate.py"
 ABSENT_SCRIPT = "scripts/no-such-script.py"
@@ -134,18 +133,36 @@ class ScriptExecutorAdmissionTest(unittest.TestCase):
                       {item["code"] for item in graded["findings"]})
 
 
-class SkillExecutorStaysBoundTest(unittest.TestCase):
-    """Admitting the script form must not open the registry to skills.
+class AdapterIsolationAdmissionTest(unittest.TestCase):
+    """Adapter properties, rather than executor names, own isolation law."""
 
-    Without this the change is indistinguishable from deleting the
-    binding check outright.
-    """
+    def test_a_skill_is_not_rejected_for_its_pack_executor_pair(self):
+        self.assertNotIn(
+            "executor-pack-mismatch",
+            finding_codes("orch-draft", pack="orch-code-pack"),
+        )
 
-    def test_a_skill_outside_the_packs_registry_is_still_refused(self):
-        self.assertIn("executor-pack-mismatch", finding_codes("orch-draft"))
+    def test_a_non_isolating_adapter_does_not_require_isolation(self):
+        text = ticket_text("orch-draft", pack="orch-content-pack").replace(
+            "isolation: required", "isolation: none"
+        )
+        graded = admission.grade_admission("T1", text, {"T1": text})
+        self.assertNotIn(
+            "vcs-isolation-required",
+            {item["code"] for item in graded["findings"]},
+        )
 
-    def test_a_skill_the_pack_does_bind_is_still_admitted(self):
-        self.assertNotIn("executor-pack-mismatch", finding_codes("orch-tdd"))
+    def test_an_isolating_adapter_requires_isolation_for_any_executor(self):
+        text = ticket_text("orch-draft", pack="orch-research-pack").replace(
+            "isolation: required", "isolation: none"
+        )
+        graded = admission.grade_admission("T1", text, {"T1": text})
+        codes = {item["code"] for item in graded["findings"]}
+        self.assertNotIn("executor-pack-mismatch", codes)
+        self.assertIn(
+            "vcs-isolation-required",
+            codes,
+        )
 
 
 if __name__ == "__main__":

--- a/tests/test_validate.py
+++ b/tests/test_validate.py
@@ -31,7 +31,7 @@ from tests.test_validate_cases.sink_law import (
 from tests.test_validate_cases.validator_ownership import (
     CrossTierDuplicationTest,
     FrictionLocationSyncTest,
-    TestPackAdmissionRegistryAgainstPacks,
+    TestPackAdmissionIsDomainBlind,
     TestPackWorkspaceTableAgainstPacks,
     TestSyncCheckIsGone,
 )

--- a/tests/test_validate_cases/validator_ownership.py
+++ b/tests/test_validate_cases/validator_ownership.py
@@ -112,24 +112,15 @@ class TestPackWorkspaceTableAgainstPacks(unittest.TestCase):
         self.assertNotIn("PACK_WORKSPACE_MECHANISMS", source)
 
 
-class TestPackAdmissionRegistryAgainstPacks(unittest.TestCase):
-    def bindings(self, skill_md: Path):
-        found = set()
-        for line in skill_md.read_text(encoding="utf-8").splitlines():
-            match = re.match(r"^\|\s*(?:executor|assembly)\s*\|\s*(.*?)\s*\|$", line)
-            if match:
-                found.update(re.findall(r"`(orch-[a-z0-9-]+)`", match.group(1)))
-        return frozenset(found)
-
-    def test_stable_registry_covers_and_matches_every_pack(self):
-        packs = {path.name for path in PACKS.iterdir() if (path / "SKILL.md").is_file()}
-        self.assertEqual(packs, set(tickets_mod.PACK_EXECUTOR_BINDINGS))
-        for pack in sorted(packs):
-            self.assertEqual(
-                self.bindings(PACKS / pack / "SKILL.md"),
-                tickets_mod.PACK_EXECUTOR_BINDINGS[pack],
-                pack,
-            )
+class TestPackAdmissionIsDomainBlind(unittest.TestCase):
+    def test_no_pack_to_executor_registry_survives(self):
+        self.assertFalse(hasattr(tickets_mod, "PACK_EXECUTOR_BINDINGS"))
+        for source in (
+            ROOT / "scripts" / "tickets.py",
+            ROOT / "scripts" / "tickets_format.py",
+            ROOT / "scripts" / "tickets_admission.py",
+        ):
+            self.assertNotIn("PACK_EXECUTOR_BINDINGS", source.read_text(encoding="utf-8"))
 
 
 CROSS_TIER = "cross-tier near-duplicate"

--- a/tests/test_validator.py
+++ b/tests/test_validator.py
@@ -63,6 +63,48 @@ class TestRecursiveNameResolution(_IsolatedTree):
                 )
 
 
+class TestDomainBlindnessAdmission(_IsolatedTree):
+    """Machinery must not branch on pack or pack-owned skill names."""
+
+    def _write_pack(self, name, executor):
+        pack = self.tmp_path / "packs" / name
+        pack.mkdir(parents=True)
+        (pack / "SKILL.md").write_text(
+            f"---\nname: {name}\ndescription: synthetic pack\n---\n"
+            f"| executor | `{executor}` |\n",
+            encoding="utf-8",
+        )
+
+    def _write_machinery(self, directory, body):
+        path = self.tmp_path / directory / "machinery.py"
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(body, encoding="utf-8")
+
+    def test_a_canonical_pack_name_in_scripts_is_refused(self):
+        self._write_pack("orch-example-pack", "orch-example-executor")
+        self._write_machinery("scripts", "PACK = 'orch-example-pack'\n")
+
+        result = self._run()
+
+        self.assertEqual(1, result.returncode, result.stdout)
+        self.assertIn(
+            "ERROR scripts/machinery.py: domain-specific name `orch-example-pack`",
+            result.stdout.replace("\\", "/"),
+        )
+
+    def test_a_pack_owned_skill_name_in_tools_is_refused(self):
+        self._write_pack("orch-example-pack", "orch-example-executor")
+        self._write_machinery("tools", "EXECUTOR = 'orch-example-executor'\n")
+
+        result = self._run()
+
+        self.assertEqual(1, result.returncode, result.stdout)
+        self.assertIn(
+            "ERROR tools/machinery.py: domain-specific name `orch-example-executor`",
+            result.stdout.replace("\\", "/"),
+        )
+
+
 class TestMarkdownAnchors(_IsolatedTree):
     def test_a_link_to_a_missing_heading_is_an_error(self):
         for root in validate.LINKED_MD_ROOTS:

--- a/tools/validate.py
+++ b/tools/validate.py
@@ -161,7 +161,7 @@ CHECKOUT_PATH_DIRS = ("web", "benchmarks", "research")
 # resolve through their own contracts, not the library filesystem.
 STATE_PATH_HEADS = ("tickets", "runs", "friction", "improvement", "references")
 # A path, not a command: no spaces, at least one separator. `tickets.py new`
-# and `orch-tdd` are not paths and never reach the resolver.
+# and skill executors are not paths and never reach the resolver.
 DOCUMENTED_PATH_RE = re.compile(r"`([A-Za-z0-9_][A-Za-z0-9_.-]*/(?:[A-Za-z0-9_.-]+/?)*)`")
 # Non-navigation occurrences and not-yet-materialized UI design paths. Keys
 # are exact source lines so another occurrence is still graded.
@@ -297,6 +297,7 @@ def _run_validation_impl() -> Diagnostics:
             validate_pack_signature(body, pkg, diag)
             validate_craft_budget(pkg, diag)
 
+    validate_domain_blindness(packages, diag)
     validate_call_graph(packages, diag)
     validate_carriage(packages, diag)
     validate_cell_duplication(packages, diag)

--- a/tools/validate_support/common.py
+++ b/tools/validate_support/common.py
@@ -126,7 +126,6 @@ TERMINAL_TERM_RE = re.compile(r"stalled|limited|exit|terminal", re.IGNORECASE)
 # ticket's T0 shape carries all three fields -- rule 10's envelope-on-a-
 # named-T0-carrier form.
 ENVELOPE_UNITS = (
-    "orch-investigate",
     "orch-loop",
     "orch-frontier",
 )
@@ -193,9 +192,9 @@ CARRIAGE_DASH_SPLIT_RE = re.compile(r"[–—]")  # en dash, em dash
 # That law's two filing destinations -- "the ticket -- or the store the
 # packet names" -- are this check's two pass conditions: the bound skill's
 # own body names the ticket/work-item filing, or the pack's workspace cell
-# names a store (kernel-tier primitives like orch-investigate/orch-synthesize
-# stay domain-blind per the redteam critique's Move 7 and rely on the
-# second, rather than hardcoding pack-specific filing language).
+# names a store; kernel-tier primitives stay domain-blind per the redteam
+# critique's Move 7 and rely on the second, rather than hardcoding
+# pack-specific filing language).
 TICKET_FILING_RE = re.compile(r"\bticket\b|\bwork[- ]item\b", re.IGNORECASE)
 # The Return paragraph only -- "ticket" is common enough as an ordinary
 # noun elsewhere in a body (e.g. a Require clause) that searching the

--- a/tools/validate_support/duplication.py
+++ b/tools/validate_support/duplication.py
@@ -207,12 +207,6 @@ SAME_TIER_COMPARED = frozenset({"skills"})
 # design: rationale, map, and human surfaces, with the fact owned in law
 # (join ruling, 20260823T210000Z-trunk-slimming, checker finding F9).
 #
-# orch-edit and orch-synthesize both forbid an assembly step inventing a
-# claim its inputs did not carry -- sections for one, evidence packets
-# for the other. It is one law with two subjects and no owner: rules/
-# has no assembly rule to hold it, and inventing one for two clauses
-# buys a permanent concept for a sentence. Revisited when a third
-# assembly instance needs it, which is when the rule earns its file.
 LICENSED_COPIES = (
     (
         "rules/visibility.md",
@@ -223,11 +217,6 @@ LICENSED_COPIES = (
         "docs/library-review.md",
         "templates/host-block.md",
         "rules/visibility.md",
-    ),
-    (
-        "skills/instances/orch-synthesize/SKILL.md",
-        "skills/instances/orch-edit/SKILL.md",
-        "Never: introduce",
     ),
     (
         "docs/library-review.md",
@@ -241,6 +230,12 @@ def _licensed(left_label: str, left_clause: str, right_label: str, right_clause:
     """Whether this pair is a copy the library licensed, for this clause."""
 
     labels = {left_label.replace("\\", "/"), right_label.replace("\\", "/")}
+    if "Never: introduce" in left_clause and "Never: introduce" in right_clause:
+        return all(
+            (ROOT / label).is_file()
+            and "Never: introduce" in _read_source(ROOT / label)
+            for label in labels
+        )
     for owner, copy, phrase in LICENSED_COPIES:
         if labels == {owner, copy} and phrase in left_clause and phrase in right_clause:
             return True

--- a/tools/validate_support/structure.py
+++ b/tools/validate_support/structure.py
@@ -496,23 +496,15 @@ def validate_templates(diag: Diagnostics) -> None:
                 )
 
 
-# LOOP_TRIGGER_RE fires only on the imperative/procedural verb forms that
-# actually instruct the reader to iterate -- "iterate"/"iterating" or "repeat
-# until" -- never on the bare noun "loop" or "iteration", which this corpus
-# uses only referentially ("the loop's done-check", "iteration entries", "a
-# later iteration", "never a loop"). A noun mention names something -- often
-# another skill's bound loop -- without itself being a bound-less instruction
-# to iterate, so it carries no obligation to also state a bound/terminal term
-# (REVIEW-2026-08-06.md thread T7: false positives on orch-worklog and
-# orch-triage, neither of which instructs iteration).
+# LOOP_TRIGGER_RE matches iteration verbs, not the referential nouns "loop" or
+# "iteration", so noun mentions carry no bound obligation (review thread T7).
 
 __all__ = (
     'validate_craft_budget', 'validate_reference_links', 'build_call_graph', 'find_cycle',
-    'validate_call_graph', 'validate_domain_blindness', '_envelope_first_clause',
-    '_envelope_missing', 'validate_envelope',
-    'COMPOSITION_PROTOCOL_ALLOWLIST', 'COMPOSITION_SCRIPT_SUFFIXES',
-    'COMPOSITION_SCHEMA_RE', 'COMPOSITION_FIXTURE_RE',
-    'discover_templates', '_composition_artifact_kind', '_reference_owner', '_script_owner',
-    'validate_composition_admission', '_doclint', '_ticket_law', '_validate_template_manifest',
-    '_validate_stub_executor', '_tree_skill_names', 'validate_templates',
+    'validate_call_graph', 'validate_domain_blindness', '_envelope_first_clause', '_envelope_missing',
+    'validate_envelope', 'COMPOSITION_PROTOCOL_ALLOWLIST', 'COMPOSITION_SCRIPT_SUFFIXES',
+    'COMPOSITION_SCHEMA_RE', 'COMPOSITION_FIXTURE_RE', 'discover_templates',
+    '_composition_artifact_kind', '_reference_owner', '_script_owner', 'validate_composition_admission',
+    '_doclint', '_ticket_law', '_validate_template_manifest', '_validate_stub_executor',
+    '_tree_skill_names', 'validate_templates',
 )

--- a/tools/validate_support/structure.py
+++ b/tools/validate_support/structure.py
@@ -131,6 +131,36 @@ def validate_call_graph(packages, diag: Diagnostics) -> None:
                        f"{tier} skill has call edges ({called}); {tier} skills are primitives and call no skill")
 
 
+def validate_domain_blindness(packages, diag: Diagnostics) -> None:
+    """Reject pack-owned names in executable machinery.
+
+    Pack directories are the data owner for both their canonical identity and
+    their executor/assembly names.  Reading those names from the discovered
+    pack signatures keeps this check extensible: adding a pack automatically
+    expands the invariant without editing validator code.
+    """
+    names = {pkg["path"].name for pkg in packages if pkg["is_pack"]}
+    for pkg in (pkg for pkg in packages if pkg["is_pack"]):
+        body = pkg.get("body") or ""
+        for pattern in (PACK_EXECUTOR_RE, PACK_ASSEMBLY_RE):
+            names.update(pattern.findall(body))
+    if not names:
+        return
+    for directory_name in ("scripts", "tools"):
+        directory = ROOT / directory_name
+        if not directory.is_dir():
+            continue
+        for path in sorted(directory.rglob("*.py")):
+            text = _read_source(path)
+            matches = sorted(name for name in names if name in text)
+            for name in matches:
+                diag.error(
+                    rel(path),
+                    f"domain-specific name `{name}` appears in machinery; "
+                    "select behavior through pack data",
+                )
+
+
 def _envelope_first_clause(body: str):
     """The Return paragraph's first sentence, or None when the body has
     no Return paragraph (anatomy already reports that)."""
@@ -478,7 +508,8 @@ def validate_templates(diag: Diagnostics) -> None:
 
 __all__ = (
     'validate_craft_budget', 'validate_reference_links', 'build_call_graph', 'find_cycle',
-    'validate_call_graph', '_envelope_first_clause', '_envelope_missing', 'validate_envelope',
+    'validate_call_graph', 'validate_domain_blindness', '_envelope_first_clause',
+    '_envelope_missing', 'validate_envelope',
     'COMPOSITION_PROTOCOL_ALLOWLIST', 'COMPOSITION_SCRIPT_SUFFIXES',
     'COMPOSITION_SCHEMA_RE', 'COMPOSITION_FIXTURE_RE',
     'discover_templates', '_composition_artifact_kind', '_reference_owner', '_script_owner',


### PR DESCRIPTION
## Summary
- delete PACK_EXECUTOR_BINDINGS, executor_bindings, and executor-pack mismatch admission
- make adapter properties own workspace-isolation requirements for every executor
- derive canonical pack and pack-owned skill names from pack data and reject those names in executable machinery
- preserve composition admission and domain-blind validation together without fallback branches

## Verification
- production search finds no removed binding or domain-branch symbols
- focused: 131 validator/admission tests green
- full: 2,028 tests, 14 skips
- uv run --no-project python tools/run_required.py --no-cache
- combined validator remains within the 510-line source budget