### PR TITLE
U9: add deterministic ticket grade and gate reuse

### DIFF
--- a/scripts/tickets.py
+++ b/scripts/tickets.py
@@ -40,6 +40,7 @@ if __package__:
     from . import tickets_attempts as _tickets_attempts_module
     from . import tickets_dispatch_packet as _tickets_dispatch_packet_module
     from . import tickets_join as _tickets_join_module
+    from . import tickets_grade as _tickets_grade_module
 else:
     # By name, as `tickets_generations` is reached: the family's
     # module-level import census is pinned, and this module joined after it.
@@ -60,6 +61,7 @@ else:
     import tickets_attempts as _tickets_attempts_module
     import tickets_dispatch_packet as _tickets_dispatch_packet_module
     import tickets_join as _tickets_join_module
+    _tickets_grade_module = __import__('tickets_grade')
 
 BOUND_KINDS = _tickets_bound_module.BOUND_KINDS
 OTHER_BOUND_KIND = _tickets_bound_module.OTHER_BOUND_KIND
@@ -274,6 +276,7 @@ _upstream = _tickets_worklog_module._upstream
 _write_rendered_worklog = _tickets_worklog_module._write_rendered_worklog
 template_defects = _tickets_worklog_module.template_defects
 GATE_USAGE = _tickets_commands_module.GATE_USAGE
+GRADE_USAGE = _tickets_commands_module.GRADE_USAGE
 DISPATCH_USAGE = _tickets_commands_module.DISPATCH_USAGE
 HELP_COMMANDS = _tickets_commands_module.HELP_COMMANDS
 HELP_FLAGS = _tickets_commands_module.HELP_FLAGS
@@ -288,6 +291,8 @@ apply_fixes = _tickets_lint_module.apply_fixes
 lint_findings = _tickets_lint_module.lint_findings
 _cmd_lint = _tickets_lint_module._cmd_lint
 _cmd_gate = _tickets_dispatch_module._cmd_gate
+_cmd_fixed_gate = _tickets_grade_module._cmd_fixed_gate
+_cmd_grade = _tickets_dispatch_module._cmd_grade
 _cmd_dispatch = _tickets_dispatch_module._cmd_dispatch
 _cmd_help = _tickets_dispatch_module._cmd_help
 _cmd_improvement = _tickets_dispatch_module._cmd_improvement

--- a/scripts/tickets_commands.py
+++ b/scripts/tickets_commands.py
@@ -46,6 +46,7 @@ DISPATCH_USAGE = (
     "[--form reference | inline]"
 )
 GATE_USAGE = "gate <run> <root-or-checked-id> [--lens <name>[,<name>] | --ordered-lens-bundle <name>[,<name>]]"
+GRADE_USAGE = "grade <run> <root>"
 CHECKER_STAGE_USAGE = "checker-stage <run> <id>"
 BOUND_CHECK_USAGE = "bound-check <run> [--now <iso>]"
 STAMP_GENERATION_USAGE = "stamp-generation <run> <root-id>"
