### PR TITLE
Condition-wait the candidate cut instead of sleeping a fixed window

### DIFF
--- a/tests/test_workspace_cases/candidate_cases.py
+++ b/tests/test_workspace_cases/candidate_cases.py
@@ -15,7 +15,11 @@ from scripts import (  # noqa: F401
     state_root, tickets_dispatch_facade, tickets_store, workspace_candidate,
 )
 
-# long enough that a child which was going to stamp would have stamped
+# a loaded host stretches `git worktree add` past any fixed window, so the
+# cut is waited for by condition under this deadline, never by a sleep
+CUT_DEADLINE = 120.0
+# counted from the observed cut: long enough that a child which was going
+# to stamp without the lock would have stamped
 LOCK_WAIT = 2.0
 
 
@@ -265,9 +269,13 @@ class TestEstablishCreatesTheDerivedCandidate(unittest.TestCase):
                     stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True,
                     encoding="utf-8", errors="replace", cwd=str(tmp), env=git_env(),
                 )
+                deadline = time.monotonic() + CUT_DEADLINE
+                while (not derived["path"].is_dir() and child.poll() is None
+                       and time.monotonic() < deadline):
+                    time.sleep(0.05)
+                cut = derived["path"].is_dir()
                 time.sleep(LOCK_WAIT)
                 early = child.poll()
-                cut = derived["path"].is_dir()
                 stamped = workspace.PATH_KEY in ticket.read_text(encoding="utf-8")
             out, err = child.communicate(timeout=120)
 


### PR DESCRIPTION
## Summary
- `test_the_tree_is_cut_before_the_run_lock_and_stamped_inside_it` flaked under parallel suite load (module 444s at -j6 vs ~128s solo; four sightings across the 2026-08-30/31 gate runs): it slept a fixed `LOCK_WAIT = 2.0` and then asserted the derived tree was already cut, so a loaded host stretching `git worktree add` past the window failed the test.
- The cut (a presence check) is now polled by condition under a generous 120s deadline, breaking early if the child exits; host contention can no longer fail it.
- The fixed 2.0s window survives only as the grace counted from the observed cut, where it guards absence — a child that was going to stamp without the lock would have stamped by then — so a slow host can only weaken detection, never produce a spurious failure.
- Ordering semantics are intact and still asserted while the lock is held: the tree is cut before the run lock, the stamp lands only inside it, and the child stays blocked until release.

## Verification
- `uv run --no-project python tools/run_required.py --no-cache` — all five checks green: 81 modules, 1990 tests, 0 failures (tests.test_workspace 123 tests passed at ~90s under full 24-worker load).

🤖 Generated with [Claude Code](https://claude.com/claude-code)