### PR TITLE
Admit a loop's rounds through the stub the seal did name

### DIFF
--- a/scripts/tickets_admission.py
+++ b/scripts/tickets_admission.py
@@ -12,8 +12,8 @@ if __package__:
     from .tickets_format import (
         DELIVERED_STATE, RESULT_BEARING_STATES, ROOT_EXECUTOR,
         SCRIPT_EXECUTOR_PREFIX, adapter_id, canonical_json, dequote,
-        is_review_stage_id, _executor_of, _parse_frontmatter,
-        _set_frontmatter_field,
+        is_loop_stub, is_review_stage_id, round_parent, _executor_of,
+        _parse_frontmatter, _set_frontmatter_field,
     )
 else:
     from tickets_registry import EXECUTOR_REGISTRY, executor_refusal, executor_registered
@@ -21,8 +21,8 @@ else:
     from tickets_format import (
         DELIVERED_STATE, RESULT_BEARING_STATES, ROOT_EXECUTOR,
         SCRIPT_EXECUTOR_PREFIX, adapter_id, canonical_json, dequote,
-        is_review_stage_id, _executor_of, _parse_frontmatter,
-        _set_frontmatter_field,
+        is_loop_stub, is_review_stage_id, round_parent, _executor_of,
+        _parse_frontmatter, _set_frontmatter_field,
     )
 
 ADMISSION_PENDING = "pending"
@@ -138,6 +138,29 @@ def graph_descendants(ticket_id: str, siblings) -> list:
     ]
 
 
+def loop_round_stub(ticket_id: str, siblings) -> str | None:
+    """The live loop stub whose own machinery minted this id, or ``None``.
+
+    `loop-arm` writes `<stub>.iter.NN` from the stub's frozen goal, and the
+    `check` done form mints `<stub>.iter.NN.done` beside a round to judge it.
+    Both appear only after the cut that sealed the stub, so neither is ever a
+    member of the sealed assignment set and neither is a member the stub was
+    decomposed into -- the two readings that refused the whole loop lane the
+    first time it was driven through the dispatch trunk.
+
+    `tickets_format.round_parent` owns the grammar; what is added here is the
+    marker, because the same grammar spells a landing's `<id>.repair.NN`
+    rounds and those descend from an ordinary ticket, not from a loop.
+    """
+    stub_id = round_parent(ticket_id)
+    if stub_id is None:
+        return None
+    text = dict(siblings or {}).get(stub_id)
+    if text is None or not is_loop_stub(_parse_frontmatter(text)):
+        return None
+    return stub_id
+
+
 def graph_closed(ticket_id: str, siblings, *evidence) -> bool:
     """Whether a decomposed root yet owes ``graph_findings`` a member count.
 
@@ -159,9 +182,18 @@ def graph_findings(ticket_id: str, data: dict, siblings: dict, *, complete=False
     authority with a caller, so it is refused at every admission door.  The
     member-count checks are deferred until a generation is being validated:
     the first root ticket is necessarily issued before its members exist.
+
+    A loop stub's own rounds are dropped before the count: an armed
+    `<stub>.iter.NN` is an id-descendant of its stub by construction, and
+    reading it as a member would refuse every armed loop stub for owning the
+    iterations the loop marker is the licence to arm.  An author-written
+    child of a loop stub matches no round grammar and is still refused.
     """
     executor = _executor_of(data)
-    descendants = graph_descendants(ticket_id, siblings)
+    descendants = [
+        identifier for identifier in graph_descendants(ticket_id, siblings)
+        if loop_round_stub(identifier, siblings) is None
+    ]
     findings = []
     if executor == ROOT_EXECUTOR:
         if dequote(data.get("independence")) == "checker":
@@ -222,6 +254,32 @@ def _ordinary_review_target(ticket_id: str, data: dict, dependencies, siblings):
     else:
         from tickets_ordinary_review import ordinary_stage_text
     return target_id, ordinary_stage_text(run, target_id, target, kind)
