### PR TITLE
Dogfood graph run: five friction fixes through the full frontier + gate

### DIFF
--- a/scripts/tickets_attempts.py
+++ b/scripts/tickets_attempts.py
@@ -150,7 +150,11 @@ def _cmd_dispatch_open(rest, *, _lock_held=False):
                     return _open_response(run, ticket_id, same, "replayed")
                 return _classification(
                     "idempotency-conflict",
-                    f"dispatch_id '{dispatch_id}' was already opened with different content",
+                    f"dispatch_id '{dispatch_id}' was already opened with different "
+                    "content; `tickets.py dispatch` retires a failed attempt "
+                    "automatically, so open a fresh --dispatch-id instead of "
+                    "reusing this one, or run `tickets.py dispatch-replace` to "
+                    "replace a still-live attempt explicitly",
                 )
             if seal_findings(ticket_id, text):
                 return _classification(
@@ -266,7 +270,10 @@ def _commit_record(
                 if prior.get("content") != normalized:
                     return _classification(
                         "idempotency-conflict",
-                        f"record_id '{record_id}' was already committed with different content",
+                        f"record_id '{record_id}' was already committed with "
+                        "different content; choose a different --record-id for "
+                        "new content, or match the original content exactly to "
+                        "replay it",
                     )
                 success = prior.get("success")
                 if not isinstance(success, dict):
@@ -436,7 +443,8 @@ def _cmd_dispatch_replace(rest):
         if any(item.get("dispatch_id") == replacement_id for item in state["attempts"]):
             return text, None, _classification(
                 "idempotency-conflict",
-                f"replacement dispatch_id '{replacement_id}' was already used",
+                f"replacement dispatch_id '{replacement_id}' was already used; "
+                "choose a different --replacement-dispatch-id",
             )
         now = datetime.now(timezone.utc)
         undeclared = dispatch_guards.undeclared_supersession_failure(

--- a/scripts/tickets_dispatch_inline.py
+++ b/scripts/tickets_dispatch_inline.py
@@ -48,17 +48,26 @@ def _inline_assignment_failure(packet: dict, assignment: dict):
     # that declares none -- while the projection carries the derived value
     # (the stamped pack's adapter decides), so both sides read through the
     # one derivation. What the seal hashes is untouched.
+    #
+    # Both derivations are rooted at the packet's established workspace,
+    # not the receiver's current directory: a project-scope pack the
+    # dispatcher could see from inside the workspace must resolve the same
+    # way for a receiver that has not yet stepped into it, and a receiver
+    # standing somewhere unrelated must not have that location decide
+    # which pack answers (contracts/dispatch.md).
+    workspace = packet.get("workspace")
+    pack_root = workspace if isinstance(workspace, str) and workspace.strip() else None
     expected = {
         "executor": executor,
         "independence": system.get("independence") or "checker",
-        "isolation": derived_isolation(system.get("isolation"), system.get("pack")),
+        "isolation": derived_isolation(system.get("isolation"), system.get("pack"), root=pack_root),
         "pack": system.get("pack"),
         "profile": assignment_profile,
         "review_kind": system.get("review_kind"),
         "role": role,
     }
     observed = {key: packet.get(key) for key in expected}
-    observed["isolation"] = derived_isolation(observed["isolation"], packet.get("pack"))
+    observed["isolation"] = derived_isolation(observed["isolation"], packet.get("pack"), root=pack_root)
     if observed != expected:
         return _classification(
             "assignment-divergent",

--- a/scripts/tickets_dispatch_receipt.py
+++ b/scripts/tickets_dispatch_receipt.py
@@ -54,17 +54,25 @@ def _workspace_failure(packet: dict):
     dispatcher.  The receiver must prove that fact from its own mechanism;
     accepting a second path argument here would let the receiver choose the
     authority it is supposed to authenticate.
+
+    The pack itself is resolved under that same established workspace, not
+    under the receiver's current directory: a project-scope pack the
+    dispatcher could see from inside the workspace must resolve the same
+    way for a receiver that has not yet stepped into it, and a receiver
+    standing somewhere unrelated must not have that location decide which
+    pack answers.
     """
 
+    expected = packet.get("workspace")
+    pack_root = expected if isinstance(expected, str) and expected.strip() else None
     try:
-        adapter = adapter_spec(packet.get("pack"))
+        adapter = adapter_spec(packet.get("pack"), root=pack_root)
     except AdapterError as error:
         return classification(
             "authority-mismatch",
             f"cannot derive workspace authority from packet adapter: {error.detail}",
         )
 
-    expected = packet.get("workspace")
     strategy = adapter.workspace_strategy
     if strategy == "git":
         if not isinstance(expected, str) or not expected.strip():

--- a/scripts/tickets_format.py
+++ b/scripts/tickets_format.py
@@ -109,6 +109,7 @@ ESCAPED_NEWLINE_RE = re.compile('\\\\n')
 # for. A real newline never matches this: it is one byte, not two.
 _PATH_RUN_RE = re.compile('(?:\\\\[^\\s\\\\]*)+')
 _DRIVE_LETTER_RE = re.compile('[A-Za-z]:')
+_INLINE_CODE_RE = re.compile('`[^`]*`')
 class DuplicateJsonKey(ValueError):
     """A canonical JSON object repeated one key."""
 def _json_object(pairs):
@@ -145,11 +146,22 @@ def _windows_path_spans(line: str) -> list:
         elif not rooted and len(segments) >= 2 and all(len(part) >= 2 for part in segments):
             spans.append(match.span())
     return spans
+def _inline_code_spans(line: str) -> list:
+    """Character spans in ``line`` between paired single backticks.
+
+    A fenced block already reads as code, never prose; this is the same
+    exemption for the inline case -- the repository's own idiom for naming
+    a newline in running text, as in `newline=` or "rstrip of a newline".
+    An unpaired backtick protects nothing: only a closed span counts.
+    """
+    return [match.span() for match in _INLINE_CODE_RE.finditer(line)]
 def _section_has_escaped_newline(body) -> bool:
     """Whether one section body carries a literal backslash-n outside code
     and outside a Windows path -- fenced lines are read as code, never
     prose, via the same ``_fence_run`` tracking `_scan_sections` uses to
-    find the next heading.
+    find the next heading. An inline single-backtick span is the same
+    exemption for one unfenced line, the idiom prose uses to name the
+    escape without writing it.
     """
     lines, fence = str(body or '').split('\n'), None
     for line in lines:
@@ -161,7 +173,7 @@ def _section_has_escaped_newline(body) -> bool:
         if run is not None:
             fence = run
             continue
-        protected = _windows_path_spans(line)
+        protected = _windows_path_spans(line) + _inline_code_spans(line)
         for match in ESCAPED_NEWLINE_RE.finditer(line):
             if not any(start <= match.start() < end for start, end in protected):
                 return True

--- a/scripts/tickets_format.py
+++ b/scripts/tickets_format.py
@@ -103,6 +103,12 @@ GATE_CRITIQUE_MARKER = '.gate.critique.'
 CHECKER_STAGE_SUFFIX = '.check'
 TEMPLATE_FILE = 'template.md'
 PLACEHOLDER_RE = re.compile('\\{\\{\\s*([^{}]*?)\\s*\\}\\}')
+ESCAPED_NEWLINE_RE = re.compile('\\\\n')
+# A literal backslash then the letter 'n' -- the two-character escape a
+# shell or a hand can type in place of the one byte it was meant to stand
+# for. A real newline never matches this: it is one byte, not two.
+_PATH_RUN_RE = re.compile('(?:\\\\[^\\s\\\\]*)+')
+_DRIVE_LETTER_RE = re.compile('[A-Za-z]:')
 class DuplicateJsonKey(ValueError):
     """A canonical JSON object repeated one key."""
 def _json_object(pairs):
@@ -119,9 +125,59 @@ def canonical_json(value) -> str:
 def parse_canonical_json(encoded: str):
     """Parse the portable canonical JSON grammar shared by ticket fields."""
     return json.loads(encoded, object_pairs_hook=_json_object, parse_constant=_nonfinite_json)
+def _windows_path_spans(line: str) -> list:
+    """Character spans in ``line`` that read as a Windows path, not prose.
+
+    A drive letter or a UNC's doubled backslash roots a path outright, so
+    even its first segment counts. Unrooted needs two real (2+ character)
+    segments, so a doubled escape (``\\n\\n``) is never misread as the
+    two one-letter segments of a path nothing names -- the exact shape a
+    collapsed multi-bullet ``--context`` value takes.
+    """
+    spans = []
+    for match in _PATH_RUN_RE.finditer(line):
+        run = match.group()
+        prefix = line[max(0, match.start() - 2):match.start()]
+        rooted = run.startswith('\\\\') or bool(_DRIVE_LETTER_RE.fullmatch(prefix))
+        segments = [part for part in run.split('\\') if part]
+        if rooted and segments:
+            spans.append(match.span())
+        elif not rooted and len(segments) >= 2 and all(len(part) >= 2 for part in segments):
+            spans.append(match.span())
+    return spans
+def _section_has_escaped_newline(body) -> bool:
+    """Whether one section body carries a literal backslash-n outside code
+    and outside a Windows path -- fenced lines are read as code, never
+    prose, via the same ``_fence_run`` tracking `_scan_sections` uses to
+    find the next heading.
+    """
+    lines, fence = str(body or '').split('\n'), None
+    for line in lines:
+        run = _fence_run(line)
+        if fence is not None:
+            if run is not None and run[0] == fence[0] and len(run) >= len(fence) and not line.strip()[len(run):].strip():
+                fence = None
+            continue
+        if run is not None:
+            fence = run
+            continue
+        protected = _windows_path_spans(line)
+        for match in ESCAPED_NEWLINE_RE.finditer(line):
+            if not any(start <= match.start() < end for start, end in protected):
+                return True
+    return False
 def format_policy_defects(text, data, sections):
-    del data, sections
-    return [f"frontmatter repeats '{key}'" for key in _duplicate_frontmatter_keys(text)]
+    del data
+    defects = [f"frontmatter repeats '{key}'" for key in _duplicate_frontmatter_keys(text)]
+    for key, body in sections.items():
+        if _section_has_escaped_newline(body):
+            name = CUT_SECTIONS_BY_KEY.get(key) or EXECUTOR_SECTIONS_BY_KEY.get(key) or key
+            defects.append(
+                f"'## {name}' carries a literal backslash-n: an escaped newline "
+                "that never reached stored bytes as one (write a real line "
+                "break, or fence the code that needs the literal)"
+            )
+    return defects
 def _read_utf8(path, subject: str='ticket', encoding: str='utf-8'):
     """One file's text as ``(text, None)``, or ``(None, {"error": ...})``.
     Both exceptions in one place because they are one failure to a caller --

--- a/scripts/tickets_outcome.py
+++ b/scripts/tickets_outcome.py
@@ -360,9 +360,12 @@ def _cmd_dispatch_outcome(rest, *, _lock_held=False):
                     f"{RESULT_ATTRIBUTION_PREFIX}`{content['by']}`\n\n{body}"
                 )
                 if prior == materialized or f"\n\n{materialized}" in prior:
+                    flag = OUTCOME_FILE_FLAGS[section]
                     return text, None, _classification(
                         "outcome-invalid",
-                        f"outcome {section} repeats evidence already materialized by this dispatch",
+                        f"outcome {section} repeats evidence already materialized "
+                        f"by this dispatch. Pass only the unstreamed delta through "
+                        f"`{flag}`",
                     )
                 updated = _write_section(
                     updated, section, materialized,

--- a/scripts/tickets_outcome.py
+++ b/scripts/tickets_outcome.py
@@ -359,7 +359,14 @@ def _cmd_dispatch_outcome(rest, *, _lock_held=False):
                 materialized = (
                     f"{RESULT_ATTRIBUTION_PREFIX}`{content['by']}`\n\n{body}"
                 )
-                if prior == materialized or f"\n\n{materialized}" in prior:
+                # The writer stores each block with trailing whitespace
+                # stripped, and a block with nothing before it in the
+                # section carries no leading blank line, so neither side of
+                # this comparison may depend on either: rstrip both before
+                # comparing, and test membership on its own, with no
+                # required prefix.
+                stripped = materialized.rstrip()
+                if stripped and (prior.rstrip() == stripped or stripped in prior):
                     flag = OUTCOME_FILE_FLAGS[section]
                     return text, None, _classification(
                         "outcome-invalid",

--- a/templates/host-block.md
+++ b/templates/host-block.md
@@ -13,7 +13,7 @@
   its executor chooses implementation and verification. **graph** — for one
   sealed, stamped root, run `tickets.py dispatch <run> <root> --by
   <assigned-name> --dispatch-id <dispatch-id> --lease-expires-at <absolute-iso>
-  --reply-to <parent-name> --host <host> [--workspace <tree>]` and invoke its
+  --reply-to <parent-name> [--host <host>] [--workspace <tree>]` and invoke its
   emitted `launch` verbatim; require the accepted
   `tickets.py dispatch-receive --file <path|->` receipt before exact
   `orch-decompose`. A ticket path is not the complete packet. Then

--- a/tests/serial_compat_manifest.json
+++ b/tests/serial_compat_manifest.json
@@ -1,6 +1,6 @@
 {
  "discovery": {
-  "count": 1970,
+  "count": 1973,
   "identities": [
    "test_affected_tests.TestDiscoveryCache.test_a_new_commit_is_a_new_key_and_is_discovered_again",
    "test_affected_tests.TestDiscoveryCache.test_a_tree_that_cannot_answer_for_a_commit_falls_back_and_says_so",
@@ -832,6 +832,9 @@
    "test_staleness_and_remedies.TestInlineIsolationIsReadTheOneWay.test_a_backticked_isolation_value_still_accepts",
    "test_staleness_and_remedies.TestInlineIsolationIsReadTheOneWay.test_a_real_divergence_is_still_refused",
    "test_staleness_and_remedies.TestInlineIsolationIsReadTheOneWay.test_an_absent_isolation_field_accepts_the_derived_packet",
+   "test_staleness_and_remedies.TestOutcomeNamesTheDeltaFlag.test_a_different_cause_is_not_told_that_remedy",
+   "test_staleness_and_remedies.TestOutcomeNamesTheDeltaFlag.test_a_repeated_section_names_its_flag",
+   "test_staleness_and_remedies.TestOutcomeNamesTheDeltaFlag.test_the_named_flag_is_the_one_that_works",
    "test_staleness_and_remedies.TestPendingNamesItsPromotion.test_a_stale_receipt_is_not_told_to_promote",
    "test_staleness_and_remedies.TestPendingNamesItsPromotion.test_the_named_promotion_is_the_one_that_works",
    "test_staleness_and_remedies.TestPendingNamesItsPromotion.test_the_refusal_names_the_promotion",
@@ -1973,7 +1976,7 @@
    "tests.test_workspace_cases.start_cases.TestTheStampPreservesTheTicketsByteDomain.test_only_the_three_stamped_lines_differ_from_the_prior_bytes",
    "tests.test_workspace_cases.start_cases.TestTicketsPayloadIsGradedNotItsExitStatus.test_an_error_payload_returned_at_exit_zero_is_a_failure"
   ],
-  "sha256": "1c9272e425421790ffd71a7e4345db4be86e8bccb8b1039c6d3c011fc2b30ae7"
+  "sha256": "d7daaa51f37729d3d8bbbff981895d023ab43adedebfc87273e9b5abc94e2720"
  },
  "mutation_owners": [
   {

--- a/tests/serial_compat_manifest.json
+++ b/tests/serial_compat_manifest.json
@@ -1,6 +1,6 @@
 {
  "discovery": {
-  "count": 1988,
+  "count": 1990,
   "identities": [
    "test_affected_tests.TestDiscoveryCache.test_a_new_commit_is_a_new_key_and_is_discovered_again",
    "test_affected_tests.TestDiscoveryCache.test_a_tree_that_cannot_answer_for_a_commit_falls_back_and_says_so",
@@ -379,6 +379,8 @@
    "test_installer.TestHostBlockDemands.test_host_block_demands_dropped_one_at_a_time_fail_the_check",
    "test_installer.TestHostBlockDemands.test_host_block_demands_fit_the_every_turn_budget",
    "test_installer.TestHostBlockDemands.test_host_block_demands_number_exactly_eight",
+   "test_installer.TestHostBlockDispatchFlags.test_dispatch_example_flag_pin_can_fail",
+   "test_installer.TestHostBlockDispatchFlags.test_dispatch_example_names_exactly_the_required_flags",
    "test_installer.TestHostBlockRendering.test_render_host_block_substitutes_resolved_interpreter",
    "test_installer.TestHostBlockRendering.test_rendered_block_contains_name_to_path_map",
    "test_installer.TestHostBlockRendering.test_rendered_block_states_one_routing_rule",
@@ -1991,7 +1993,7 @@
    "tests.test_workspace_cases.start_cases.TestTheStampPreservesTheTicketsByteDomain.test_only_the_three_stamped_lines_differ_from_the_prior_bytes",
    "tests.test_workspace_cases.start_cases.TestTicketsPayloadIsGradedNotItsExitStatus.test_an_error_payload_returned_at_exit_zero_is_a_failure"
   ],
-  "sha256": "8f4ec02b7db1e572950926e65a4bbb6e2f7024c4775a90277d7727cf4e9052d6"
+  "sha256": "9aaa92a28e3def32634adff782b46b41d0f7e8d15921dafa4370cd34f40f0df9"
  },
  "mutation_owners": [
   {

--- a/tests/serial_compat_manifest.json
+++ b/tests/serial_compat_manifest.json
@@ -1,6 +1,6 @@
 {
  "discovery": {
-  "count": 1970,
+  "count": 1971,
   "identities": [
    "test_affected_tests.TestDiscoveryCache.test_a_new_commit_is_a_new_key_and_is_discovered_again",
    "test_affected_tests.TestDiscoveryCache.test_a_tree_that_cannot_answer_for_a_commit_falls_back_and_says_so",
@@ -907,6 +907,7 @@
    "test_tickets.AdapterRegistryTest.test_admission_reports_exactly_adapter_unregistered_for_the_pack_key",
    "test_tickets.AdapterRegistryTest.test_an_unregistered_declared_key_fails_closed",
    "test_tickets.AdapterRegistryTest.test_consumers_branch_on_properties_not_the_adapter_key",
+   "test_tickets.AdapterRegistryTest.test_dispatch_receive_resolves_the_pack_under_the_packet_workspace",
    "test_tickets.AdapterRegistryTest.test_unknown_pack_cells_fail_through_the_shared_resolver_parser",
    "test_tickets.ResultAttributionTest.test_ambiguous_overwrite_lifecycle_and_forged_paths_are_refused",
    "test_tickets.ResultAttributionTest.test_each_append_records_and_returns_exactly_one_current_claim_writer",
@@ -1973,7 +1974,7 @@
    "tests.test_workspace_cases.start_cases.TestTheStampPreservesTheTicketsByteDomain.test_only_the_three_stamped_lines_differ_from_the_prior_bytes",
    "tests.test_workspace_cases.start_cases.TestTicketsPayloadIsGradedNotItsExitStatus.test_an_error_payload_returned_at_exit_zero_is_a_failure"
   ],
-  "sha256": "1c9272e425421790ffd71a7e4345db4be86e8bccb8b1039c6d3c011fc2b30ae7"
+  "sha256": "c54531b89e5d40ef03fa41f49bcdc398adcd3446c4e3fc9ae247fbe49b7d33d2"
  },
  "mutation_owners": [
   {

--- a/tests/serial_compat_manifest.json
+++ b/tests/serial_compat_manifest.json
@@ -1,6 +1,6 @@
 {
  "discovery": {
-  "count": 1976,
+  "count": 1983,
   "identities": [
    "test_affected_tests.TestDiscoveryCache.test_a_new_commit_is_a_new_key_and_is_discovered_again",
    "test_affected_tests.TestDiscoveryCache.test_a_tree_that_cannot_answer_for_a_commit_falls_back_and_says_so",
@@ -829,9 +829,15 @@
    "test_staleness_and_remedies.TestDependsOnIsCanonicallyOrdered.test_no_dependency_still_writes_the_empty_list",
    "test_staleness_and_remedies.TestDependsOnIsCanonicallyOrdered.test_the_authoring_flag_writes_them_sorted",
    "test_staleness_and_remedies.TestDependsOnIsCanonicallyOrdered.test_the_finding_names_the_order_it_wants",
+   "test_staleness_and_remedies.TestIdempotencyConflictsNameDistinctRemedies.test_a_recommitted_record_is_pointed_at_a_fresh_record_id",
+   "test_staleness_and_remedies.TestIdempotencyConflictsNameDistinctRemedies.test_a_reopened_dispatch_id_is_pointed_at_dispatch_and_replace",
+   "test_staleness_and_remedies.TestIdempotencyConflictsNameDistinctRemedies.test_a_reused_replacement_id_is_pointed_at_a_fresh_replacement_id",
    "test_staleness_and_remedies.TestInlineIsolationIsReadTheOneWay.test_a_backticked_isolation_value_still_accepts",
    "test_staleness_and_remedies.TestInlineIsolationIsReadTheOneWay.test_a_real_divergence_is_still_refused",
    "test_staleness_and_remedies.TestInlineIsolationIsReadTheOneWay.test_an_absent_isolation_field_accepts_the_derived_packet",
+   "test_staleness_and_remedies.TestOutcomeNamesTheDeltaFlag.test_a_different_cause_is_not_told_that_remedy",
+   "test_staleness_and_remedies.TestOutcomeNamesTheDeltaFlag.test_a_repeated_section_names_its_flag",
+   "test_staleness_and_remedies.TestOutcomeNamesTheDeltaFlag.test_the_named_flag_is_the_one_that_works",
    "test_staleness_and_remedies.TestPendingNamesItsPromotion.test_a_stale_receipt_is_not_told_to_promote",
    "test_staleness_and_remedies.TestPendingNamesItsPromotion.test_the_named_promotion_is_the_one_that_works",
    "test_staleness_and_remedies.TestPendingNamesItsPromotion.test_the_refusal_names_the_promotion",
@@ -907,6 +913,7 @@
    "test_tickets.AdapterRegistryTest.test_admission_reports_exactly_adapter_unregistered_for_the_pack_key",
    "test_tickets.AdapterRegistryTest.test_an_unregistered_declared_key_fails_closed",
    "test_tickets.AdapterRegistryTest.test_consumers_branch_on_properties_not_the_adapter_key",
+   "test_tickets.AdapterRegistryTest.test_dispatch_receive_resolves_the_pack_under_the_packet_workspace",
    "test_tickets.AdapterRegistryTest.test_unknown_pack_cells_fail_through_the_shared_resolver_parser",
    "test_tickets.ResultAttributionTest.test_ambiguous_overwrite_lifecycle_and_forged_paths_are_refused",
    "test_tickets.ResultAttributionTest.test_each_append_records_and_returns_exactly_one_current_claim_writer",
@@ -1979,7 +1986,7 @@
    "tests.test_workspace_cases.start_cases.TestTheStampPreservesTheTicketsByteDomain.test_only_the_three_stamped_lines_differ_from_the_prior_bytes",
    "tests.test_workspace_cases.start_cases.TestTicketsPayloadIsGradedNotItsExitStatus.test_an_error_payload_returned_at_exit_zero_is_a_failure"
   ],
-  "sha256": "9911d0ca62faa5374d3b72fb3fb7cd24be1c56feb55e316cedd7f1aa0250c160"
+  "sha256": "ca52bde836a393f3448a0988e98953d83df9673367b7ce0cbbf99fa0ac90a00b"
  },
  "mutation_owners": [
   {
@@ -2670,6 +2677,14 @@
    "restoration": "sharded-module-guard",
    "seams": [
     "monkeypatch"
+   ]
+  },
+  {
+   "module": "tests.test_installer_cases.managed_text.host_block",
+   "owner": "_flags_by_bracket_depth",
+   "restoration": "sharded-module-guard",
+   "seams": [
+    "threads"
    ]
   },
   {

--- a/tests/serial_compat_manifest.json
+++ b/tests/serial_compat_manifest.json
@@ -1,6 +1,6 @@
 {
  "discovery": {
-  "count": 1983,
+  "count": 1988,
   "identities": [
    "test_affected_tests.TestDiscoveryCache.test_a_new_commit_is_a_new_key_and_is_discovered_again",
    "test_affected_tests.TestDiscoveryCache.test_a_tree_that_cannot_answer_for_a_commit_falls_back_and_says_so",
@@ -833,10 +833,13 @@
    "test_staleness_and_remedies.TestIdempotencyConflictsNameDistinctRemedies.test_a_reopened_dispatch_id_is_pointed_at_dispatch_and_replace",
    "test_staleness_and_remedies.TestIdempotencyConflictsNameDistinctRemedies.test_a_reused_replacement_id_is_pointed_at_a_fresh_replacement_id",
    "test_staleness_and_remedies.TestInlineIsolationIsReadTheOneWay.test_a_backticked_isolation_value_still_accepts",
+   "test_staleness_and_remedies.TestInlineIsolationIsReadTheOneWay.test_a_project_scope_pack_resolves_under_the_packet_workspace_not_cwd",
    "test_staleness_and_remedies.TestInlineIsolationIsReadTheOneWay.test_a_real_divergence_is_still_refused",
    "test_staleness_and_remedies.TestInlineIsolationIsReadTheOneWay.test_an_absent_isolation_field_accepts_the_derived_packet",
    "test_staleness_and_remedies.TestOutcomeNamesTheDeltaFlag.test_a_different_cause_is_not_told_that_remedy",
+   "test_staleness_and_remedies.TestOutcomeNamesTheDeltaFlag.test_a_first_block_repeat_still_refuses",
    "test_staleness_and_remedies.TestOutcomeNamesTheDeltaFlag.test_a_repeated_section_names_its_flag",
+   "test_staleness_and_remedies.TestOutcomeNamesTheDeltaFlag.test_a_trailing_newline_in_the_filed_body_still_refuses",
    "test_staleness_and_remedies.TestOutcomeNamesTheDeltaFlag.test_the_named_flag_is_the_one_that_works",
    "test_staleness_and_remedies.TestPendingNamesItsPromotion.test_a_stale_receipt_is_not_told_to_promote",
    "test_staleness_and_remedies.TestPendingNamesItsPromotion.test_the_named_promotion_is_the_one_that_works",
@@ -1538,8 +1541,10 @@
    "tests.test_tickets_cases.escaped_newline.EscapedNewlineShapeTest.test_new_accepts_a_real_multiline_context",
    "tests.test_tickets_cases.escaped_newline.EscapedNewlineShapeTest.test_new_accepts_a_windows_path_segment_beginning_with_n",
    "tests.test_tickets_cases.escaped_newline.EscapedNewlineShapeTest.test_new_accepts_the_escape_inside_a_fenced_code_block",
+   "tests.test_tickets_cases.escaped_newline.EscapedNewlineShapeTest.test_new_accepts_the_escape_inside_an_inline_code_span",
    "tests.test_tickets_cases.escaped_newline.EscapedNewlineShapeTest.test_new_refusal_and_lint_finding_share_one_message",
    "tests.test_tickets_cases.escaped_newline.EscapedNewlineShapeTest.test_new_refuses_the_exact_collapsed_bullet_shape",
+   "tests.test_tickets_cases.escaped_newline.EscapedNewlineShapeTest.test_new_still_refuses_the_collapsed_shape_beside_an_inline_span",
    "tests.test_tickets_cases.family_fixture.TestTheTicketFamilyIsDiscoveredNotListed.test_a_module_added_beside_the_facade_joins_the_family",
    "tests.test_tickets_cases.family_fixture.TestTheTicketFamilyIsDiscoveredNotListed.test_the_facade_is_not_one_of_its_own_support_modules",
    "tests.test_tickets_cases.family_fixture.TestTheTicketFamilyIsDiscoveredNotListed.test_the_support_names_are_the_sorted_siblings_of_the_facade",
@@ -1986,7 +1991,7 @@
    "tests.test_workspace_cases.start_cases.TestTheStampPreservesTheTicketsByteDomain.test_only_the_three_stamped_lines_differ_from_the_prior_bytes",
    "tests.test_workspace_cases.start_cases.TestTicketsPayloadIsGradedNotItsExitStatus.test_an_error_payload_returned_at_exit_zero_is_a_failure"
   ],
-  "sha256": "ca52bde836a393f3448a0988e98953d83df9673367b7ce0cbbf99fa0ac90a00b"
+  "sha256": "8f4ec02b7db1e572950926e65a4bbb6e2f7024c4775a90277d7727cf4e9052d6"
  },
  "mutation_owners": [
   {

--- a/tests/serial_compat_manifest.json
+++ b/tests/serial_compat_manifest.json
@@ -2667,6 +2667,14 @@
    ]
   },
   {
+   "module": "tests.test_installer_cases.managed_text.host_block",
+   "owner": "_flags_by_bracket_depth",
+   "restoration": "sharded-module-guard",
+   "seams": [
+    "threads"
+   ]
+  },
+  {
    "module": "tests.test_installer_cases.planning.host_detection",
    "owner": "DryRunOracleTest._dry_run",
    "restoration": "sharded-module-guard",

--- a/tests/serial_compat_manifest.json
+++ b/tests/serial_compat_manifest.json
@@ -1,6 +1,6 @@
 {
  "discovery": {
-  "count": 1970,
+  "count": 1973,
   "identities": [
    "test_affected_tests.TestDiscoveryCache.test_a_new_commit_is_a_new_key_and_is_discovered_again",
    "test_affected_tests.TestDiscoveryCache.test_a_tree_that_cannot_answer_for_a_commit_falls_back_and_says_so",
@@ -829,6 +829,9 @@
    "test_staleness_and_remedies.TestDependsOnIsCanonicallyOrdered.test_no_dependency_still_writes_the_empty_list",
    "test_staleness_and_remedies.TestDependsOnIsCanonicallyOrdered.test_the_authoring_flag_writes_them_sorted",
    "test_staleness_and_remedies.TestDependsOnIsCanonicallyOrdered.test_the_finding_names_the_order_it_wants",
+   "test_staleness_and_remedies.TestIdempotencyConflictsNameDistinctRemedies.test_a_recommitted_record_is_pointed_at_a_fresh_record_id",
+   "test_staleness_and_remedies.TestIdempotencyConflictsNameDistinctRemedies.test_a_reopened_dispatch_id_is_pointed_at_dispatch_and_replace",
+   "test_staleness_and_remedies.TestIdempotencyConflictsNameDistinctRemedies.test_a_reused_replacement_id_is_pointed_at_a_fresh_replacement_id",
    "test_staleness_and_remedies.TestInlineIsolationIsReadTheOneWay.test_a_backticked_isolation_value_still_accepts",
    "test_staleness_and_remedies.TestInlineIsolationIsReadTheOneWay.test_a_real_divergence_is_still_refused",
    "test_staleness_and_remedies.TestInlineIsolationIsReadTheOneWay.test_an_absent_isolation_field_accepts_the_derived_packet",
@@ -1973,7 +1976,7 @@
    "tests.test_workspace_cases.start_cases.TestTheStampPreservesTheTicketsByteDomain.test_only_the_three_stamped_lines_differ_from_the_prior_bytes",
    "tests.test_workspace_cases.start_cases.TestTicketsPayloadIsGradedNotItsExitStatus.test_an_error_payload_returned_at_exit_zero_is_a_failure"
   ],
-  "sha256": "1c9272e425421790ffd71a7e4345db4be86e8bccb8b1039c6d3c011fc2b30ae7"
+  "sha256": "203df4a8de2dbe7cd5c6c2a3d927d74c12c117be6196960db5b435a88740725f"
  },
  "mutation_owners": [
   {

--- a/tests/serial_compat_manifest.json
+++ b/tests/serial_compat_manifest.json
@@ -1,6 +1,6 @@
 {
  "discovery": {
-  "count": 1970,
+  "count": 1976,
   "identities": [
    "test_affected_tests.TestDiscoveryCache.test_a_new_commit_is_a_new_key_and_is_discovered_again",
    "test_affected_tests.TestDiscoveryCache.test_a_tree_that_cannot_answer_for_a_commit_falls_back_and_says_so",
@@ -1527,6 +1527,12 @@
    "tests.test_tickets_cases.cli_help.HelpTest.test_help_never_touches_the_repository",
    "tests.test_tickets_cases.cli_help.HelpTest.test_the_subcommand_list_is_not_empty_and_excludes_help_flags",
    "tests.test_tickets_cases.cli_help.HelpTest.test_the_usage_table_covers_exactly_the_dispatched_subcommands",
+   "tests.test_tickets_cases.escaped_newline.EscapedNewlineShapeTest.test_lint_reports_the_same_defect_on_an_issued_ticket",
+   "tests.test_tickets_cases.escaped_newline.EscapedNewlineShapeTest.test_new_accepts_a_real_multiline_context",
+   "tests.test_tickets_cases.escaped_newline.EscapedNewlineShapeTest.test_new_accepts_a_windows_path_segment_beginning_with_n",
+   "tests.test_tickets_cases.escaped_newline.EscapedNewlineShapeTest.test_new_accepts_the_escape_inside_a_fenced_code_block",
+   "tests.test_tickets_cases.escaped_newline.EscapedNewlineShapeTest.test_new_refusal_and_lint_finding_share_one_message",
+   "tests.test_tickets_cases.escaped_newline.EscapedNewlineShapeTest.test_new_refuses_the_exact_collapsed_bullet_shape",
    "tests.test_tickets_cases.family_fixture.TestTheTicketFamilyIsDiscoveredNotListed.test_a_module_added_beside_the_facade_joins_the_family",
    "tests.test_tickets_cases.family_fixture.TestTheTicketFamilyIsDiscoveredNotListed.test_the_facade_is_not_one_of_its_own_support_modules",
    "tests.test_tickets_cases.family_fixture.TestTheTicketFamilyIsDiscoveredNotListed.test_the_support_names_are_the_sorted_siblings_of_the_facade",
@@ -1973,7 +1979,7 @@
    "tests.test_workspace_cases.start_cases.TestTheStampPreservesTheTicketsByteDomain.test_only_the_three_stamped_lines_differ_from_the_prior_bytes",
    "tests.test_workspace_cases.start_cases.TestTicketsPayloadIsGradedNotItsExitStatus.test_an_error_payload_returned_at_exit_zero_is_a_failure"
   ],
-  "sha256": "1c9272e425421790ffd71a7e4345db4be86e8bccb8b1039c6d3c011fc2b30ae7"
+  "sha256": "9911d0ca62faa5374d3b72fb3fb7cd24be1c56feb55e316cedd7f1aa0250c160"
  },
  "mutation_owners": [
   {

--- a/tests/test_installer_cases/managed_text/host_block.py
+++ b/tests/test_installer_cases/managed_text/host_block.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from ..support import *  # noqa: F403
+from scripts.tickets_commands import DISPATCH_USAGE
 
 
 class TestHostBlockRendering(unittest.TestCase):
@@ -275,3 +276,89 @@ class TestHostBlockDemands(unittest.TestCase):
                             _demand_gaps(cut),
                             f"{name}: dropping {anchor!r} left the check green",
                         )
+
+
+# The route demand above pins that `tickets.py dispatch <run> <root>` is
+# named at all, and stops at the command's positional arguments -- the flag
+# list past them is unpinned on both sides: a routed example can omit a flag
+# the command actually requires, or hold one out as required that the
+# command treats as optional, and neither text carries the other's proof.
+# (state sink friction/2026-08.jsonl, 2026-08-30T20:37:01Z: `tickets.py
+# dispatch` refused the block's own graph-route invocation with a usage
+# error.) This binds both sides to one reader instead: `DISPATCH_USAGE`
+# (scripts/tickets_commands.py) is the command's own required-flag
+# authority, and the block's routed example is read the same way it is
+# written, by bracket depth -- `[...]` is optional, bare is required.
+_FLAG_RE = re.compile(r"--[a-z][a-z-]*")
+_GRAPH_EXAMPLE_RE = re.compile(r"`(tickets\.py dispatch <run> <root>[^`]*)`")
+
+
+def _flags_by_bracket_depth(text: str) -> tuple:
+    """(required, optional) flag sets in `text`, split by bracket nesting.
+
+    A flag named outside every `[...]` is required; nested inside one it is
+    optional. Depth is counted from the unmatched brackets before each
+    match rather than tracked in one pass, because the strings this reads
+    are a single short line -- never worth a second traversal to save.
+    """
+    required, optional = set(), set()
+    for match in _FLAG_RE.finditer(text):
+        prefix = text[: match.start()]
+        depth = prefix.count("[") - prefix.count("]")
+        (required if depth == 0 else optional).add(match.group(0))
+    return frozenset(required), frozenset(optional)
+
+
+def _graph_dispatch_example() -> str:
+    """The routed `tickets.py dispatch <run> <root> ...` command, verbatim,
+    off the collapsed (unrendered) template -- `{{...}}` placeholders never
+    appear in this command, so rendering is not needed to read it."""
+    match = _GRAPH_EXAMPLE_RE.search(_collapsed_block())
+    return match.group(1) if match else ""
+
+
+class TestHostBlockDispatchFlags(unittest.TestCase):
+    """The graph-route dispatch example and `tickets.py dispatch`'s own
+    required flags cannot diverge unobserved."""
+
+    def test_dispatch_example_names_exactly_the_required_flags(self):
+        example = _graph_dispatch_example()
+        self.assertTrue(
+            example, "no `tickets.py dispatch <run> <root>` example found"
+        )
+        example_required, _ = _flags_by_bracket_depth(example)
+        usage_required, _ = _flags_by_bracket_depth(DISPATCH_USAGE)
+        self.assertEqual(
+            usage_required,
+            example_required,
+            "templates/host-block.md's routed dispatch example names "
+            f"{sorted(example_required)} as required; `tickets.py dispatch` "
+            f"actually requires {sorted(usage_required)}",
+        )
+
+    def test_dispatch_example_flag_pin_can_fail(self):
+        """Can-fail evidence (rules/verification.md §8), taken on copies
+        beside the tree and never by mutating it under test: an example that
+        drops a required flag, a command that grows one the example never
+        names, and an example that holds an optional flag out as required
+        (the exact shape of the friction this closes, before `--host` was
+        bracketed) each leave the check above red.
+        """
+        example = _graph_dispatch_example()
+        usage_required, _ = _flags_by_bracket_depth(DISPATCH_USAGE)
+        example_required, _ = _flags_by_bracket_depth(example)
+        self.assertEqual(usage_required, example_required)  # green on arrival
+
+        omitted = example.replace("--reply-to <parent-name>", "")
+        omitted_required, _ = _flags_by_bracket_depth(omitted)
+        self.assertNotEqual(usage_required, omitted_required)
+
+        grown_usage = DISPATCH_USAGE.replace(
+            "--reply-to <name> ", "--reply-to <name> --new-required <x> "
+        )
+        grown_required, _ = _flags_by_bracket_depth(grown_usage)
+        self.assertNotEqual(grown_required, example_required)
+
+        overclaimed = example.replace("[--host <host>]", "--host <host>")
+        overclaimed_required, _ = _flags_by_bracket_depth(overclaimed)
+        self.assertNotEqual(usage_required, overclaimed_required)

--- a/tests/test_installer_managed.py
+++ b/tests/test_installer_managed.py
@@ -8,6 +8,7 @@ if _facade is None:
 from tests.test_installer_cases.application.partial_apply import TestPartialApplyAfterRmtree
 from tests.test_installer_cases.managed_text.host_block import (
     TestHostBlockDemands,
+    TestHostBlockDispatchFlags,
     TestHostBlockRendering,
 )
 from tests.test_installer_cases.managed_text.markers import (
@@ -20,6 +21,7 @@ from tests.test_installer_cases.managed_text.roles import TestRoleAgentInstructi
 
 TestPartialApplyAfterRmtree.__module__ = _facade.__name__
 TestHostBlockDemands.__module__ = _facade.__name__
+TestHostBlockDispatchFlags.__module__ = _facade.__name__
 TestHostBlockRendering.__module__ = _facade.__name__
 TestConservativeBlockRemoval.__module__ = _facade.__name__
 TestHostConfigLimitRemoval.__module__ = _facade.__name__

--- a/tests/test_staleness_and_remedies.py
+++ b/tests/test_staleness_and_remedies.py
@@ -710,6 +710,47 @@ class TestOutcomeNamesTheDeltaFlag(SealedRunTest):
         committed = self.close(result="closing result delta")
         self.assertNotIn("error", committed)
 
+    def stream_second_result(self, body):
+        return self.dispatch(
+            "result", "run", "T",
+            "--assignment-seal", self.frontmatter("T")["assignment_seal"],
+            "--dispatch-id", "D1", "--record-id", "result-2", "--by", "worker",
+            "--section", "Result", "--text", body, "--append",
+        )
+
+    def test_a_trailing_newline_in_the_filed_body_still_refuses(self):
+        """Miss case A: a filed body that ends with a newline byte-matches
+        an already-streamed block only after both sides are rstripped, so
+        neither the exact-equality nor the substring reading fires.
+
+        Regression for state sink run 20260831T001500Z-friction-fixes,
+        ticket R1.02: a repeated block that is not the section's first
+        (so the substring reading's blank-line prefix is present) still
+        slipped past the guard once the closing file's content carried a
+        trailing newline the streamed copy had stripped on write.
+        """
+
+        self.accept()
+        self.stream_result(body="first")
+        self.assertNotIn("error", self.stream_second_result("second"))
+        refused = self.close(result="second\n")
+        self.assertEqual("outcome-invalid", refused["code"])
+        self.assertIn("--result-file", refused["error"])
+
+    def test_a_first_block_repeat_still_refuses(self):
+        """Miss case B: a repeated block that is the section's first has
+        nothing before it, so the substring reading's required leading
+        blank line can never match -- independent of any newline mismatch,
+        since this filed body reproduces the stored block byte for byte.
+        """
+
+        self.accept()
+        self.stream_result(body="first")
+        self.assertNotIn("error", self.stream_second_result("second"))
+        refused = self.close(result="first")
+        self.assertEqual("outcome-invalid", refused["code"])
+        self.assertIn("--result-file", refused["error"])
+
 
 class TestInlineIsolationIsReadTheOneWay(unittest.TestCase):
     """The seal stores the rare declared override verbatim and the packet
@@ -765,6 +806,43 @@ class TestInlineIsolationIsReadTheOneWay(unittest.TestCase):
         packet = self.sealed(self.packet(isolation="none"), assignment)
         failure = _inline_assignment_failure(packet, assignment)
         self.assertEqual("assignment-divergent", failure["code"])
+
+    def test_a_project_scope_pack_resolves_under_the_packet_workspace_not_cwd(self):
+        """The inline form's isolation derivation must not read the
+        receiver's cwd either -- the second of the two pack readers on the
+        dispatch-receive path (`tests.test_tickets.AdapterRegistryTest`
+        covers the reference form's `_workspace_failure`).
+
+        Regression for state sink friction/2026-08.jsonl: a pack
+        project-scoped only inside the packet's own committed workspace
+        must resolve the same way for a receiver standing anywhere else.
+        Measured proof: a pack declaring adapter `document-tree` resolves
+        isolation `none` when rooted at the packet workspace; rooted at an
+        unrelated cwd it cannot resolve at all and fails closed to
+        `required`, so the two legs of this comparison diverge unless both
+        are rooted at the packet's `workspace`.
+        """
+        with tempfile.TemporaryDirectory() as raw:
+            workspace = Path(raw) / "workspace"
+            pack = workspace / "packs" / "widget-pack"
+            pack.mkdir(parents=True)
+            (pack / "SKILL.md").write_text(
+                "---\nname: widget-pack\ndescription: Synthetic project pack.\n---\n\n"
+                "| cell | binding |\n| --- | --- |\n"
+                "| adapter | document-tree |\n",
+                encoding="utf-8",
+            )
+            elsewhere = Path(raw) / "elsewhere-receiver"
+            elsewhere.mkdir()
+
+            assignment = self.assignment(pack="widget-pack")
+            packet = self.sealed(
+                self.packet(pack="widget-pack", isolation="none", workspace=str(workspace)),
+                assignment,
+            )
+            with mock.patch("scripts.tickets_adapters.Path.cwd", return_value=elsewhere):
+                failure = _inline_assignment_failure(packet, assignment)
+            self.assertIsNone(failure)
 
 
 class TestIdempotencyConflictsNameDistinctRemedies(SealedRunTest):

--- a/tests/test_staleness_and_remedies.py
+++ b/tests/test_staleness_and_remedies.py
@@ -654,6 +654,63 @@ class TestTheJoinsTerminalWriteIsInsideTheLock(SealedRunTest):
         self.assertEqual("T", identity["terminal_ticket_id"])
 
 
+class TestOutcomeNamesTheDeltaFlag(SealedRunTest):
+    """A closing section that repeats evidence a streamed result record
+    already materialized used to say only that it repeated -- not which flag
+    carries the unstreamed delta instead, so the caller had to guess one."""
+
+    def accept(self):
+        packet = self.project()["packet"]
+        path = self.home / "packet.json"
+        path.write_text(canonical_json(packet), encoding="utf-8")
+        with standing_in(self.candidate):
+            return self.dispatch(*receive_argv(path, packet, "worker"))
+
+    def stream_result(self, body="delivered"):
+        path = self.home / "streamed.md"
+        path.write_text(body, encoding="utf-8")
+        return self.dispatch(
+            "result", "run", "T",
+            "--assignment-seal", self.frontmatter("T")["assignment_seal"],
+            "--dispatch-id", "D1", "--record-id", "result-1", "--by", "worker",
+            "--section", "Result", "--file", str(path),
+        )
+
+    def evidence_file(self, name, body):
+        path = self.home / f"outcome-{name}.txt"
+        path.write_text(body, encoding="utf-8")
+        return str(path)
+
+    def close(self, *, result="delivered", verification="verified"):
+        return tickets._dispatch([
+            "dispatch-outcome", "run", "T", "--status", "complete",
+            "--result-file", self.evidence_file("result", result),
+            "--verification-file", self.evidence_file("verification", verification),
+        ])
+
+    def test_a_repeated_section_names_its_flag(self):
+        self.accept()
+        self.stream_result()
+        refused = self.close(result="delivered")
+        self.assertEqual("outcome-invalid", refused["code"])
+        self.assertIn("--result-file", refused["error"])
+
+    def test_a_different_cause_is_not_told_that_remedy(self):
+        """Empty Result evidence refuses `outcome-invalid` for being
+        incomplete, a cause the repeated-section flag has no bearing on."""
+
+        self.accept()
+        refused = self.close(result="")
+        self.assertEqual("outcome-invalid", refused["code"])
+        self.assertNotIn("--result-file", refused["error"])
+
+    def test_the_named_flag_is_the_one_that_works(self):
+        self.accept()
+        self.stream_result()
+        committed = self.close(result="closing result delta")
+        self.assertNotIn("error", committed)
+
+
 class TestInlineIsolationIsReadTheOneWay(unittest.TestCase):
     """The seal stores the rare declared override verbatim and the packet
     carries the derived value, so both sides read through the one

--- a/tests/test_staleness_and_remedies.py
+++ b/tests/test_staleness_and_remedies.py
@@ -710,5 +710,66 @@ class TestInlineIsolationIsReadTheOneWay(unittest.TestCase):
         self.assertEqual("assignment-divergent", failure["code"])
 
 
+class TestIdempotencyConflictsNameDistinctRemedies(SealedRunTest):
+    """Three refusals share one code, `idempotency-conflict`, and until now
+    one message: a reopened dispatch id, a recommitted record, and a reused
+    replacement id were all silent on the fix, or -- worse -- pointed a
+    driver at attempt surgery (`dispatch-retire`) that a different cause's
+    refusal does not accept.
+    """
+
+    def replace(self, dispatch_id, replacement_id, record_id):
+        return tickets._dispatch([
+            "dispatch-replace", "run", "T",
+            "--assignment-seal", self.frontmatter("T")["assignment_seal"],
+            "--dispatch-id", dispatch_id, "--record-id", record_id,
+            "--replacement-dispatch-id", replacement_id,
+            "--by", "worker", "--lease-expires-at", self.lease,
+            "--supersede-live",
+        ])
+
+    def test_a_reopened_dispatch_id_is_pointed_at_dispatch_and_replace(self):
+        changed = self.refuse(
+            "dispatch-open", "run", "T", "--by", "worker",
+            "--dispatch-id", "D1", "--lease-expires-at", "2099-01-01T00:00:00Z",
+        )
+        self.assertEqual("idempotency-conflict", changed["code"])
+        self.assertIn("`tickets.py dispatch`", changed["error"])
+        self.assertIn("`tickets.py dispatch-replace`", changed["error"])
+        self.assertNotIn("--record-id", changed["error"])
+        self.assertNotIn("--replacement-dispatch-id", changed["error"])
+
+    def test_a_recommitted_record_is_pointed_at_a_fresh_record_id(self):
+        self.assertNotIn("error", self.dispatch(
+            "dispatch-commit", "run", "T", "--dispatch-id", "D1",
+            "--record-id", "R1", "--content", '{"value":1}',
+        ))
+        conflict = self.refuse(
+            "dispatch-commit", "run", "T", "--dispatch-id", "D1",
+            "--record-id", "R1", "--content", '{"value":2}',
+        )
+        self.assertEqual("idempotency-conflict", conflict["code"])
+        self.assertIn("--record-id", conflict["error"])
+        self.assertNotIn("dispatch-replace", conflict["error"])
+        self.assertNotIn("--replacement-dispatch-id", conflict["error"])
+
+    def test_a_reused_replacement_id_is_pointed_at_a_fresh_replacement_id(self):
+        self.assertNotIn(
+            "error", self.replace("D1", "D2", "lifecycle:replace-1")
+        )
+        conflict = self.refuse(
+            "dispatch-replace", "run", "T",
+            "--assignment-seal", self.frontmatter("T")["assignment_seal"],
+            "--dispatch-id", "D2", "--record-id", "lifecycle:replace-2",
+            "--replacement-dispatch-id", "D1",
+            "--by", "worker", "--lease-expires-at", self.lease,
+            "--supersede-live",
+        )
+        self.assertEqual("idempotency-conflict", conflict["code"])
+        self.assertIn("--replacement-dispatch-id", conflict["error"])
+        self.assertNotIn("--record-id", conflict["error"])
+        self.assertNotIn("fresh --dispatch-id", conflict["error"])
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_thin_orchestrator.py
+++ b/tests/test_thin_orchestrator.py
@@ -121,7 +121,7 @@ class ThinOrchestratorContractTests(unittest.TestCase):
             "stamped root",
             "tickets.py dispatch <run> <root> --by <assigned-name> "
             "--dispatch-id <dispatch-id> --lease-expires-at <absolute-iso> "
-            "--reply-to <parent-name> --host <host> [--workspace <tree>]",
+            "--reply-to <parent-name> [--host <host>] [--workspace <tree>]",
             "tickets.py dispatch-receive",
             "accepted",
             "exact `orch-decompose`",

--- a/tests/test_tickets.py
+++ b/tests/test_tickets.py
@@ -42,6 +42,7 @@ from tests.test_tickets_cases.run_state_terminal import (  # noqa: F401
 )
 
 import scripts.tickets as tickets_mod
+import scripts.tickets_dispatch_receipt as tickets_dispatch_receipt
 import scripts.tickets_packet as tickets_packet
 import scripts.tickets_review as tickets_review
 
@@ -143,6 +144,39 @@ class AdapterRegistryTest(unittest.TestCase):
                         "widget-pack", "not-a-git-identity", str(root),
                     )
             self.assertIn("git:<full-commit-id>", str(caught.exception))
+
+    def test_dispatch_receive_resolves_the_pack_under_the_packet_workspace(self):
+        """A receiver's cwd never decides which pack answers a packet.
+
+        Regression for state sink friction/2026-08.jsonl, entry ts
+        2026-08-30T20:48:12Z: `dispatch-receive` refused `authority-mismatch
+        (pack does not resolve: field-notes-pack)` for a project-scope pack
+        that lived only inside the packet's own committed workspace, solely
+        because the receiving process happened to be standing elsewhere.
+        Pack resolution must walk from the packet's `workspace`, not from
+        `Path.cwd()`.
+        """
+        with tempfile.TemporaryDirectory() as raw:
+            workspace = Path(raw) / "workspace"
+            workspace.mkdir()
+            self._pack(workspace, "evidence-store")
+            elsewhere = Path(raw) / "elsewhere-receiver"
+            elsewhere.mkdir()
+
+            packet = {"pack": "widget-pack", "workspace": str(workspace)}
+            with mock.patch("scripts.tickets_adapters.Path.cwd", return_value=elsewhere):
+                accepted = tickets_dispatch_receipt._workspace_failure(packet)
+            self.assertIsNone(accepted)
+
+            # A pack that resolves in neither the established workspace nor
+            # installed/canonical scope still refuses closed, regardless of
+            # where the receiver stands.
+            bare = Path(raw) / "workspace-without-the-pack"
+            bare.mkdir()
+            unresolved = {"pack": "widget-pack", "workspace": str(bare)}
+            with mock.patch("scripts.tickets_adapters.Path.cwd", return_value=elsewhere):
+                refused = tickets_dispatch_receipt._workspace_failure(unresolved)
+            self.assertEqual("authority-mismatch", refused["code"])
 
 
 def _result_ticket(tmp: Path, *, status="claimed", claimed_by="agent-a"):

--- a/tests/test_tickets.py
+++ b/tests/test_tickets.py
@@ -10,6 +10,9 @@ from tests._receiver_vantage import git_checkout, receive_argv, standing_in
 from tests.test_ticket_semantic_contract import SemanticTicketContractTest
 from tests.test_tickets_cases.common import run_cmd, use_sink
 from tests.test_tickets_cases.cli_help import HelpTest  # noqa: F401
+from tests.test_tickets_cases.escaped_newline import (  # noqa: F401
+    EscapedNewlineShapeTest,
+)
 from tests.test_tickets_cases.family_fixture import (  # noqa: F401
     TestTheTicketFamilyIsDiscoveredNotListed,
 )

--- a/tests/test_tickets_cases/escaped_newline.py
+++ b/tests/test_tickets_cases/escaped_newline.py
@@ -1,0 +1,134 @@
+"""A literal backslash-n in a semantic section: one owner, two doors.
+
+friction/2026-08.jsonl, 2026-08-30T21:02:18Z: `tickets.py new --context`
+accepted a shell string carrying an escaped newline and collapsed three
+intake bullets onto one stored line; lint and admission both passed it, and
+only a checker reading stored bytes saw the collapse. `format_policy_defects`
+is the one shape-defect owner both `new` (refusal) and `lint` (finding)
+already read through `ticket_defects` -> `_issue_defects`, so a fix there
+reaches both doors without a second reader.
+"""
+
+import unittest
+
+from .common import *  # noqa: F401,F403
+
+
+class EscapedNewlineShapeTest(unittest.TestCase):
+    def setUp(self):
+        self.temporary = tempfile.TemporaryDirectory()
+        self.sink = use_sink(Path(self.temporary.name))
+
+    def tearDown(self):
+        self.temporary.cleanup()
+
+    def dispatch(self, *arguments):
+        return tickets_mod._dispatch(list(arguments))
+
+    def test_new_refuses_the_exact_collapsed_bullet_shape(self):
+        """The friction repro, verbatim: three bullets joined by `\\n`."""
+        refused = self.dispatch(
+            "new", "testrun", "T1", "--executor", "orch-execute",
+            "--goal", "Deliver the artifact.",
+            "--context", "- one\\n- two\\n- three",
+            "--pack", "orch-code-pack", "--isolation", "required",
+        )
+        self.assertIn("error", refused)
+        self.assertIn("backslash-n", refused["error"])
+        self.assertIn("Context", refused["error"])
+        self.assertFalse((self.sink / "tickets" / "testrun" / "T1.md").exists())
+
+    def test_new_accepts_a_real_multiline_context(self):
+        """An actual line break is invisible to the check -- it is one byte,
+        not the two-character escape."""
+        accepted = self.dispatch(
+            "new", "testrun", "T2", "--executor", "orch-execute",
+            "--goal", "Deliver the artifact.",
+            "--context", "line one\nline two\nline three",
+            "--pack", "orch-code-pack", "--isolation", "required",
+        )
+        self.assertNotIn("error", accepted)
+
+    def test_new_accepts_a_windows_path_segment_beginning_with_n(self):
+        """A rooted Windows path is read as the path it is, not the escape."""
+        accepted = self.dispatch(
+            "new", "testrun", "T3", "--executor", "orch-execute",
+            "--goal", "Deliver the artifact.",
+            "--context",
+            "Evidence: C:\\Users\\danhm\\.orchflows\\state\\notes\\thing.md.",
+            "--pack", "orch-code-pack", "--isolation", "required",
+        )
+        self.assertNotIn("error", accepted)
+
+    def test_new_accepts_the_escape_inside_a_fenced_code_block(self):
+        """A fenced code block is read as code, not prose."""
+        fenced_goal = (
+            "Deliver the parser.\n\n```\nassert body.split('\\n') == parts\n```"
+        )
+        accepted = self.dispatch(
+            "new", "testrun", "T4", "--executor", "orch-execute",
+            "--goal", fenced_goal, "--context", "[]",
+            "--pack", "orch-code-pack", "--isolation", "required",
+        )
+        self.assertNotIn("error", accepted)
+
+    def test_lint_reports_the_same_defect_on_an_issued_ticket(self):
+        """The corruption the friction entry describes: a checker reading
+        stored bytes, after the shell has already done the collapsing --
+        here simulated by a direct write past the CLI, since a fixed `new`
+        can no longer produce this ticket itself."""
+        accepted = self.dispatch(
+            "new", "testrun", "T5", "--executor", "orch-execute",
+            "--goal", "Deliver the artifact.", "--context", "[]",
+            "--pack", "orch-code-pack", "--isolation", "required",
+        )
+        self.assertNotIn("error", accepted)
+        path = Path(accepted["new"]["path"])
+        corrupted = path.read_text(encoding="utf-8").replace(
+            "## Result\n", "## Result\n\nfirst\\nsecond\n", 1,
+        )
+        path.write_text(corrupted, encoding="utf-8")
+
+        linted = self.dispatch("lint", "testrun", "T5")
+        messages = [item["message"] for item in linted["lint"]["findings"]]
+        self.assertTrue(
+            any("backslash-n" in message and "Result" in message for message in messages),
+            messages,
+        )
+        self.assertEqual(1, linted["exit_code"])
+
+    def test_new_refusal_and_lint_finding_share_one_message(self):
+        """One shape-defect owner: `new`'s refusal and `lint`'s finding on
+        the same broken text read identically, because both call
+        `ticket_defects` through `_issue_defects`."""
+        from scripts.tickets_format import ticket_defects
+        from scripts.tickets_issue_render import _render_ticket
+
+        fields = {
+            "id": "T6", "run": "testrun", "status": "pending",
+            "admission": "pending", "executor": "orch-execute",
+            "pack": "orch-code-pack", "independence": "gate",
+            "depends_on": [], "isolation": "required", "bound": "30m",
+        }
+        sections = [
+            ("Goal", "Deliver the artifact."),
+            ("Context", "note one\\nnote two"),
+            ("Result", ""), ("Verification", ""),
+            ("Feedback", "[]"), ("Risks", "[]"),
+        ]
+        text = _render_ticket(fields, sections)
+        defects = ticket_defects(text)
+        matches = [d for d in defects if "backslash-n" in d]
+        self.assertEqual(1, len(matches), defects)
+
+        refused = self.dispatch(
+            "new", "testrun", "T7", "--executor", "orch-execute",
+            "--goal", "Deliver the artifact.",
+            "--context", "note one\\nnote two",
+            "--pack", "orch-code-pack", "--isolation", "required",
+        )
+        self.assertIn(matches[0], refused["error"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_tickets_cases/escaped_newline.py
+++ b/tests/test_tickets_cases/escaped_newline.py
@@ -72,6 +72,39 @@ class EscapedNewlineShapeTest(unittest.TestCase):
         )
         self.assertNotIn("error", accepted)
 
+    def test_new_accepts_the_escape_inside_an_inline_code_span(self):
+        """The repository's own idiom for naming a newline in prose -- a
+        backticked fragment such as `newline=` or "rstrip of a newline" --
+        is not the collapsed-bullet defect. Only fenced code was exempt
+        before; this is the same exemption for one unfenced line.
+
+        Regression for state sink run 20260831T001500Z-friction-fixes,
+        finding F3: measured on the live state sink, 41 of 67 tickets the
+        prior discriminator newly flagged were flagged only because they
+        named the escape inside an inline backtick span like this one.
+        """
+        accepted = self.dispatch(
+            "new", "testrun", "T4b", "--executor", "orch-execute",
+            "--goal", "Deliver the artifact.",
+            "--context", "Pass `newline=\\n` to open() and rstrip a newline.",
+            "--pack", "orch-code-pack", "--isolation", "required",
+        )
+        self.assertNotIn("error", accepted)
+
+    def test_new_still_refuses_the_collapsed_shape_beside_an_inline_span(self):
+        """The inline-code exemption protects only its own span: a real
+        collapsed bullet elsewhere on the same line still refuses, so the
+        exemption cannot be used to smuggle the defect past the check."""
+        refused = self.dispatch(
+            "new", "testrun", "T4c", "--executor", "orch-execute",
+            "--goal", "Deliver the artifact.",
+            "--context", "See `newline=\\n` for context. - one\\n- two\\n- three",
+            "--pack", "orch-code-pack", "--isolation", "required",
+        )
+        self.assertIn("error", refused)
+        self.assertIn("backslash-n", refused["error"])
+        self.assertIn("Context", refused["error"])
+
     def test_lint_reports_the_same_defect_on_an_issued_ticket(self):
         """The corruption the friction entry describes: a checker reading
         stored bytes, after the shell has already done the collapsing --


### PR DESCRIPTION
The first decomposed graph run on the minimal machinery — the U3-acceptance evidence run. Root R1 (run 20260831T001500Z-friction-fixes) was cut by a dispatched decomposer into five independent members, all five ran in parallel derived worktrees, landed complete, and crossed the composite gate: code-lens critique (7 findings, 3 blocking accepted), repair (integration + the three blockers, each proven red-then-green), fresh verify (FAIL — caught the pin class imported by no shard; two-line remedy applied join-side per user direction to close the loop).

Fixes: dispatch-receive and the inline leg resolve packs from the packet's workspace, never receiver cwd; the host block's dispatch example is pinned to the command's required flag set (and its --host overclaim fixed); the outcome-collision and idempotency-conflict refusals name their remedies; escaped newlines in semantic sections refuse at new/lint with fenced-code, inline-code, and Windows-path exemptions; closing-delta guard catches trailing-newline and first-block repeats.

Every launch traced to script output; zero engine dispatches. Friction ledger grew by the verify-close law collision and the missing round-two materializer — successor material.

🤖 Generated with [Claude Code](https://claude.com/claude-code)