### PR TITLE
Dogfood fix: establish and check read isolation through the one derivation

### DIFF
--- a/scripts/tickets.py
+++ b/scripts/tickets.py
@@ -143,6 +143,7 @@ Adapter = _tickets_adapters_module.Adapter
 AdapterError = _tickets_adapters_module.AdapterError
 adapter_id = _tickets_adapters_module.adapter_id
 adapter_spec = _tickets_adapters_module.adapter_spec
+derived_isolation = _tickets_adapters_module.derived_isolation
 binding_findings = _tickets_admission_module.binding_findings
 graph_findings = _tickets_admission_module.graph_findings
 grade_admission = _tickets_admission_module.grade_admission

--- a/scripts/workspace.py
+++ b/scripts/workspace.py
@@ -35,7 +35,8 @@ failure mode, and every ``tickets.py`` call it makes is graded by parsing
 the returned payload, never by exit status.
 
 Exit codes:
-    0  success, including ``isolation: none`` or absent
+    0  success, including ``isolation: none`` or an absent field whose
+       stamped pack's adapter does not establish isolation
     1  usage or internal error
     2  isolation-missing
     3  wrong-branch-point
@@ -312,7 +313,7 @@ def _cmd_check(rest):
     data = _graded(tickets._load_ticket(path), f"read {run}/{ticket_id}")
     reported = {"run": run, "id": ticket_id, "ticket": str(path)}
 
-    isolation = tickets.normalized_isolation(data.get(ISOLATION_KEY))
+    isolation = tickets.derived_isolation(data.get(ISOLATION_KEY), data.get("pack"))
     if isolation != REQUIRED:
         # read-only lanes and unisolated-by-design items never reach git
         reported.update({ISOLATION_KEY: isolation, "verdict": "not required"})

--- a/scripts/workspace_candidate.py
+++ b/scripts/workspace_candidate.py
@@ -333,7 +333,7 @@ def _establishment(run, ticket_id, key, held, seams, source, where):
             f"adapter-not-establishable: {adapter.key} does not establish a "
             "candidate workspace"
         )
-    isolation = tickets_store.normalized_isolation(data.get(ISOLATION_KEY))
+    isolation = tickets_adapters.derived_isolation(data.get(ISOLATION_KEY), data.get("pack"))
     if source is None or isolation != REQUIRED:
         body, code = _observed(run, ticket_id, path, data, prior_text, held, seams, where)
         return {key: body}, code