+
+
+def sealed_loop_target(ticket_id, text, data, siblings, digest):
+    """The loop stub one lawful post-seal round binds its admission through.
+
+    The sealed cut names the assignments that existed when it was sealed, and
+    a round exists only afterwards, so a round can never be named there.  What
+    the seal did name is the stub, and a round is lawful exactly when it
+    descends from that stub unaltered: the stub's own `root_generation` and
+    `cut_generation`, and a self-seal that still matches the round's current
+    bytes.  A round whose bytes moved after it was armed fails that last
+    reading and falls through to the sealed-set door, which has never named it
+    and refuses it.
+    """
+    stub_id = loop_round_stub(ticket_id, siblings)
+    if stub_id is None:
+        return None
+    stub = _parse_frontmatter(siblings[stub_id])
+    if any(
+        str(data.get(field) or "") != str(stub.get(field) or "")
+        for field in ("cut_generation", "root_generation")
+    ):
+        return None
+    if str(data.get("assignment_seal") or "") != digest(ticket_id, text):
+        return None
+    return stub_id
 
 
 def grade_admission(ticket_id: str, text: str, siblings: dict, context=None) -> dict:
@@ -287,6 +345,9 @@ def grade_admission(ticket_id: str, text: str, siblings: dict, context=None) -> 
             review_target = _ordinary_review_target(
                 ticket_id, data, dependencies, siblings,
             )
+            loop_stub = sealed_loop_target(
+                ticket_id, text, data, siblings, assignment_digest,
+            )
             if review_target is not None:
                 target_id, expected_stage = review_target
                 target_text = siblings.get(target_id)
@@ -313,6 +374,13 @@ def grade_admission(ticket_id: str, text: str, siblings: dict, context=None) -> 
                         "ordinary-review-stage-mismatch", "assignment_seal",
                         "ordinary repair or verification assignment differs from "
                         "the canonical checked-target continuation",
+                    ))
+            elif loop_stub is not None:
+                stub = _parse_frontmatter(siblings[loop_stub])
+                if sealed_assignments.get(loop_stub) != stub.get("assignment_seal"):
+                    findings.append(finding(
+                        "sealed-loop-stub-mismatch", "assignment_seal",
+                        "sealed state does not bind the loop stub this round was armed from",
                     ))
             elif sealed_assignments.get(ticket_id) != data.get("assignment_seal"):
                 findings.append(finding("sealed-assignment-mismatch", "assignment_seal", "sealed state does not bind this assignment"))
@@ -387,6 +455,6 @@ def refresh_admissions(run, run_dir, snapshot: dict, write_atomically) -> list:
 __all__ = (
     "ADMISSION_PENDING", "RESULT_BEARING_STATES", "adapter_id",
     "binding_findings", "dependency_order_findings", "finding",
-    "graph_findings", "grade_admission", "is_receipt", "pinned_digest_finding",
-    "refresh_admissions",
+    "graph_findings", "grade_admission", "is_receipt", "loop_round_stub",
+    "pinned_digest_finding", "refresh_admissions", "sealed_loop_target",
 )

--- a/scripts/tickets_done.py
+++ b/scripts/tickets_done.py
@@ -28,23 +28,25 @@ import subprocess
 if __package__:
     from .tickets_admission import ADMISSION_PENDING
     from .tickets_format import (
-        DELIVERED_STATE, REPORT_SECTION, _sections, _set_frontmatter_field,
+        DELIVERED_STATE, DONE_TICKET_SUFFIX, REPAIR_MARKER, REPORT_SECTION,
+        _sections, _set_frontmatter_field,
         _write_section, dequote, done_defects, parse_done,
     )
     from .tickets_generations import assignment_digest
     from .tickets_issue_render import _render_ticket