@@ -53,6 +54,7 @@ SUBCOMMAND_USAGE = {
     "new": NEW_USAGE,
     "instantiate": INSTANTIATE_USAGE,
     "gate": GATE_USAGE,
+    "grade": GRADE_USAGE,
     "checker-stage": CHECKER_STAGE_USAGE,
     "stamp-generation": STAMP_GENERATION_USAGE,
     "list": "list [--run R]",
@@ -82,6 +84,7 @@ SUBCOMMAND_SUMMARY = {
     "new": "Create one Goal/Context ticket; Suggested files are optional and non-binding.",
     "instantiate": "Instantiate, validate, and seal one current-format template graph all or none.",
     "gate": "Create a composite gate, or materialize repair and fresh verification after an ordinary checker accepts blockers.",
+    "grade": "Report deterministic width, shape, pack coverage, adapter capability, and decomposition state.",
     "checker-stage": "Create or replay one explicit ordinary read-only checker stage.",
     "stamp-generation": "Stamp one unclaimed direct or decomposed root and its members.",
     "list": "List tickets.",

--- a/scripts/tickets_dispatch.py
+++ b/scripts/tickets_dispatch.py
@@ -42,32 +42,20 @@ if __package__:
 else:
     from tickets_worklog import WORKLOG_USAGE, _cmd_worklog, _run_tickets, _template_order
 if __package__:
-    from .tickets_emission import grade_run_emission; from .tickets_context import run_snapshot; from .tickets_generations import GENERATION_RE, _root_payload, canonical_json, draft_snapshot, generation_identity, seal_assignments, validate_draft; from .tickets_transitions import pending_admission, stamp; from .tickets_commands import STAMP_GENERATION_USAGE, GATE_USAGE, HELP_COMMANDS, HELP_FLAGS, INSTANTIATE_USAGE, LINT_USAGE, SUBCOMMAND_SUMMARY, SUBCOMMAND_USAGE, VALUE_FLAGS, resolve_payload_flags; from .tickets_lint import _cmd_lint; from .tickets_bound import _cmd_bound_check
+    from .tickets_emission import grade_run_emission; from .tickets_context import run_snapshot; from .tickets_generations import GENERATION_RE, _root_payload, canonical_json, draft_snapshot, generation_identity, seal_assignments, validate_draft; from .tickets_transitions import pending_admission, stamp; from .tickets_commands import STAMP_GENERATION_USAGE, GATE_USAGE, HELP_COMMANDS, HELP_FLAGS, INSTANTIATE_USAGE, LINT_USAGE, SUBCOMMAND_SUMMARY, SUBCOMMAND_USAGE, VALUE_FLAGS, resolve_payload_flags; from .tickets_lint import _cmd_lint; from .tickets_bound import _cmd_bound_check; from .tickets_grade import _cmd_gate, _cmd_grade
     from .tickets_dispatch_facade import _cmd_dispatch
     from .tickets_generations import GENERATION_SUBCOMMANDS
     from .tickets_root_reservation import mismatch as _root_reservation_mismatch
-    from .tickets_dispatch_gate import _gate_body, _gate_input, _gate_sections, _gate_stub, _gate_under_run_lock, _input_name, _listed_items, _pack_domain; from .tickets_dispatch_gate import _cmd_checker_stage, _cmd_gate as _gate_command
+    from .tickets_dispatch_gate import _gate_body, _gate_input, _gate_sections, _gate_stub, _gate_under_run_lock, _input_name, _listed_items, _pack_domain; from .tickets_dispatch_gate import _cmd_checker_stage
 else:
-    from tickets_emission import grade_run_emission; from tickets_context import run_snapshot; from tickets_transitions import pending_admission, stamp; _generations = __import__('tickets_generations'); GENERATION_RE = _generations.GENERATION_RE; _root_payload = _generations._root_payload; canonical_json = _generations.canonical_json; draft_snapshot = _generations.draft_snapshot; generation_identity = _generations.generation_identity; seal_assignments = _generations.seal_assignments; validate_draft = _generations.validate_draft; from tickets_commands import STAMP_GENERATION_USAGE, GATE_USAGE, HELP_COMMANDS, HELP_FLAGS, INSTANTIATE_USAGE, LINT_USAGE, SUBCOMMAND_SUMMARY, SUBCOMMAND_USAGE, VALUE_FLAGS, resolve_payload_flags; from tickets_lint import _cmd_lint
+    from tickets_emission import grade_run_emission; from tickets_context import run_snapshot; from tickets_transitions import pending_admission, stamp; _generations = __import__('tickets_generations'); GENERATION_RE = _generations.GENERATION_RE; _root_payload = _generations._root_payload; canonical_json = _generations.canonical_json; draft_snapshot = _generations.draft_snapshot; generation_identity = _generations.generation_identity; seal_assignments = _generations.seal_assignments; validate_draft = _generations.validate_draft; from tickets_commands import STAMP_GENERATION_USAGE, GATE_USAGE, HELP_COMMANDS, HELP_FLAGS, INSTANTIATE_USAGE, LINT_USAGE, SUBCOMMAND_SUMMARY, SUBCOMMAND_USAGE, VALUE_FLAGS, resolve_payload_flags; from tickets_lint import _cmd_lint; _grade_module = __import__('tickets_grade'); _cmd_gate = _grade_module._cmd_gate; _cmd_grade = _grade_module._cmd_grade
     from tickets_dispatch_facade import _cmd_dispatch
     _cmd_bound_check = __import__('tickets_bound')._cmd_bound_check
-    _gate_module = __import__('tickets_dispatch_gate'); _cmd_checker_stage = _gate_module._cmd_checker_stage; _gate_command = _gate_module._cmd_gate; _gate_body = _gate_module._gate_body; _gate_input = _gate_module._gate_input; _gate_sections = _gate_module._gate_sections
+    _gate_module = __import__('tickets_dispatch_gate'); _cmd_checker_stage = _gate_module._cmd_checker_stage; _gate_body = _gate_module._gate_body; _gate_input = _gate_module._gate_input; _gate_sections = _gate_module._gate_sections
     _gate_stub = _gate_module._gate_stub; _gate_under_run_lock = _gate_module._gate_under_run_lock; _input_name = _gate_module._input_name; _listed_items = _gate_module._listed_items; _pack_domain = _gate_module._pack_domain
     try: GENERATION_SUBCOMMANDS = __import__("tickets_generations").GENERATION_SUBCOMMANDS
     except ModuleNotFoundError: GENERATION_SUBCOMMANDS = {}
     _root_reservation_mismatch = __import__('tickets_root_reservation').mismatch
-def _cmd_gate(rest):
-    """`gate`, with this module's HEAD probe sealed into the family.
-
-    The probe is supplied from here rather than read inside the gate module
-    so that one revision reaches every stub the family writes, and so that
-    the seam a caller substitutes is the one this façade names.
-
-    The builder emits members for the root's sole sealed assignment model.
-    """
-    return _gate_command(rest)
-
-
 def git_head():
     done = subprocess.run(["git", "rev-parse", "HEAD"], text=True, capture_output=True)
     return done.stdout.strip() if done.returncode == 0 else None
@@ -428,7 +416,7 @@ def _dispatch(argv):
         from tickets import _sync_seams
     _sync_seams()
     if not argv:
-        return {'error': 'missing subcommand: new | lint | bound-check | instantiate | gate | checker-stage | stamp-generation | draft-validate | seal | list | show | ready | dispatch | dispatch-open | dispatch-commit | dispatch-retire | dispatch-replace | dispatch-outcome | dispatch-join | dispatch-packet | dispatch-receive | check | set-status | join-noop-repair | result | worklog | run-state | improvement'}
+        return {'error': 'missing subcommand: new | lint | bound-check | instantiate | grade | gate | checker-stage | stamp-generation | draft-validate | seal | list | show | ready | dispatch | dispatch-open | dispatch-commit | dispatch-retire | dispatch-replace | dispatch-outcome | dispatch-join | dispatch-packet | dispatch-receive | check | set-status | join-noop-repair | result | worklog | run-state | improvement'}
     command, rest = (argv[0], argv[1:])
     if command in HELP_COMMANDS:
         return _cmd_help()
@@ -446,6 +434,7 @@ def _dispatch(argv):
     if command == 'draft-validate': return GENERATION_SUBCOMMANDS[command][2](rest)
     if command == 'seal': return GENERATION_SUBCOMMANDS[command][2](rest)
     if command == 'instantiate': return _cmd_instantiate(rest)
+    if command == 'grade': return _cmd_grade(rest)
     if command == 'gate': return _cmd_gate(rest)
     if command == 'checker-stage': return _cmd_checker_stage(rest)
     if command == 'list':

--- a/scripts/tickets_grade.py
+++ b/scripts/tickets_grade.py
@@ -1,0 +1,451 @@
+"""Deterministic routing grades and fixed-result gate probes.
+
+This module owns the small amount of state-derived routing information that
+is safe to compute without making a model decision.  In particular, it does
+not decide whether a Goal is adequate or whether a review lens is sufficient;
+it only reports graph shape, declared pack coverage, and adapter capability.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+
+if __package__:
+    from .tickets_adapters import AdapterError, adapter_spec, pack_path
+    from .tickets_format import GATE_EXECUTORS, GATE_ID_MARKER, LOOP_EXECUTOR, ROOT_EXECUTOR
+    from .tickets_markdown import _parse_frontmatter, _sections
+    from .tickets_store import NO_SINK_ERROR, _run_lock, _segment_error, _tickets_root
+    from .tickets_context import run_snapshot
+else:
+    from tickets_adapters import AdapterError, adapter_spec, pack_path
+    from tickets_format import GATE_EXECUTORS, GATE_ID_MARKER, LOOP_EXECUTOR, ROOT_EXECUTOR
+    from tickets_markdown import _parse_frontmatter, _sections
+    from tickets_store import NO_SINK_ERROR, _run_lock, _segment_error, _tickets_root
+    from tickets_context import run_snapshot
+
+
+GRADE_USAGE = "grade <run> <root>"
+_UNRESOLVED_COVER = "<unresolved-cover>"
+
+
+class GradeError(ValueError):
+    """The durable ticket projection cannot receive a deterministic grade."""
+
+
+def _ticket_data(value):
+    if isinstance(value, dict):
+        return value
+    return _parse_frontmatter(str(value or ""))
+
+
+def _ticket_text(value):
+    return value if isinstance(value, str) else ""
+
+
+def _executor(value):
+    return str(_ticket_data(value).get("executor") or "").strip().strip("`").strip()
+
+
+def _member_ids(root_id: str, snapshot: dict) -> list[str]:
+    """Return the root's executor-result members, excluding review plumbing.
+
+    Gate and ordinary checker stages are descendants in the ticket directory,
+    but they are assurance work rather than independent result members.  A
+    nested member remains a member of the issued root: the graph's width is
+    the number of independently observable result tickets in its cut.
+    """
+
+    members = []
+    for ticket_id in sorted(snapshot):
+        if not ticket_id.startswith(root_id + "."):
+            continue
+        if GATE_ID_MARKER in ticket_id or ticket_id.endswith(".check"):
+            continue
+        executor = _executor(snapshot[ticket_id])
+        if executor in set(GATE_EXECUTORS.values()):
+            continue
+        members.append(ticket_id)
+    return members
+
+
+_TABLE_ROW = re.compile(r"^\s*\|\s*([^|]+?)\s*\|\s*([^|]*?)\s*\|\s*$")
+_FIELD_SEPARATOR = re.compile(r"\s*;\s*")
+_EM_DASH = re.compile(r"\s+[—–-]\s+")
+_WORDS = re.compile(r"[a-z0-9_]+")
+_COVERS_LINE = re.compile(
+    r"(?:^|\n)[^\n]*?\b(?:covers|covered(?:\s+identities)?)\s*:\s*(.+)$",
+    re.IGNORECASE | re.MULTILINE,
+)
+
+
+def _required_spec_fields(pack: str) -> list[str]:
+    try:
+        text = pack_path(pack).read_text(encoding="utf-8")
+    except (AdapterError, OSError, UnicodeDecodeError) as error:
+        raise GradeError(str(error)) from error
+    declared = None
+    for line in text.splitlines():
+        match = _TABLE_ROW.match(line)
+        if match and match.group(1).strip().lower() == "required_spec_fields":
+            declared = match.group(2).strip()
+            break
+    if not declared:
+        return []
+    fields = []
+    for value in _FIELD_SEPARATOR.split(declared):
+        value = value.strip().strip("`").strip()
+        if not value:
+            continue
+        # A pack may explain a field after an em dash.  The stable field name
+        # is the portion before that explanation.
+        value = _EM_DASH.split(value, maxsplit=1)[0].strip().strip("`").strip()
+        if value and value not in fields:
+            fields.append(value)
+    return fields
+
+
+def _mentioned(field: str, text: str) -> bool:
+    """Match a declared field by its meaningful words, not punctuation."""
+
+    field_words = _WORDS.findall(field.casefold().replace("-", "_"))
+    body_words = set(_WORDS.findall(text.casefold().replace("-", "_")))
+    return bool(field_words) and all(word in body_words for word in field_words)
+
+
+def grade_snapshot(root_id: str, snapshot: dict) -> dict:
+    """Grade one exact ticket snapshot into the closed routing answer."""
+
+    if not isinstance(snapshot, dict) or root_id not in snapshot:
+        raise GradeError(f"root ticket not found in exact snapshot: {root_id}")
+    root_value = snapshot[root_id]
+    root_data = _ticket_data(root_value)
+    if not root_data:
+        raise GradeError(f"root ticket has no readable frontmatter: {root_id}")
+    if str(root_data.get("id") or root_id).strip() != root_id:
+        raise GradeError(f"root ticket id differs from requested id: {root_id}")
+    root_executor = _executor(root_value)
+    members = _member_ids(root_id, snapshot)
+    if root_executor == ROOT_EXECUTOR:
+        if len(members) == 1:
+            raise GradeError(f"root {root_id} is over-decomposition: one executor result member")
+        if not members:
+            raise GradeError(f"root {root_id} has no executor result members")
+        shape, width = "graph", len(members)
+    elif root_executor == LOOP_EXECUTOR:
+        shape, width = "loop", 1
+    else:
+        shape, width = "single", 1
+    pack = str(root_data.get("pack") or "").strip().strip("`").strip()
+    if not pack:
+        raise GradeError(f"root {root_id} names no pack")
+    try:
+        deterministic_gate = bool(adapter_spec(pack).deterministic_gate)
+    except AdapterError as error:
+        raise GradeError(error.detail) from error
+    sections = _sections(_ticket_text(root_value)) if _ticket_text(root_value) else {}
+    semantic_text = "\n".join(
+        sections.get(name, "") for name in ("Goal", "Context", "Suggested files")
+    )
+    unmentioned = [
+        field for field in _required_spec_fields(pack)
+        if not _mentioned(field, semantic_text)
+    ]
+    return {
+        "width": width,
+        "shape": shape,
+        "unmentioned_spec_fields": unmentioned,
+        "deterministic_gate": deterministic_gate,
+        "over_decomposed": False,
+    }
+
+
+def _section_identity(body: str) -> str:
+    return "sha256:" + hashlib.sha256(body.encode("utf-8")).hexdigest()
+
+
+def _result_identity(value):
+    data = _ticket_data(value)
+    explicit = data.get("result_identity")
+    if explicit:
+        return str(explicit).strip()
+    text = _ticket_text(value)
+    if text:
+        result_text = _sections(text).get("Result", "")
+        match = re.search(
+            r"\b(?:fixed\s+)?result(?:\s+identity)?\s*(?:is|:)?\s*`?([0-9a-f]{7,64})`?",
+            result_text, re.IGNORECASE,
+        )
+        if match:
+            return match.group(1)
+        match = re.search(
+            r"\b(?:tip|revision|as\s+of)\b[^\n:]*[: ]\s*`?([0-9a-f]{7,64})`?",
+            result_text, re.IGNORECASE,
+        )
+        if match:
+            return match.group(1)
+        return _section_identity(result_text)
+    return None
+
+
+def _identity_for(ticket_id: str, value) -> str:
+    data = _ticket_data(value)
+    seal = str(data.get("assignment_seal") or "").strip()
+    if seal:
+        return seal
+    return _section_identity(_ticket_text(value))
+
+
+def _fixed_payload(value):
+    """Find a closed verdict payload in review_v1 or Verification prose.
+
+    Older tickets carry only prose.  A fixed-result gate is opt-in: it is
+    recognized only when a Verification payload names both a verdict and
+    covered identities, so existing composite-gate lifecycle tickets retain
+    their materialization behavior.
+    """
+
+    data = _ticket_data(value)
+    raw = data.get("review_v1")
+    candidates = []
+    if raw:
+        try:
+            candidates.append(json.loads(raw) if isinstance(raw, str) else raw)
+        except (TypeError, ValueError):
+            return None
+    text = _ticket_text(value)
+    if text:
+        sections = _sections(text)
+        body = sections.get("Verification", "").strip()
+        if body:
+            try:
+                candidates.append(json.loads(body))
+            except (TypeError, ValueError):
+                match = _COVERS_LINE.search(body)
+                if match:
+                    covers = _parse_covers_prose(match.group(1))
+                    verdict_match = re.search(
+                        r"\b(PASS|FAIL|UNVERIFIED)\b", body,
+                    )
+                    verdict = verdict_match.group(1) if verdict_match else ""
+                    if verdict in {"PASS", "FAIL", "UNVERIFIED"} and covers is not None:
+                        candidates.append({"verdict": verdict, "covers": covers})
+    for candidate in candidates:
+        records = candidate.get("records") if isinstance(candidate, dict) else None
+        records = records if isinstance(records, list) else [candidate]
+        for record in reversed(records):
+            if not isinstance(record, dict) or record.get("kind") not in (None, "Verification"):
+                continue
+            if record.get("verdict") in {"PASS", "FAIL", "UNVERIFIED"} and "covers" in record:
+                return record
+    return None
+
+
+def _parse_covers_prose(value: str):
+    """Read the compact ``base ...; result ...; dependencies ...`` form."""
+
+    covers = {}
+    for part in re.split(r"\s*;\s*", value.strip()):
+        name, separator, identity = part.partition(" ")
+        name = name.strip().rstrip(":").casefold()
+        identity = identity.strip()
+        if not separator or name not in {"base", "result", "dependencies"}:
+            continue
+        if identity.casefold().startswith("none"):
+            covers[name] = []
+        else:
+            quoted = re.match(r"`([^`]+)`", identity)
+            covers[name] = quoted.group(1) if quoted else identity.split()[0]
+    return covers if covers else None
+
+
+def _cover_current(cover, target_id: str, snapshot: dict):
+    """Resolve common cover spellings to current durable identities."""
+
+    if isinstance(cover, dict):
+        target = snapshot.get(target_id)
+        target_data = _ticket_data(target)
+        dependencies = target_data.get("depends_on") or []
+        if "id" in cover and "identity" in cover:
+            covered_id = str(cover.get("id") or "")
+            current_identity = (
+                _identity_for(covered_id, snapshot[covered_id])
+                if covered_id in snapshot else _UNRESOLVED_COVER
+            )
+            return {"id": covered_id, "identity": current_identity}
+        resolved = {}
+        for key, value in sorted(cover.items()):
+            name = str(key)
+            if name in snapshot:
+                resolved[name] = _identity_for(name, snapshot[name])
+            elif name in {"base", "base_identity"}:
+                current = (
+                    target_data.get("base_identity")
+                    or target_data.get("workspace_baseline")
+                    or target_data.get("assignment_seal")
+                )
+                resolved[name] = str(current or _UNRESOLVED_COVER).split()[0]
+            elif name in {"result", "result_identity"}:
+                current = _result_identity(target)
+                resolved[name] = str(current or _UNRESOLVED_COVER)
+            elif name in {"dependencies", "dependency_identities"}:
+                current = target_data.get("dependency_identities")
+                if not current:
+                    current = [
+                        _identity_for(str(item), snapshot[str(item)])
+                        if str(item) in snapshot else _UNRESOLVED_COVER
+                        for item in dependencies
+                    ]
+                resolved[name] = current
+            else:
+                resolved[name] = _cover_current(value, target_id, snapshot)
+        return resolved
+    if isinstance(cover, list):
+        return [_cover_current(item, target_id, snapshot) for item in cover]
+    value = str(cover or "").strip()
+    if value in snapshot:
+        return _identity_for(value, snapshot[value])
+    if value.startswith("ticket:") and value[7:] in snapshot:
+        ticket_id = value[7:]
+        return _identity_for(ticket_id, snapshot[ticket_id])
+    return value
+
+
+def _cover_equal(current, expected) -> bool:
+    if isinstance(current, dict) and isinstance(expected, dict):
+        return set(current) == set(expected) and all(
+            _cover_equal(current[key], expected[key]) for key in current
+        )
+    if isinstance(current, list) and isinstance(expected, list):
+        return len(current) == len(expected) and all(
+            _cover_equal(actual, wanted)
+            for actual, wanted in zip(current, expected)
+        )
+    if isinstance(current, str) and isinstance(expected, str):
+        actual, wanted = current.strip().lower(), expected.strip().lower()
+        if actual.startswith("sha256:"):
+            actual = actual[7:]
+        if wanted.startswith("sha256:"):
+            wanted = wanted[7:]
+        return actual == wanted
+    return current == expected
+
+
+def fixed_gate_snapshot(target_id: str, snapshot: dict) -> dict | None:
+    """Return a deterministic fixed-result gate answer, or ``None``.
+
+    ``reusable`` is true only when every declared cover resolves to the same
+    current identity.  The caller can then avoid issuing a checker packet.
+    No verdict adequacy is inferred here; the stored verdict is returned as
+    evidence for the caller's route.
+    """
+
+    value = snapshot.get(target_id)
+    if value is None:
+        return None
+    payload = _fixed_payload(value)
+    if payload is None:
+        return None
+    covers = payload.get("covers")
+    if not isinstance(covers, (dict, list)) or not covers:
+        return None
+    # A mapping may carry the expected identity as its value.  For a named
+    # ticket/path key we resolve the current identity; opaque identities stay
+    # opaque and therefore compare exactly.
+    current = _cover_current(covers, target_id, snapshot)
+    reusable = _cover_equal(current, covers)
+    return {
+        "target": target_id,
+        "verdict": payload["verdict"],
+        "covers": covers,
+        "reusable": reusable,
+        "outcome": "reused" if reusable else "stale",
+    }
+
+
+def _cmd_grade(rest):
+    args = list(rest)
+    if len(args) != 2:
+        return {"error": f"usage: {GRADE_USAGE}"}
+    run, root_id = args
+    for kind, value in (("run id", run), ("ticket id", root_id)):
+        invalid = _segment_error(kind, value)
+        if invalid is not None:
+            return invalid
+    tickets_root = _tickets_root()
+    if tickets_root is None:
+        return {"error": NO_SINK_ERROR}
+    run_dir = tickets_root / run
+    try:
+        with _run_lock(run):
+            snapshot, failures = run_snapshot(run_dir) if run_dir.is_dir() else ({}, [])
+            if failures:
+                return {"error": f"unreadable ticket: {failures[0][0]}"}
+            try:
+                grade = grade_snapshot(root_id, snapshot)
+            except GradeError as error:
+                return {"error": str(error)}
+    except OSError as error:
+        return {"error": f"unable to grade: {error}"}
+    return {"grade": {"run": run, "root": root_id, **grade}}
+
+
+def _cmd_fixed_gate(rest):
+    """Probe a fixed result without issuing a checker packet.
+
+    ``None`` means the target is an ordinary lifecycle ticket and the
+    existing gate materializer should handle it.  An explicit fixed result
+    returns a closed route answer; stale covers ask the caller to issue one
+    fresh checker stage.
+    """
+
+    args = list(rest)
+    if len(args) != 2:
+        return None
+    run, target_id = args
+    if any(_segment_error(kind, value) is not None for kind, value in (("run id", run), ("ticket id", target_id))):
+        return None
+    tickets_root = _tickets_root()
+    if tickets_root is None:
+        return {"error": NO_SINK_ERROR}
+    run_dir = tickets_root / run
+    try:
+        with _run_lock(run):
+            snapshot, failures = run_snapshot(run_dir) if run_dir.is_dir() else ({}, [])
+            if failures:
+                return {"error": f"unreadable ticket: {failures[0][0]}"}
+            probe = fixed_gate_snapshot(target_id, snapshot)
+    except OSError as error:
+        return {"error": f"unable to gate: {error}"}
+    if probe is None:
+        return None
+    return {"gate": {"run": run, "root": target_id, "mode": "fixed", **probe}}
+
+
+def _cmd_gate(rest):
+    """Route fixed-result probes before the established gate materializer."""
+
+    fixed = _cmd_fixed_gate(rest)
+    if fixed is not None:
+        if "error" not in fixed and fixed.get("gate", {}).get("outcome") == "stale":
+            if __package__:
+                from .tickets_dispatch_gate import _cmd_checker_stage
+            else:
+                from tickets_dispatch_gate import _cmd_checker_stage
+            checker = _cmd_checker_stage(rest)
+            if "error" not in checker:
+                fixed["gate"]["checker_stage"] = checker.get("checker_stage")
+                fixed["gate"]["outcome"] = "checker-emitted"
+        return fixed
+    if __package__:
+        from .tickets_dispatch_gate import _cmd_gate as materialize_gate
+    else:
+        from tickets_dispatch_gate import _cmd_gate as materialize_gate
+    return materialize_gate(rest)
+
+
+__all__ = (
+    "GRADE_USAGE", "GradeError", "_cmd_fixed_gate", "_cmd_gate", "_cmd_grade", "fixed_gate_snapshot",
+    "grade_snapshot",
+)

--- a/scripts/tickets_review.py
+++ b/scripts/tickets_review.py
@@ -466,7 +466,10 @@ def repair_outcome(
     return _review_state([*records, record], allow_legacy=True)
 
 
-def verification_outcome(state: dict, artifact: str | None, verification: str, by: str) -> dict:
+def verification_outcome(
+    state: dict, artifact: str | None, verification: str, by: str,
+    *, covers=None,
+) -> dict:
     records = review_records(state, allow_legacy=True)
     if not records or records[-1]["kind"] != "RepairOutcome":
         raise ReviewError("verification requires a RepairOutcome predecessor")
@@ -478,13 +481,15 @@ def verification_outcome(state: dict, artifact: str | None, verification: str, b
         raise ReviewError(
             "verification evidence must begin PASS:, FAIL:, or UNVERIFIED:"
         )
-    record = _record(
-        "Verification", repaired["identity"],
-        artifact=repaired["artifact"],
-        by=by,
-        evidence=verification,
-        verdict=verdict,
-    )
+    fields = {
+        "artifact": repaired["artifact"],
+        "by": by,
+        "evidence": verification,
+        "verdict": verdict,
+    }
+    if covers is not None:
+        fields["covers"] = covers
+    record = _record("Verification", repaired["identity"], **fields)
     return _review_state([*records, record], allow_legacy=True)
 
 

--- a/scripts/tickets_review_schema.py
+++ b/scripts/tickets_review_schema.py
@@ -132,6 +132,11 @@ def _shape(record: dict, index: int, plan: dict | None, *, legacy: bool) -> None
         {"accepted", "artifact", "by", "input_artifact", "no_op", "result"}
         if kind == "RepairOutcome" else {"artifact", "by", "evidence", "verdict"}
     )
+    # ``covers`` is optional for legacy review ledgers.  New fixed-result
+    # ledgers may carry the closed identities from contracts/verdict.md;
+    # retaining the old shape keeps already-issued gate records replayable.
+    if kind == "Verification" and "covers" in record:
+        fields = fields | {"covers"}
     if set(record) != common | fields:
         raise SchemaError(f"review record {index} {kind} has unknown or missing fields")
     if kind == "RepairOutcome":
@@ -144,6 +149,18 @@ def _shape(record: dict, index: int, plan: dict | None, *, legacy: bool) -> None
         not nonempty(record[key]) for key in ("artifact", "by", "evidence")
     ):
         raise SchemaError("Verification has an invalid field type")
+    elif "covers" in record:
+        covers = record["covers"]
+        def valid_cover(value):
+            if isinstance(value, str):
+                return nonempty(value)
+            if isinstance(value, list):
+                return all(valid_cover(item) for item in value)
+            if isinstance(value, dict):
+                return all(nonempty(key) and valid_cover(item) for key, item in value.items())
+            return False
+        if not isinstance(covers, (dict, list)) or not covers or not valid_cover(covers):
+            raise SchemaError("Verification covers contains an empty identity")
 
 
 def validate_records(value, *, allow_legacy: bool = False) -> list:

--- a/tests/serial_compat_manifest.json
+++ b/tests/serial_compat_manifest.json
@@ -1,6 +1,6 @@
 {
  "discovery": {
-  "count": 2042,
+  "count": 2053,
   "identities": [
    "test_affected_tests.TestDiscoveryCache.test_a_new_commit_is_a_new_key_and_is_discovered_again",
    "test_affected_tests.TestDiscoveryCache.test_a_tree_that_cannot_answer_for_a_commit_falls_back_and_says_so",
@@ -744,6 +744,17 @@
    "test_tickets_bound.ParkPredicateTest.test_a_claim_with_no_readable_start_has_no_deadline_to_have_passed",
    "test_tickets_bound.ParkPredicateTest.test_motion_after_the_bound_elapsed_is_over_bound_and_not_parked",
    "test_tickets_bound.ParkPredicateTest.test_the_facade_exports_the_predicate_the_engine_rule_names",
+   "test_tickets_grade.FixedGateCommandTest.test_grade_command_reads_one_exact_run_snapshot",
+   "test_tickets_grade.FixedGateCommandTest.test_unchanged_fixed_result_does_not_emit_checker_and_changed_one_does",
+   "test_tickets_grade.GradeSnapshotTest.test_direct_and_loop_shapes_have_one_result_width",
+   "test_tickets_grade.GradeSnapshotTest.test_fixed_gate_invalidates_when_a_dependency_assignment_changes",
+   "test_tickets_grade.GradeSnapshotTest.test_fixed_gate_reuses_only_when_all_covers_match",
+   "test_tickets_grade.GradeSnapshotTest.test_graph_grade_counts_executor_members_and_reports_pack_fields",
+   "test_tickets_grade.GradeSnapshotTest.test_one_member_decomposition_is_refused",
+   "test_tickets_grade.GradeSnapshotTest.test_prose_covers_can_use_workspace_baseline_and_result_tip",
+   "test_tickets_grade.GradeSnapshotTest.test_prose_verification_covers_are_read_as_fixed_result_evidence",
+   "test_tickets_grade.GradeSnapshotTest.test_review_verification_accepts_optional_closed_covers",
+   "test_tickets_grade.GradeSnapshotTest.test_review_verification_rejects_empty_closed_covers",
    "test_trace.TestClaudeAdapter.test_clean_fixture_shape_and_fields",
    "test_trace.TestClaudeAdapter.test_cli_exits_zero_on_malformed_input",
    "test_trace.TestClaudeAdapter.test_malformed_fixture_yields_partial_trace",
@@ -2045,7 +2056,7 @@
    "tests.test_workspace_cases.start_cases.TestTheStampPreservesTheTicketsByteDomain.test_only_the_three_stamped_lines_differ_from_the_prior_bytes",
    "tests.test_workspace_cases.start_cases.TestTicketsPayloadIsGradedNotItsExitStatus.test_an_error_payload_returned_at_exit_zero_is_a_failure"
   ],
-  "sha256": "662e4d6a3039e16ac588e94d39c302784aedfcc74809ad0a4e5cab95f3c78984"
+  "sha256": "0bd13258babfae2faec2cb4ec48b1163ff69b8b4637c643d95dcdce579f11f8c"
  },
  "mutation_owners": [
   {
@@ -4316,6 +4327,15 @@
    "restoration": "sharded-module-guard",
    "seams": [
     "cwd"
+   ]
+  },
+  {
+   "module": "tests.test_tickets_grade",
+   "owner": "FixedGateCommandTest.setUp",
+   "restoration": "sharded-module-guard",
+   "seams": [
+    "environment",
+    "threads"
    ]
   },
   {

--- a/tests/test_tickets_grade.py
+++ b/tests/test_tickets_grade.py
@@ -1,0 +1,298 @@
+"""Deterministic routing grades for issued ticket graphs."""
+
+from __future__ import annotations
+
+import unittest
+import json
+import hashlib
+import os
+import tempfile
+from pathlib import Path
+from unittest import mock
+
+from scripts import tickets
+from scripts.tickets_issue_render import _render_ticket
+from scripts.tickets_format import _set_frontmatter_field
+from scripts.tickets_grade import fixed_gate_snapshot, grade_snapshot, GradeError
+from scripts import tickets_review
+
+
+def ticket(ticket_id: str, executor: str, *, goal: str = "Deliver the result.", context: str = "The repository is fixed.") -> str:
+    return "\n".join((
+        "---",
+        f"id: {ticket_id}",
+        f"executor: {executor}",
+        "pack: orch-code-pack",
+        "---",
+        "",
+        "## Goal",
+        goal,
+        "",
+        "## Context",
+        context,
+        "",
+    ))
+
+
+class GradeSnapshotTest(unittest.TestCase):
+    def test_graph_grade_counts_executor_members_and_reports_pack_fields(self):
+        snapshot = {
+            "R": ticket(
+                "R", "orch-decompose",
+                goal="Deliver an observable result for the target repository.",
+                context="The standards owner is documented by pointer.",
+            ),
+            "R.01": ticket("R.01", "orch-tdd"),
+            "R.02": ticket("R.02", "orch-tdd"),
+            "R.03": ticket("R.03", "orch-tdd"),
+            "R.04": ticket("R.04", "orch-tdd"),
+            "R.gate.critique.code": ticket("R.gate.critique.code", "orch-critique"),
+        }
+        self.assertEqual(
+            {
+                "width": 4,
+                "shape": "graph",
+                "unmentioned_spec_fields": [],
+                "deterministic_gate": True,
+                "over_decomposed": False,
+            },
+            grade_snapshot("R", snapshot),
+        )
+
+    def test_one_member_decomposition_is_refused(self):
+        snapshot = {
+            "R": ticket("R", "orch-decompose"),
+            "R.01": ticket("R.01", "orch-tdd"),
+        }
+        with self.assertRaisesRegex(GradeError, "over-decomposition"):
+            grade_snapshot("R", snapshot)
+
+    def test_direct_and_loop_shapes_have_one_result_width(self):
+        direct = {"R": ticket("R", "orch-tdd")}
+        loop = {"R": ticket("R", "orch-loop")}
+        self.assertEqual("single", grade_snapshot("R", direct)["shape"])
+        self.assertEqual(1, grade_snapshot("R", direct)["width"])
+        self.assertEqual("loop", grade_snapshot("R", loop)["shape"])
+        self.assertEqual(1, grade_snapshot("R", loop)["width"])
+
+    def test_fixed_gate_reuses_only_when_all_covers_match(self):
+        ledger = {"protocol": "orchflows.review.v1", "records": [{
+            "kind": "Verification",
+            "verdict": "PASS",
+            "covers": {
+                "base": "sha256:base",
+                "result": "sha256:result",
+                "dependencies": [],
+            },
+        }]}
+        snapshot = {
+            "R": {
+                "id": "R",
+                "assignment_seal": "sha256:base",
+                "result_identity": "sha256:result",
+                "depends_on": [],
+                "review_v1": json.dumps(ledger),
+            },
+        }
+        self.assertTrue(fixed_gate_snapshot("R", snapshot)["reusable"])
+        snapshot["R"]["assignment_seal"] = "sha256:changed"
+        self.assertFalse(fixed_gate_snapshot("R", snapshot)["reusable"])
+
+    def test_review_verification_accepts_optional_closed_covers(self):
+        plan = tickets_review._record(
+            "GatePlan", None, artifact="artifact", criteria=[{
+                "identity": "sha256:criterion", "lens": "code",
+                "order": 0, "ticket": "R.gate.critique.code",
+            }], isolation="none", mode="gate", pack="orch-code-pack",
+            root="R", workspace=str(Path.cwd()),
+        )
+        finding = {
+            "blocking": False, "class": "correctness", "evidence": ["e"],
+            "goal_impact": "none", "id": "B1", "repair": "none",
+            "summary": "none",
+        }
+        adjudication = tickets_review._record(
+            "CritiqueAdjudication", plan["identity"], accepted=[],
+            adjudicated_by="agent", artifact="artifact", findings=[finding],
+            lens="code",
+        )
+        repair = tickets_review._record(
+            "RepairOutcome", adjudication["identity"], accepted=[],
+            artifact="artifact", by="agent", input_artifact="artifact",
+            no_op=True, result="none",
+        )
+        verification = tickets_review._record(
+            "Verification", repair["identity"], artifact="artifact", by="agent",
+            evidence="PASS: unchanged", verdict="PASS",
+            covers={"base": "sha256:base", "dependencies": []},
+        )
+        state = tickets_review._review_state(
+            [plan, adjudication, repair, verification]
+        )
+        self.assertEqual(verification, state["records"][-1])
+
+    def test_review_verification_rejects_empty_closed_covers(self):
+        plan = tickets_review._record(
+            "GatePlan", None, artifact="artifact", criteria=[{
+                "identity": "sha256:criterion", "lens": "code",
+                "order": 0, "ticket": "R.gate.critique.code",
+            }], isolation="none", mode="gate", pack="orch-code-pack",
+            root="R", workspace=str(Path.cwd()),
+        )
+        finding = {
+            "blocking": False, "class": "correctness", "evidence": ["e"],
+            "goal_impact": "none", "id": "B1", "repair": "none",
+            "summary": "none",
+        }
+        adjudication = tickets_review._record(
+            "CritiqueAdjudication", plan["identity"], accepted=[],
+            adjudicated_by="agent", artifact="artifact", findings=[finding],
+            lens="code",
+        )
+        repair = tickets_review._record(
+            "RepairOutcome", adjudication["identity"], accepted=[],
+            artifact="artifact", by="agent", input_artifact="artifact",
+            no_op=True, result="none",
+        )
+        with self.assertRaises(tickets_review.ReviewError):
+            tickets_review._review_state([
+                plan, adjudication, repair,
+                tickets_review._record(
+                    "Verification", repair["identity"], artifact="artifact",
+                    by="agent", evidence="PASS: unchanged", verdict="PASS",
+                    covers={},
+                ),
+            ])
+
+    def test_prose_verification_covers_are_read_as_fixed_result_evidence(self):
+        text = "\n".join((
+            "---", "id: R", "assignment_seal: sha256:base",
+            "workspace_baseline: sha256:base", "---", "",
+            "## Goal", "Deliver the result.", "",
+            "## Context", "The repository is fixed.", "",
+            "## Result", "Fixed result identity: " + "a" * 40, "",
+            "## Verification",
+            "PASS: checks are green; covers: base sha256:base; result " + "a" * 40 + "; dependencies none",
+            "",
+        ))
+        result = fixed_gate_snapshot("R", {"R": text})
+        self.assertEqual("PASS", result["verdict"])
+        self.assertTrue(result["reusable"])
+
+    def test_prose_covers_can_use_workspace_baseline_and_result_tip(self):
+        base, result_identity = "b" * 7, "c" * 7
+        text = "\n".join((
+            "---", "id: R", f"workspace_baseline: {base} clean", "---", "",
+            "## Goal", "Deliver the result.", "",
+            "## Context", "The repository is fixed.", "",
+            "## Result", f"Tip of the worktree: {result_identity}", "",
+            "## Verification",
+            f"PASS: checks are green; covers: base `{base}`; result `{result_identity}`; no dependencies.",
+            "",
+        ))
+        result = fixed_gate_snapshot("R", {"R": text})
+        self.assertTrue(result["reusable"])
+
+    def test_fixed_gate_invalidates_when_a_dependency_assignment_changes(self):
+        snapshot = {
+            "R": {
+                "id": "R", "assignment_seal": "sha256:base",
+                "result_identity": "sha256:result", "depends_on": ["D"],
+                "review_v1": json.dumps({"records": [{
+                    "kind": "Verification", "verdict": "PASS", "covers": {
+                        "base": "sha256:base", "result": "sha256:result",
+                        "dependencies": ["sha256:dep"],
+                    },
+                }]}),
+            },
+            "D": {"id": "D", "assignment_seal": "sha256:dep"},
+        }
+        self.assertTrue(fixed_gate_snapshot("R", snapshot)["reusable"])
+        snapshot["D"]["assignment_seal"] = "sha256:changed"
+        self.assertFalse(fixed_gate_snapshot("R", snapshot)["reusable"])
+
+
+class FixedGateCommandTest(unittest.TestCase):
+    def setUp(self):
+        self.temporary = tempfile.TemporaryDirectory()
+        self.environment = mock.patch.dict(
+            os.environ, {"ORCHFLOWS_STATE_HOME": self.temporary.name}
+        )
+        self.environment.start()
+
+    def tearDown(self):
+        self.environment.stop()
+        self.temporary.cleanup()
+
+    def _write_target(self, assignment_seal: str):
+        result_identity = "sha256:" + hashlib.sha256(
+            "The fixed artifact.".encode("utf-8")
+        ).hexdigest()
+        ledger = {
+            "protocol": "orchflows.review.v1",
+            "records": [{
+                "kind": "Verification",
+                "verdict": "PASS",
+                "covers": {
+                    "base": assignment_seal,
+                    "result": result_identity,
+                    "dependencies": [],
+                },
+            }],
+        }
+        fields = {
+            "id": "R", "run": "run", "status": "complete",
+            "admission": "git:sha256:admission", "executor": "orch-tdd",
+            "pack": "orch-code-pack", "independence": "checker",
+            "isolation": "required", "depends_on": [], "bound": "30m",
+            "claimed_by": "", "claimed_at": "", "root_generation": "root:R",
+            "cut_generation": "cut:R", "assignment_seal": assignment_seal,
+        }
+        text = _render_ticket(fields, [
+            ("Goal", "Deliver the result."),
+            ("Context", "The repository is fixed."),
+            ("Result", "The fixed artifact."),
+            ("Verification", json.dumps(ledger, separators=(",", ":"))),
+            ("Feedback", "[]"), ("Risks", "[]"),
+        ])
+        run_dir = Path(self.temporary.name) / "tickets" / "run"
+        run_dir.mkdir(parents=True)
+        (run_dir / "R.md").write_text(text, encoding="utf-8")
+        return run_dir / "R.md"
+
+    def test_unchanged_fixed_result_does_not_emit_checker_and_changed_one_does(self):
+        path = self._write_target("sha256:base")
+        reused = tickets._dispatch(["gate", "run", "R"])
+        self.assertEqual("reused", reused["gate"]["outcome"])
+        self.assertFalse(path.with_name("R.check.md").exists())
+
+        path.write_text(
+            path.read_text(encoding="utf-8").replace(
+                "assignment_seal: sha256:base", "assignment_seal: sha256:changed"
+            ),
+            encoding="utf-8",
+        )
+        stale = tickets._dispatch(["gate", "run", "R"])
+        self.assertEqual("checker-emitted", stale["gate"]["outcome"])
+        self.assertTrue(path.with_name("R.check.md").exists())
+
+    def test_grade_command_reads_one_exact_run_snapshot(self):
+        run_dir = Path(self.temporary.name) / "tickets" / "run"
+        run_dir.mkdir(parents=True)
+        (run_dir / "R.md").write_text(ticket(
+            "R", "orch-decompose",
+            goal="Deliver an observable result for the target repository.",
+            context="The standards owner is documented by pointer.",
+        ), encoding="utf-8")
+        for item in ("R.01", "R.02"):
+            (run_dir / f"{item}.md").write_text(
+                ticket(item, "orch-tdd"), encoding="utf-8"
+            )
+        result = tickets._dispatch(["grade", "run", "R"])
+        self.assertNotIn("error", result, result)
+        self.assertEqual(2, result["grade"]["width"])
+        self.assertEqual("graph", result["grade"]["shape"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add deterministic issued-graph grading for width, shape, required fields, adapter gate capability, and over-decomposition
- add fixed-result gate reuse only when every covered identity remains unchanged
- fall back to the checker when a cover is stale, with no scripted Goal meaning or assurance judgment
- validate and persist review covers without a legacy route parser

## Verification
- uv run --no-project python tools/run_required.py --no-cache
- 2,053 tests passed; 14 skipped