--- a/tests/serial_compat_manifest.json
+++ b/tests/serial_compat_manifest.json
@@ -1,6 +1,6 @@
 {
  "discovery": {
-  "count": 1968,
+  "count": 1970,
   "identities": [
    "test_affected_tests.TestDiscoveryCache.test_a_new_commit_is_a_new_key_and_is_discovered_again",
    "test_affected_tests.TestDiscoveryCache.test_a_tree_that_cannot_answer_for_a_commit_falls_back_and_says_so",
@@ -1861,6 +1861,7 @@
    "tests.test_workspace_cases.candidate_cases.TestEstablishCreatesTheDerivedCandidate.test_a_second_establishment_replays_without_moving_a_byte",
    "tests.test_workspace_cases.candidate_cases.TestEstablishCreatesTheDerivedCandidate.test_a_stamped_baseline_decides_the_revision_the_tree_is_cut_from",
    "tests.test_workspace_cases.candidate_cases.TestEstablishCreatesTheDerivedCandidate.test_an_item_that_declares_no_isolation_observes_the_source_tree",
+   "tests.test_workspace_cases.candidate_cases.TestEstablishCreatesTheDerivedCandidate.test_an_item_with_no_isolation_field_derives_the_git_adapters_default",
    "tests.test_workspace_cases.candidate_cases.TestEstablishCreatesTheDerivedCandidate.test_it_creates_the_derived_worktree_and_records_what_it_created",
    "tests.test_workspace_cases.candidate_cases.TestEstablishCreatesTheDerivedCandidate.test_the_tree_is_cut_before_the_run_lock_and_stamped_inside_it",
    "tests.test_workspace_cases.candidate_cases.TestEstablishCreatesTheDerivedCandidate.test_two_siblings_of_one_run_are_established_into_two_trees",
@@ -1903,6 +1904,7 @@
    "tests.test_workspace_cases.grade_cases.TestCheckGradesFromTheCallersGit.test_a_branch_already_on_the_callers_head_exits_isolation_missing",
    "tests.test_workspace_cases.grade_cases.TestCheckGradesFromTheCallersGit.test_a_branch_not_cut_from_the_base_exits_wrong_branch_point",
    "tests.test_workspace_cases.grade_cases.TestCheckGradesFromTheCallersGit.test_a_branch_that_does_not_resolve_exits_isolation_missing",
+   "tests.test_workspace_cases.grade_cases.TestCheckGradesFromTheCallersGit.test_an_absent_isolation_field_is_graded_as_required",
    "tests.test_workspace_cases.grade_cases.TestCheckGradesFromTheCallersGit.test_an_in_scope_branch_passes_and_reports_what_it_changed",
    "tests.test_workspace_cases.grade_cases.TestCheckGradesFromTheCallersGit.test_an_unresolvable_base_is_an_internal_error",
    "tests.test_workspace_cases.grade_cases.TestCheckGradesFromTheCallersGit.test_required_with_no_recorded_branch_exits_no_record",
@@ -1971,7 +1973,7 @@
    "tests.test_workspace_cases.start_cases.TestTheStampPreservesTheTicketsByteDomain.test_only_the_three_stamped_lines_differ_from_the_prior_bytes",
    "tests.test_workspace_cases.start_cases.TestTicketsPayloadIsGradedNotItsExitStatus.test_an_error_payload_returned_at_exit_zero_is_a_failure"
   ],
-  "sha256": "790f9d5fee86e19cb6bf3c217e0f10833541fa5e505bbcda3ba88f50de689c93"
+  "sha256": "1c9272e425421790ffd71a7e4345db4be86e8bccb8b1039c6d3c011fc2b30ae7"
  },
  "mutation_owners": [
   {

--- a/tests/test_workspace_cases/candidate_cases.py
+++ b/tests/test_workspace_cases/candidate_cases.py
@@ -225,6 +225,27 @@ class TestEstablishCreatesTheDerivedCandidate(unittest.TestCase):
             self.assertEqual(str(main.resolve()), body[workspace.PATH_KEY])
             self.assertFalse(derived["path"].exists())
 
+    def test_an_item_with_no_isolation_field_derives_the_git_adapters_default(self):
+        """Absent ``isolation`` is not ``none``: a git-adapter pack still
+        establishes a tree of the item's own (``contracts/work-item.md``,
+        ``scripts/tickets_adapters.derived_isolation``). Established through
+        the shared source tree instead is the defect this proves against."""
+
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp = Path(tmp)
+            main, run_dir = make_repo(tmp)
+            make_ticket(run_dir, "T1", isolation=None)
+            derived = state_root.candidate_paths("testrun", "T1")
+
+            done = self.establish(tmp, main)
+
+            self.assertEqual(0, done.returncode, done.stdout + done.stderr)
+            body = payload_of(done)["establish"]
+            self.assertEqual(str(derived["path"]), body[workspace.PATH_KEY])
+            self.assertEqual(derived["branch"], body[workspace.BRANCH_KEY])
+            self.assertTrue(body["isolated"])
+            self.assertNotEqual(str(main.resolve()), body[workspace.PATH_KEY])
+
     def test_the_tree_is_cut_before_the_run_lock_and_stamped_inside_it(self):
         """The lock protects the ticket's bytes, not git's seconds. Cutting
         the tree under it would make every sibling of a run wait through a

--- a/tests/test_workspace_cases/common.py
+++ b/tests/test_workspace_cases/common.py
@@ -87,13 +87,15 @@ def payload_of(completed) -> dict:
 
 def make_ticket(
     run_dir: Path, tid: str, *, scope=("scratch",), extra=(),
-    pack="orch-code-pack",
+    pack="orch-code-pack", isolation="required",
 ) -> Path:
     """A fixture work item, never this run's own ticket.
 
     The cutover made an isolated candidate the only lawful Git-adapter
     shape, so the item carries ``isolation: required`` unless a caller is
-    grading some other value through ``extra``.
+    grading some other value through ``extra`` or ``isolation``.
+    ``isolation=None`` omits the field entirely, for a fixture proving what
+    an absent declaration derives from the stamped pack.
     """
 
     lines = [
@@ -108,8 +110,8 @@ def make_ticket(
     ]
     lines += [f"  - {entry}" for entry in scope]
     lines += ["bound: 30m"]
-    if not any(key == "isolation" for key, _ in extra):
-        lines += ["isolation: required"]
+    if not any(key == "isolation" for key, _ in extra) and isolation is not None:
+        lines += [f"isolation: {isolation}"]
     lines += [f"{key}: {value}" for key, value in extra]
     if not any(key == "mutations" for key, _ in extra):
         plans = []
@@ -269,13 +271,16 @@ def tearDownModule():
 
 def graded_item(tid, *, branch="wt-branch", scope=("scratch",), isolation="required",
                 recorded=True, extra=()):
-    """A ticket of the shared repository, under this test's own id."""
+    """A ticket of the shared repository, under this test's own id.
+
+    ``isolation=None`` omits the field, for a fixture proving what an
+    absent declaration derives from the stamped pack.
+    """
 
     graded = graded_repository()
-    declared = ((workspace.ISOLATION_KEY, isolation),) if isolation else ()
     stamps = ((workspace.BRANCH_KEY, branch),) if recorded else ()
     make_ticket(
-        graded["run_dir"], tid, scope=scope,
-        extra=declared + stamps + tuple(extra),
+        graded["run_dir"], tid, scope=scope, isolation=isolation,
+        extra=stamps + tuple(extra),
     )
     return graded

--- a/tests/test_workspace_cases/grade_cases.py
+++ b/tests/test_workspace_cases/grade_cases.py
@@ -62,6 +62,20 @@ class TestCheckGradesFromTheCallersGit(unittest.TestCase):
         self.assertEqual(2, done.returncode, done.stdout)
         self.assertEqual("isolation-missing", payload_of(done)["verdict"])
 
+    def test_an_absent_isolation_field_is_graded_as_required(self):
+        """No declared ``isolation`` on a git-adapter pack still derives
+        ``required`` at the join: an absent field must not read as ``none``
+        and skip the grade at exit 0 with ``not required``
+        (``contracts/work-item.md``, ``scripts/tickets_adapters.derived_isolation``)."""
+
+        graded = graded_repository()
+        graded_item("T-absent-own", branch=graded["own"], isolation=None)
+        done = run_workspace(
+            graded["main"], "check", "testrun", "T-absent-own", "--base", graded["base"]
+        )
+        self.assertEqual(2, done.returncode, done.stdout)
+        self.assertEqual("isolation-missing", payload_of(done)["verdict"])
+
     def test_a_branch_already_on_the_callers_head_exits_isolation_missing(self):
         # stale-branch sits at the base the caller has since moved past
         graded = graded_item("T-stale", branch="stale-branch")


### PR DESCRIPTION
The first fully dogfooded fix on the minimal machinery, and the U4 regression the U6 proof exposed: `workspace_candidate.py establish` and `workspace.py check` still read the ticket's *declared* isolation field, which the ticket diet made absent-by-default — so a derived-required ticket (git-adapter pack, no declared field) was established straight into the shared source tree on its own branch, and the join-side check graded it "not required" at exit 0. Dogfood run `20260830T231500Z-u6-proof` ticket N1 reproduced it; the friction sink holds the entries.

Both sites now read `tickets_adapters.derived_isolation(declared, pack)` — the one derivation `contracts/work-item.md` names. Two tests fail on the prior tree and pass here (`candidate_cases.py`: an item with no isolation field derives the git adapter's default; `grade_cases.py`: an absent field grades as required). Serial manifest regenerated.

Provenance: run `20260830T234500Z-workspace-derivation`, single ticket W1 with an explicit `isolation: required` override (the workaround for the very bug it fixes), executed by a dispatched worker in a derived candidate worktree through the full dispatch → receive → outcome → join → retire protocol; candidate `55d12fc4`, integrated at `62355eb6`; required gate exit 0 at both the candidate and the integrated tip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)