-    from .tickets_loop import REPAIR_MARKER, advance_action, check_reading
+    from .tickets_loop import advance_action, check_reading
     from .tickets_result import RESULT_ATTRIBUTION_PREFIX
     from .tickets_store import _create_text_exclusively, _write_text_atomically
 else:  # pragma: no cover - direct/installed flat script path
     from tickets_admission import ADMISSION_PENDING
     from tickets_format import (
-        DELIVERED_STATE, REPORT_SECTION, _sections, _set_frontmatter_field,
+        DELIVERED_STATE, DONE_TICKET_SUFFIX, REPAIR_MARKER, REPORT_SECTION,
+        _sections, _set_frontmatter_field,
         _write_section, dequote, done_defects, parse_done,
     )
     from tickets_generations import assignment_digest
     from tickets_issue_render import _render_ticket
-    from tickets_loop import REPAIR_MARKER, advance_action, check_reading
+    from tickets_loop import advance_action, check_reading
     from tickets_result import RESULT_ATTRIBUTION_PREFIX
     from tickets_store import _create_text_exclusively, _write_text_atomically
 
@@ -54,7 +56,6 @@ else:  # pragma: no cover - direct/installed flat script path
 COMMAND_VERIFICATION = "done command `{command}` exited {exit} in {tree}"
 CHECK_VERIFICATION = "done check `{criterion}` judged {status} by {ticket}"
 COMMAND_TIMEOUT_SECONDS = 1800
-DONE_TICKET_SUFFIX = ".done"
 
 
 def predicate(data: dict):
@@ -246,6 +247,6 @@ def resolve(run: str, ticket_id: str, run_dir, path, data: dict, tree,
 
 
 __all__ = (
-    "CHECK_VERIFICATION", "COMMAND_VERIFICATION", "DONE_TICKET_SUFFIX",
+    "CHECK_VERIFICATION", "COMMAND_VERIFICATION",
     "predicate", "record_verification", "resolve", "verification_line",
 )

--- a/scripts/tickets_format.py
+++ b/scripts/tickets_format.py
@@ -92,6 +92,21 @@ CHECKED_BY_KEY = 'checked_by'
 GATE_ID_MARKER = '.gate.'
 GATE_CRITIQUE_MARKER = '.gate.critique.'
 CHECKER_STAGE_SUFFIX = '.check'
+# The ids the round machinery mints after a cut is already sealed, and the
+# one grammar that names them. `loop-arm` writes a loop stub's `<id>.iter.NN`
+# body, a landing whose `done` command refused arms its `<id>.repair.NN`
+# round, and the `check` done form mints a `<round>.done` judge beside
+# either. Three readers have to agree on which ids those are -- the arm, the
+# advance, and the sealed-admission door -- and while the grammar was spelled
+# only inside `tickets_loop`, that door answered by never asking: it read
+# every armed iteration as an assignment the seal did not name and refused
+# the whole loop lane at its first dispatch.
+ITERATION_MARKER = 'iter'
+REPAIR_MARKER = 'repair'
+DONE_TICKET_SUFFIX = '.done'
+ROUND_ID_RE = re.compile(
+    f'^(?P<parent>.+)\\.(?:{ITERATION_MARKER}|{REPAIR_MARKER})\\.(?P<number>\\d+)$'
+)
 TEMPLATE_FILE = 'template.md'
 PLACEHOLDER_RE = re.compile('\\{\\{\\s*([^{}]*?)\\s*\\}\\}')
 ESCAPED_NEWLINE_RE = re.compile('\\\\n')
@@ -287,6 +302,32 @@ def is_loop_stub(data) -> bool:
     landing -- so it is spelled the one way a marker can be spelled.
     """
     return dequote(data.get('loop')) == LOOP_MARKER
+def iteration_of(ticket_id):
+    """`(parent_id, number)` when an id names one bounded round, else None.
+
+    The round itself, never the `.done` judge minted beside one: a judge is
+    read *against* a round and is not one, and what counts rounds -- the
+    stall rule of `rules/loops.md` Section 3 -- would count each round twice
+    if it were.
+    """
+    match = ROUND_ID_RE.fullmatch(str(ticket_id or ''))
+    if match is None:
+        return None
+    return match.group('parent'), int(match.group('number'))
+def round_parent(ticket_id):
+    """The ticket whose post-seal round machinery minted this id, or None.
+
+    A round names its parent, and the `.done` judge minted for a round names
+    the same parent that round does. Both are the machinery's ids rather
+    than an author's, so both bind through the one sealed ticket they
+    descend from; this answers *whose*, and the caller answers whether that
+    ticket is the kind whose machinery may mint them.
+    """
+    text = str(ticket_id or '')
+    if text.endswith(DONE_TICKET_SUFFIX):
+        text = text[:-len(DONE_TICKET_SUFFIX)]
+    parsed = iteration_of(text)
+    return None if parsed is None else parsed[0]
 def parse_done(data):
     """The parsed frontmatter ``done`` predicate of one ticket, or None.
 

--- a/scripts/tickets_loop.py
+++ b/scripts/tickets_loop.py
@@ -17,16 +17,16 @@ iteration.
 from __future__ import annotations
 
 import hashlib
-import re
 import shlex
 import subprocess
 
 if __package__:
     from .tickets_admission import ADMISSION_PENDING
     from .tickets_format import (
-        DELIVERED_STATE, REPORT_SECTION, RESULT_BEARING_STATES, TERMINAL_STATES,
+        DELIVERED_STATE, DONE_TICKET_SUFFIX, ITERATION_MARKER, REPAIR_MARKER,
+        REPORT_SECTION, RESULT_BEARING_STATES, TERMINAL_STATES,
         _executor_of, _sections, _set_frontmatter_field, dequote, is_loop_stub,
-        loop_defects, parse_done, ticket_defects,
+        iteration_of, loop_defects, parse_done, ticket_defects,
     )
     from .tickets_generations import assignment_digest
     from .tickets_issue_render import _render_ticket
@@ -37,9 +37,10 @@ if __package__:
 else:  # pragma: no cover - direct/installed flat script path
     from tickets_admission import ADMISSION_PENDING
     from tickets_format import (
-        DELIVERED_STATE, REPORT_SECTION, RESULT_BEARING_STATES, TERMINAL_STATES,
+        DELIVERED_STATE, DONE_TICKET_SUFFIX, ITERATION_MARKER, REPAIR_MARKER,
+        REPORT_SECTION, RESULT_BEARING_STATES, TERMINAL_STATES,
         _executor_of, _sections, _set_frontmatter_field, dequote, is_loop_stub,
-        loop_defects, parse_done, ticket_defects,
+        iteration_of, loop_defects, parse_done, ticket_defects,
     )
     from tickets_generations import assignment_digest
     from tickets_issue_render import _render_ticket
@@ -51,15 +52,13 @@ else:  # pragma: no cover - direct/installed flat script path
 LOOP_ARM_USAGE = "loop-arm <run> <id>"
 LOOP_EVALUATE_USAGE = "loop-evaluate <run> <id>"
 LOOP_ADVANCE_USAGE = "loop-advance <run> <id>"
-DONE_TICKET_SUFFIX = ".done"
-# The two iteration markers this machinery arms under. A loop's body is an
-# `.iter.NN` ticket; a landing whose `done` command refused arms its round
-# two as a `.repair.NN` ticket through the same three rules below, because
-# the question -- is there anything left to build on, and has it moved? --
-# is the same question in both places.
-ITERATION_MARKER = "iter"
-REPAIR_MARKER = "repair"
-ITERATION_RE = re.compile(r"\.(?:iter|repair)\.(\d+)$")
+# The two markers this machinery arms under are `tickets_format`'s, beside
+# the grammar that reads them: a loop's body is an `.iter.NN` ticket, and a
+# landing whose `done` command refused arms its round two as a `.repair.NN`
+# ticket through the same three rules below, because the question -- is there
+# anything left to build on, and has it moved? -- is the same question in
+# both places. The sealed-admission door reads the same grammar to bind a
+# round through the ticket it was minted under.
 # Two consecutive terminal iterations with no result delta exit stalled
 # (rules/loops.md).
 STALL_WINDOW = 2
@@ -70,22 +69,19 @@ def iterations(run_dir, parent_id, marker: str = ITERATION_MARKER):
 
     One reader for both markers: a loop's `<id>.iter.NN` bodies and the
     `<id>.repair.NN` rounds a failed `done` command arms. The `.done` check
-    tickets minted beside them are skipped -- they judge an iteration and
-    are not one.
+    tickets minted beside them are not rounds -- they judge one -- and the
+    grammar `iteration_of` owns does not read them as one.
     """
 
     found = []
     for path in sorted(run_dir.glob(f"{parent_id}.{marker}.*.md")):
-        stem = path.stem
-        if stem.endswith(DONE_TICKET_SUFFIX):
-            continue
-        match = ITERATION_RE.search(stem)
-        if match is None:
+        parsed = iteration_of(path.stem)
+        if parsed is None or parsed[0] != parent_id:
             continue
         loaded = _load_ticket(path)
         if "error" in loaded:
             continue
-        found.append((int(match.group(1)), stem, loaded))
+        found.append((parsed[1], path.stem, loaded))
     return sorted(found)
 
 

--- a/tests/serial_compat_manifest.json
+++ b/tests/serial_compat_manifest.json
@@ -1,6 +1,6 @@
 {
  "discovery": {
-  "count": 2054,
+  "count": 2059,
   "identities": [
    "test_affected_tests.TestDiscoveryCache.test_a_new_commit_is_a_new_key_and_is_discovered_again",
    "test_affected_tests.TestDiscoveryCache.test_a_tree_that_cannot_answer_for_a_commit_falls_back_and_says_so",
@@ -1001,6 +1001,11 @@
    "test_tickets_grade.GradeSnapshotTest.test_no_reader_reconstructs_a_verdict_out_of_a_report",
    "test_tickets_grade.GradeSnapshotTest.test_one_member_decomposition_is_refused",
    "test_tickets_grade.GradeSnapshotTest.test_the_ledger_ends_at_the_repair_and_admits_no_verification_record",
+   "test_tickets_loop.LoopCheckRoundAdmissionTest.test_the_minted_done_check_and_its_round_both_admit",
+   "test_tickets_loop.LoopRoundAdmissionTest.test_a_hand_authored_child_of_a_loop_stub_is_still_refused",
+   "test_tickets_loop.LoopRoundAdmissionTest.test_a_round_edited_after_it_was_armed_is_bound_by_nothing",
+   "test_tickets_loop.LoopRoundAdmissionTest.test_a_round_whose_stub_the_seal_does_not_name_is_refused",
+   "test_tickets_loop.LoopRoundAdmissionTest.test_ready_promotes_the_armed_round_and_the_stub_owns_no_members",
    "test_tickets_loop.LoopStubProtocolTest.test_a_ticket_without_a_loop_object_is_refused",
    "test_tickets_loop.LoopStubProtocolTest.test_advance_rearms_then_closes_complete_on_the_done_reading",
    "test_tickets_loop.LoopStubProtocolTest.test_arm_creates_the_next_iteration_and_replays_while_it_is_live",
@@ -2057,7 +2062,7 @@
    "tests.test_workspace_cases.start_cases.TestTheStampPreservesTheTicketsByteDomain.test_only_the_two_stamped_lines_differ_from_the_prior_bytes",
    "tests.test_workspace_cases.start_cases.TestTicketsPayloadIsGradedNotItsExitStatus.test_an_error_payload_returned_at_exit_zero_is_a_failure"
   ],
-  "sha256": "11f4ff8b0041aa651f514a22287da01980123f87fc34a60479018fc9fc77feff"
+  "sha256": "5dcd42bebcfc7c76d68a99e9da3259f7966c5ec0af26318e6137b966b76ad593"
  },
  "mutation_owners": [
   {
@@ -4741,7 +4746,7 @@
   },
   {
    "module": "tests.test_tickets_loop",
-   "owner": "LoopStubProtocolTest.setUp",
+   "owner": "LoopSinkTest.setUp",
    "restoration": "selected-module-boundary",
    "seams": [
     "environment"
@@ -4749,7 +4754,7 @@
   },
   {
    "module": "tests.test_tickets_loop",
-   "owner": "LoopStubProtocolTest.setUp.restore",
+   "owner": "LoopSinkTest.setUp.restore",
    "restoration": "selected-module-boundary",
    "seams": [
     "environment"

--- a/tests/test_tickets_loop.py
+++ b/tests/test_tickets_loop.py
@@ -1,4 +1,13 @@
-"""The loop stub's arm/evaluate/advance protocol and its replay after a kill."""
+"""The loop stub's arm/evaluate/advance protocol, and the trunk it crosses.
+
+Two halves, because the lane broke exactly where they were never joined.
+`LoopStubProtocolTest` drives the scripts-only protocol -- arm, evaluate,
+advance, replay after a kill -- which is the whole of what the loop
+machinery was proved against before the dispatch trunk existed.
+`LoopRoundAdmissionTest` and `LoopCheckRoundAdmissionTest` drive an armed
+round through `ready` and the dispatch admission door, which is where every
+loop refused on its first real run.
+"""
 
 from __future__ import annotations
 
@@ -11,6 +20,8 @@ from pathlib import Path
 
 from scripts import tickets
 from scripts import state_root
+from scripts.tickets_context import graded_admission, run_snapshot
+from scripts.tickets_dispatch_guards import admission_failure
 
 
 TEMPLATE_MANIFEST = """---
@@ -23,11 +34,14 @@ placeholders: [probe]
 One loop stub whose done-check is a deterministic command.
 """
 
+COMMAND_DONE = '{"form":"command","value":"{{probe}}"}'
+CHECK_DONE = '{"form":"check","value":"The probe artifact converged."}'
+
 LOOP_STUB = """---
 id: L1
 executor: orch-execute
 loop: true
-done: {"form":"command","value":"{{probe}}"}
+done: DONE_BINDING
 pack: orch-code-pack
 depends_on: []
 bound: 30m
@@ -51,8 +65,38 @@ PROBE_SCRIPT = (
     "sys.exit(0 if (pathlib.Path(__file__).resolve().parent / 'marker').exists() else 1)\n"
 )
 
+# An author-written child of the loop stub: it is an id-descendant like a
+# round is, and it is not a round, so it is what tells the shape exemption
+# from a hole in the shape check.
+AUTHORED_CHILD = """---
+id: L1.extra
+run: looprun
+status: pending
+executor: orch-execute
+pack: orch-code-pack
+depends_on: []
+bound: 30m
+independence: checker
+isolation: none
+---
 
-class LoopStubProtocolTest(unittest.TestCase):
+## Goal
+
+A hand-authored child of a loop stub, which is not one of its rounds.
+
+## Context
+
+- input: written straight into the run directory.
+
+## Report
+"""
+
+
+class LoopSinkTest(unittest.TestCase):
+    """The temp sink, sealed loop template, and probe every case runs on."""
+
+    DONE = COMMAND_DONE
+
     def setUp(self):
         self._sink = tempfile.TemporaryDirectory()
         self.addCleanup(self._sink.cleanup)
@@ -72,7 +116,9 @@ class LoopStubProtocolTest(unittest.TestCase):
         template = work / "loop-probe"
         template.mkdir()
         (template / "template.md").write_text(TEMPLATE_MANIFEST, encoding="utf-8")
-        (template / "L1.md").write_text(LOOP_STUB, encoding="utf-8")
+        (template / "L1.md").write_text(
+            LOOP_STUB.replace("DONE_BINDING", self.DONE), encoding="utf-8",
+        )
         self.probe = work / "probe.py"
         self.probe.write_text(PROBE_SCRIPT, encoding="utf-8")
         self.marker = work / "marker"
@@ -86,9 +132,12 @@ class LoopStubProtocolTest(unittest.TestCase):
     def _loop(self, command):
         return tickets._dispatch([command, "looprun", "L1"])
 
+    def _run_dir(self):
+        return Path(self._sink.name) / "tickets" / "looprun"
+
     def _close_iteration(self, ticket_id, status="complete", result_text=""):
         if result_text:
-            root = Path(self._sink.name) / "tickets" / "looprun" / f"{ticket_id}.md"
+            root = self._run_dir() / f"{ticket_id}.md"
             text = root.read_text(encoding="utf-8")
             root.write_text(
                 text.replace("## Report\n", f"## Report\n\n{result_text}\n", 1),
@@ -97,6 +146,18 @@ class LoopStubProtocolTest(unittest.TestCase):
         closed = tickets._dispatch(["set-status", "looprun", ticket_id, status])
         self.assertNotIn("error", closed, closed)
 
+    def _codes(self, ticket_id):
+        """The admission finding codes one ticket carries right now."""
+
+        snapshot, failures = run_snapshot(self._run_dir())
+        self.assertEqual([], failures, failures)
+        grade = graded_admission(
+            ticket_id, snapshot[ticket_id], snapshot, "looprun",
+        )
+        return {str(item["code"]) for item in grade["findings"]}
+
+
+class LoopStubProtocolTest(LoopSinkTest):
     def test_arm_creates_the_next_iteration_and_replays_while_it_is_live(self):
         armed = self._loop("loop-arm")
         self.assertEqual(
@@ -152,6 +213,82 @@ class LoopStubProtocolTest(unittest.TestCase):
     def test_a_ticket_without_a_loop_object_is_refused(self):
         result = tickets._dispatch(["loop-arm", "looprun", "missing"])
         self.assertIn("not found", result["error"])
+
+
+class LoopRoundAdmissionTest(LoopSinkTest):
+    """An armed round crosses `ready` and the dispatch admission door.
+
+    Neither reading was ever taken before the trunk existed: the sealed cut
+    is written at instantiate and a round is minted after it, so the sealed
+    set can never name a round; and a round is an id-descendant of its stub
+    by construction, so the graph shape read an armed stub as a
+    non-decomposed root owning members. Both fired on the same first run.
+    """
+
+    def test_ready_promotes_the_armed_round_and_the_stub_owns_no_members(self):
+        armed = self._loop("loop-arm")["loop_arm"]
+        self.assertEqual("L1.iter.1", armed["ticket"])
+        promoted = tickets._dispatch(["ready", "--run", "looprun"])
+        self.assertNotIn("error", promoted, promoted)
+        self.assertIn(
+            "L1.iter.1", {item["id"] for item in promoted["ready"]}, promoted,
+        )
+        self.assertEqual([], promoted["skipped"], promoted["skipped"])
+        path = self._run_dir() / "L1.iter.1.md"
+        text = path.read_text(encoding="utf-8")
+        self.assertIsNone(admission_failure(
+            path, text, tickets._parse_frontmatter(text), "looprun", "L1.iter.1",
+        ))
+
+    def test_a_round_edited_after_it_was_armed_is_bound_by_nothing(self):
+        self._loop("loop-arm")
+        self.assertEqual(set(), self._codes("L1.iter.1"))
+        path = self._run_dir() / "L1.iter.1.md"
+        path.write_text(
+            path.read_text(encoding="utf-8").replace(
+                "Converge the probe artifact", "Converge the probe artifacts", 1,
+            ),
+            encoding="utf-8",
+        )
+        self.assertIn("sealed-assignment-mismatch", self._codes("L1.iter.1"))
+
+    def test_a_hand_authored_child_of_a_loop_stub_is_still_refused(self):
+        self._loop("loop-arm")
+        self.assertEqual(set(), self._codes("L1"))
+        (self._run_dir() / "L1.extra.md").write_text(
+            AUTHORED_CHILD, encoding="utf-8",
+        )
+        self.assertIn("graph-direct-members", self._codes("L1"))
+
+    def test_a_round_whose_stub_the_seal_does_not_name_is_refused(self):
+        self._loop("loop-arm")
+        self.assertEqual(set(), self._codes("L1.iter.1"))
+        stub = self._run_dir() / "L1.md"
+        stub.write_text(tickets._set_frontmatter_field(
+            stub.read_text(encoding="utf-8"), "assignment_seal",
+            "sha256:" + "0" * 64,
+        ), encoding="utf-8")
+        self.assertIn("sealed-loop-stub-mismatch", self._codes("L1.iter.1"))
+
+
+class LoopCheckRoundAdmissionTest(LoopSinkTest):
+    """The judge the `check` done form mints binds through the same stub.
+
+    `loop-evaluate` mints `<round>.done` after the round lands, later still
+    than the round itself, and it is an id-descendant of both the round and
+    the stub. It is the second id the loop machinery writes past the seal,
+    and it crosses admission through the one ticket the seal did name.
+    """
+
+    DONE = CHECK_DONE
+
+    def test_the_minted_done_check_and_its_round_both_admit(self):
+        self._loop("loop-arm")
+        self._close_iteration("L1.iter.1", result_text="Revision r1 delivered.")
+        reading = self._loop("loop-evaluate")["loop_evaluate"]
+        self.assertEqual("L1.iter.1.done", reading["pending"])
+        for ticket_id in ("L1", "L1.iter.1", "L1.iter.1.done"):
+            self.assertEqual(set(), self._codes(ticket_id), ticket_id)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Blocking regression found by the first trunk-driven loop (the self-improve run over the super-research harvest): `loop-arm` mints self-sealed iterations bound through the stub's sealed generation (its own law — "arm follows the seal"), but admission only accepted seals that are members of the run's sealed cut, and the graph-shape check refused the armed stub as "a non-decomposed root that owns members." The loop lane was last proven by a scripts-only smoke before the dispatch trunk existed; no test drove an iteration through `ready`/`dispatch` admission, so every gate stayed green while the lane was broken end-to-end.

- One grammar owner for round ids in `tickets_format` (`iteration_of`/`round_parent` beside `is_loop_stub`); the private regex and the second `.done` suffix spelling deleted from their old homes.
- Admission grades a lawful round against the STUB's membership in the sealed cut: identical `root_generation` + `cut_generation`, and the round's self-seal verifying against its own current bytes — a tampered round still refuses (`sealed-assignment-mismatch`), a non-round child of a loop stub still refuses (`graph-direct-members`), a round whose stub the seal no longer binds refuses the new `sealed-loop-stub-mismatch`.
- Trunk-path tests: `loop-arm` → `ready` promotes → the dispatch door accepts, for both done forms; a mutant forcing the pre-fix tree fails all five new cases and reproduces the field repro verbatim.

No contract changed — the sealed-cut membership rule lives only in code, like the two pre-existing post-seal exemptions. Gates: `run_required --no-cache` 0 + `preflight` 0 at the tip.

Known adjacent, deliberately preserved and chipped separately: land's own post-seal rounds (`.repair.NN`/`.done` under an ordinary ticket) carry the identical refusal pair.

🤖 Generated with [Claude Code](https://claude.com/claude-code)