### PR TITLE
Admit a landing's rounds through the ticket the seal did name

### DIFF
--- a/scripts/tickets_admission.py
+++ b/scripts/tickets_admission.py
@@ -12,8 +12,8 @@ if __package__:
     from .tickets_format import (
         DELIVERED_STATE, RESULT_BEARING_STATES, ROOT_EXECUTOR,
         SCRIPT_EXECUTOR_PREFIX, adapter_id, canonical_json, dequote,
-        is_loop_stub, is_review_stage_id, round_parent, _executor_of,
-        _parse_frontmatter, _set_frontmatter_field,
+        is_loop_stub, is_review_stage_id, parse_done, round_parent,
+        _executor_of, _parse_frontmatter, _set_frontmatter_field,
     )
 else:
     from tickets_registry import EXECUTOR_REGISTRY, executor_refusal, executor_registered
@@ -21,8 +21,8 @@ else:
     from tickets_format import (
         DELIVERED_STATE, RESULT_BEARING_STATES, ROOT_EXECUTOR,
         SCRIPT_EXECUTOR_PREFIX, adapter_id, canonical_json, dequote,
-        is_loop_stub, is_review_stage_id, round_parent, _executor_of,
-        _parse_frontmatter, _set_frontmatter_field,
+        is_loop_stub, is_review_stage_id, parse_done, round_parent,
+        _executor_of, _parse_frontmatter, _set_frontmatter_field,
     )
 
 ADMISSION_PENDING = "pending"
@@ -150,7 +150,8 @@ def loop_round_stub(ticket_id: str, siblings) -> str | None:
 
     `tickets_format.round_parent` owns the grammar; what is added here is the
     marker, because the same grammar spells a landing's `<id>.repair.NN`
-    rounds and those descend from an ordinary ticket, not from a loop.
+    rounds and those descend from an ordinary ticket, not from a loop --
+    `landing_round_parent` answers for those.
     """
     stub_id = round_parent(ticket_id)
     if stub_id is None:
@@ -159,6 +160,35 @@ def loop_round_stub(ticket_id: str, siblings) -> str | None:
     if text is None or not is_loop_stub(_parse_frontmatter(text)):
         return None
     return stub_id
+
+
+def landing_round_parent(ticket_id: str, siblings) -> str | None:
+    """The landed ticket whose own `done` predicate minted this id, or ``None``.
+
+    `land` evaluates an ordinary ticket's `done` predicate over the
+    integrated tree: a refusal arms `<id>.repair.NN` through the same
+    advance rules a loop uses, and the `check` form mints the `<id>.done`
+    judge beside the landed ticket itself. Both exist only after the cut
+    that sealed the ticket, so the sealed set never names them and the
+    graph shape would read them as members -- the two refusals that closed
+    the loop lane before `loop_round_stub` was written, reproduced verbatim
+    on the landing lane's first drive through the trunk.
+
+    The licence is the parent's own predicate: a loop stub's rounds answer
+    to its marker, and a landing's answer to the `done` binding `land`
+    runs. A parent carrying neither licenses nothing, and its
+    id-descendants stay refused as the authored children they are.
+    """
+    parent_id = round_parent(ticket_id)
+    if parent_id is None:
+        return None
+    text = dict(siblings or {}).get(parent_id)
+    if text is None:
+        return None
+    parent = _parse_frontmatter(text)
+    if is_loop_stub(parent) or parse_done(parent) is None:
+        return None
+    return parent_id
 
 
 def graph_closed(ticket_id: str, siblings, *evidence) -> bool:
@@ -183,16 +213,19 @@ def graph_findings(ticket_id: str, data: dict, siblings: dict, *, complete=False
     member-count checks are deferred until a generation is being validated:
     the first root ticket is necessarily issued before its members exist.
 
-    A loop stub's own rounds are dropped before the count: an armed
-    `<stub>.iter.NN` is an id-descendant of its stub by construction, and
-    reading it as a member would refuse every armed loop stub for owning the
-    iterations the loop marker is the licence to arm.  An author-written
-    child of a loop stub matches no round grammar and is still refused.
+    A round minter's own rounds are dropped before the count: an armed
+    `<stub>.iter.NN` is an id-descendant of its stub by construction, and a
+    landing's `<id>.repair.NN` round and `<id>.done` judge are
+    id-descendants of the landed ticket the same way.  Reading either as a
+    member would refuse the parent for owning the rounds its marker or
+    `done` predicate is the licence to mint.  An author-written child of
+    either parent matches no round grammar and is still refused.
     """
     executor = _executor_of(data)
     descendants = [
         identifier for identifier in graph_descendants(ticket_id, siblings)
         if loop_round_stub(identifier, siblings) is None
+        and landing_round_parent(identifier, siblings) is None
     ]
     findings = []
     if executor == ROOT_EXECUTOR:
@@ -256,30 +289,34 @@ def _ordinary_review_target(ticket_id: str, data: dict, dependencies, siblings):
     return target_id, ordinary_stage_text(run, target_id, target, kind)
 
 
-def sealed_loop_target(ticket_id, text, data, siblings, digest):
-    """The loop stub one lawful post-seal round binds its admission through.
+def sealed_round_target(ticket_id, text, data, siblings, digest):
+    """The sealed parent one lawful post-seal round binds its admission through.
 
     The sealed cut names the assignments that existed when it was sealed, and
     a round exists only afterwards, so a round can never be named there.  What
-    the seal did name is the stub, and a round is lawful exactly when it
-    descends from that stub unaltered: the stub's own `root_generation` and
-    `cut_generation`, and a self-seal that still matches the round's current
-    bytes.  A round whose bytes moved after it was armed fails that last
-    reading and falls through to the sealed-set door, which has never named it
-    and refuses it.
+    the seal did name is the parent the machinery minted it under -- a loop's
+    stub or a landing's done-bearing ticket -- and a round is lawful exactly
+    when it descends from that parent unaltered: the parent's own
+    `root_generation` and `cut_generation`, and a self-seal that still
+    matches the round's current bytes.  A round whose bytes moved after it
+    was minted fails that last reading and falls through to the sealed-set
+    door, which has never named it and refuses it.
     """
-    stub_id = loop_round_stub(ticket_id, siblings)
-    if stub_id is None:
+    parent_id = (
+        loop_round_stub(ticket_id, siblings)
+        or landing_round_parent(ticket_id, siblings)
+    )
+    if parent_id is None:
         return None
-    stub = _parse_frontmatter(siblings[stub_id])
+    parent = _parse_frontmatter(siblings[parent_id])
     if any(
-        str(data.get(field) or "") != str(stub.get(field) or "")
+        str(data.get(field) or "") != str(parent.get(field) or "")
         for field in ("cut_generation", "root_generation")
     ):
         return None
     if str(data.get("assignment_seal") or "") != digest(ticket_id, text):
         return None
-    return stub_id
+    return parent_id
 
 
 def grade_admission(ticket_id: str, text: str, siblings: dict, context=None) -> dict:
@@ -345,7 +382,7 @@ def grade_admission(ticket_id: str, text: str, siblings: dict, context=None) -> 
             review_target = _ordinary_review_target(
                 ticket_id, data, dependencies, siblings,
             )
-            loop_stub = sealed_loop_target(
+            round_parent_id = sealed_round_target(
                 ticket_id, text, data, siblings, assignment_digest,
             )
             if review_target is not None:
@@ -375,12 +412,17 @@ def grade_admission(ticket_id: str, text: str, siblings: dict, context=None) -> 
                         "ordinary repair or verification assignment differs from "
                         "the canonical checked-target continuation",
                     ))
-            elif loop_stub is not None:
-                stub = _parse_frontmatter(siblings[loop_stub])
-                if sealed_assignments.get(loop_stub) != stub.get("assignment_seal"):
+            elif round_parent_id is not None:
+                parent = _parse_frontmatter(siblings[round_parent_id])
+                if sealed_assignments.get(round_parent_id) != parent.get("assignment_seal"):
+                    stub = is_loop_stub(parent)
                     findings.append(finding(
-                        "sealed-loop-stub-mismatch", "assignment_seal",
-                        "sealed state does not bind the loop stub this round was armed from",
+                        "sealed-loop-stub-mismatch" if stub
+                        else "sealed-landing-mismatch",
+                        "assignment_seal",
+                        "sealed state does not bind the "
+                        + ("loop stub this round was armed from" if stub
+                           else "landed ticket this round was minted under"),
                     ))
             elif sealed_assignments.get(ticket_id) != data.get("assignment_seal"):
                 findings.append(finding("sealed-assignment-mismatch", "assignment_seal", "sealed state does not bind this assignment"))
@@ -455,6 +497,7 @@ def refresh_admissions(run, run_dir, snapshot: dict, write_atomically) -> list:
 __all__ = (
     "ADMISSION_PENDING", "RESULT_BEARING_STATES", "adapter_id",
     "binding_findings", "dependency_order_findings", "finding",
-    "graph_findings", "grade_admission", "is_receipt", "loop_round_stub",
-    "pinned_digest_finding", "refresh_admissions", "sealed_loop_target",
+    "graph_findings", "grade_admission", "is_receipt",
+    "landing_round_parent", "loop_round_stub", "pinned_digest_finding",
+    "refresh_admissions", "sealed_round_target",
 )

--- a/scripts/tickets_format.py
+++ b/scripts/tickets_format.py
@@ -317,15 +317,20 @@ def iteration_of(ticket_id):
 def round_parent(ticket_id):
     """The ticket whose post-seal round machinery minted this id, or None.
 
-    A round names its parent, and the `.done` judge minted for a round names
-    the same parent that round does. Both are the machinery's ids rather
-    than an author's, so both bind through the one sealed ticket they
-    descend from; this answers *whose*, and the caller answers whether that
-    ticket is the kind whose machinery may mint them.
+    A round names its parent, and a `.done` judge names the subject it was
+    minted beside: a loop's judge stands beside an `.iter.NN` round and
+    binds through that round's parent, while a landing's `check` form mints
+    its judge beside the landed ticket itself, so the judge binds through
+    it. All are the machinery's ids rather than an author's; this answers
+    *whose*, and the caller answers whether that ticket is the kind whose
+    machinery may mint them -- the loop marker for a stub's rounds, the
+    `done` predicate `land` evaluates for a landing's.
     """
     text = str(ticket_id or '')
     if text.endswith(DONE_TICKET_SUFFIX):
-        text = text[:-len(DONE_TICKET_SUFFIX)]
+        subject = text[:-len(DONE_TICKET_SUFFIX)]
+        parsed = iteration_of(subject)
+        return (subject if parsed is None else parsed[0]) or None
     parsed = iteration_of(text)
     return None if parsed is None else parsed[0]
 def parse_done(data):

--- a/tests/serial_compat_manifest.json
+++ b/tests/serial_compat_manifest.json
@@ -1,6 +1,6 @@
 {
  "discovery": {
-  "count": 2059,
+  "count": 2064,
   "identities": [
    "test_affected_tests.TestDiscoveryCache.test_a_new_commit_is_a_new_key_and_is_discovered_again",
    "test_affected_tests.TestDiscoveryCache.test_a_tree_that_cannot_answer_for_a_commit_falls_back_and_says_so",
@@ -929,6 +929,11 @@
    "test_ticket_done_predicate.LandDonePredicateTest.test_two_rounds_with_no_delta_close_the_ticket_stalled",
    "test_ticket_done_predicate.LandIntegratesTheCandidateTest.test_a_conflicted_merge_refuses_naming_the_files_and_the_remedy",
    "test_ticket_done_predicate.LandIntegratesTheCandidateTest.test_the_candidates_commits_reach_the_tree_the_run_stands_in",
+   "test_ticket_done_predicate.LandRoundAdmissionTest.test_a_hand_authored_child_of_a_landed_ticket_is_still_refused",
+   "test_ticket_done_predicate.LandRoundAdmissionTest.test_a_round_edited_after_it_was_armed_is_bound_by_nothing",
+   "test_ticket_done_predicate.LandRoundAdmissionTest.test_a_round_whose_landing_the_seal_does_not_name_is_refused",
+   "test_ticket_done_predicate.LandRoundAdmissionTest.test_ready_promotes_the_armed_round_and_the_landing_owns_no_members",
+   "test_ticket_done_predicate.LandRoundAdmissionTest.test_the_minted_done_judge_binds_through_the_landed_ticket",
    "test_ticket_protocol.TicketProtocolTest.test_dispatch_attempt_state_does_not_move_assignment",
    "test_ticket_protocol.TicketProtocolTest.test_dispatch_v1_contract_owns_the_closed_public_seam",
    "test_ticket_protocol.TicketProtocolTest.test_dispatch_v1_contract_owns_the_launch",
@@ -2062,7 +2067,7 @@
    "tests.test_workspace_cases.start_cases.TestTheStampPreservesTheTicketsByteDomain.test_only_the_two_stamped_lines_differ_from_the_prior_bytes",
    "tests.test_workspace_cases.start_cases.TestTicketsPayloadIsGradedNotItsExitStatus.test_an_error_payload_returned_at_exit_zero_is_a_failure"
   ],
-  "sha256": "5dcd42bebcfc7c76d68a99e9da3259f7966c5ec0af26318e6137b966b76ad593"
+  "sha256": "cc094b36c90f1e59174c606a1d483715b903428633b66e286803252fc0535142"
  },
  "mutation_owners": [
   {
@@ -4493,28 +4498,28 @@
   },
   {
    "module": "tests.test_ticket_done_predicate",
-   "owner": "LandDonePredicateTest.setUp",
-   "restoration": "selected-module-boundary",
-   "seams": [
-    "environment",
-    "threads"
-   ]
-  },
-  {
-   "module": "tests.test_ticket_done_predicate",
-   "owner": "LandDonePredicateTest.stand_up",
-   "restoration": "selected-module-boundary",
-   "seams": [
-    "monkeypatch"
-   ]
-  },
-  {
-   "module": "tests.test_ticket_done_predicate",
    "owner": "LandIntegratesTheCandidateTest.setUp",
    "restoration": "selected-module-boundary",
    "seams": [
     "environment",
     "threads"
+   ]
+  },
+  {
+   "module": "tests.test_ticket_done_predicate",
+   "owner": "LandTrunkTest.setUp",
+   "restoration": "selected-module-boundary",
+   "seams": [
+    "environment",
+    "threads"
+   ]
+  },
+  {
+   "module": "tests.test_ticket_done_predicate",
+   "owner": "LandTrunkTest.stand_up",
+   "restoration": "selected-module-boundary",
+   "seams": [
+    "monkeypatch"
    ]
   },
   {

--- a/tests/test_ticket_done_predicate.py
+++ b/tests/test_ticket_done_predicate.py
@@ -6,6 +6,9 @@ round-two slot when that code was non-zero; and the tree that shipped never
 had a gate run against it. So: the predicate is evaluated by `land` in the
 integrated tree, its exit is the verdict, a refusal arms a repair round
 instead of wedging, and the candidate is merged before any of it.
+`LandRoundAdmissionTest` then drives the armed round through `ready` and
+the dispatch admission door, where the loop lane's rounds had already
+refused once and the landing lane's reproduced both refusals verbatim.
 """
 
 from __future__ import annotations
@@ -25,6 +28,8 @@ from scripts import state_root
 from scripts import tickets
 from scripts import tickets_done
 from scripts import tickets_loop
+from scripts.tickets_context import graded_admission, run_snapshot
+from scripts.tickets_dispatch_guards import admission_failure
 from scripts.tickets_format import _sections, parse_canonical_json
 
 # The interpreter every predicate below is run through: a bare `python` is a
@@ -39,6 +44,33 @@ def _command(code: int) -> str:
 
 def _done(form: str, value: str) -> str:
     return json.dumps({"form": form, "value": value}, sort_keys=True)
+
+
+# An author-written child of the landed ticket: it is an id-descendant like
+# a round is, and it is not a round, so it is what tells the shape exemption
+# from a hole in the shape check.
+AUTHORED_CHILD = """---
+id: T.extra
+run: run
+status: pending
+executor: orch-execute
+pack: orch-code-pack
+depends_on: []
+bound: 30m
+independence: checker
+isolation: none
+---
+
+## Goal
+
+A hand-authored child of a landed ticket, which is not one of its rounds.
+
+## Context
+
+- input: written straight into the run directory.
+
+## Report
+"""
 
 
 class DonePredicateGrammarTest(unittest.TestCase):
@@ -84,8 +116,12 @@ class DonePredicateGrammarTest(unittest.TestCase):
         self.assertIn("done", tickets_generations.ASSIGNMENT_SYSTEM_FIELDS)
 
 
-class LandDonePredicateTest(unittest.TestCase):
-    """The predicate, in the composition that owns it."""
+class LandTrunkTest(unittest.TestCase):
+    """The temp sink, candidate checkout, and one landing every case runs on.
+
+    `stand_up` walks the whole trunk short of `land`: new, done binding,
+    stamp, validate, seal, ready, dispatch, outcome.
+    """
 
     def setUp(self):
         self.temporary = tempfile.TemporaryDirectory()
@@ -165,6 +201,18 @@ class LandDonePredicateTest(unittest.TestCase):
 
     def steps(self, landed) -> dict:
         return {step["step"]: step for step in landed["land"]["steps"]}
+
+    def _codes(self, ticket_id):
+        """The admission finding codes one ticket carries right now."""
+
+        snapshot, failures = run_snapshot(self.ticket_path().parent)
+        self.assertEqual([], failures, failures)
+        grade = graded_admission(ticket_id, snapshot[ticket_id], snapshot, "run")
+        return {str(item["code"]) for item in grade["findings"]}
+
+
+class LandDonePredicateTest(LandTrunkTest):
+    """The predicate, in the composition that owns it."""
 
     def test_a_passing_command_is_the_verdict_and_land_files_its_evidence(self):
         command = _command(0)
@@ -263,6 +311,80 @@ class LandDonePredicateTest(unittest.TestCase):
         self.stand_up(_done("command", _command(0)))
         both = self.land("--status", "complete")
         self.assertIn("land evaluates", both["error"])
+
+
+class LandRoundAdmissionTest(LandTrunkTest):
+    """A landing's armed round crosses `ready` and the dispatch admission door.
+
+    The loop lane refused `sealed-assignment-mismatch` and
+    `graph-direct-members` the first time it was driven through the trunk,
+    and the landing lane reproduced both verbatim: `land` mints its
+    `<id>.repair.NN` round and `<id>.done` judge through the same machinery
+    past the same seal, under a parent whose licence is the `done` predicate
+    rather than the loop marker.
+    """
+
+    def _arm_repair_round(self):
+        """One failing command-form landing, and the round it armed."""
+
+        self.stand_up(_done("command", _command(3)))
+        landed = self.land()
+        self.assertNotIn("error", landed, landed)
+        self.assertEqual("T.repair.1", self.steps(landed)["done"]["repair"])
+
+    def test_ready_promotes_the_armed_round_and_the_landing_owns_no_members(self):
+        self._arm_repair_round()
+        self.assertNotIn("graph-direct-members", self._codes("T"))
+        promoted = self.run_command("ready", "--run", "run")
+        self.assertIn(
+            "T.repair.1", {item["id"] for item in promoted["ready"]}, promoted,
+        )
+        path = self.ticket_path("T.repair.1")
+        text = path.read_text(encoding="utf-8")
+        self.assertIsNone(admission_failure(
+            path, text, tickets._parse_frontmatter(text), "run", "T.repair.1",
+        ))
+
+    def test_a_round_edited_after_it_was_armed_is_bound_by_nothing(self):
+        self._arm_repair_round()
+        self.assertEqual(set(), self._codes("T.repair.1"))
+        path = self.ticket_path("T.repair.1")
+        path.write_text(
+            path.read_text(encoding="utf-8").replace(
+                "done predicate pass", "done predicate sing", 1,
+            ),
+            encoding="utf-8",
+        )
+        self.assertIn("sealed-assignment-mismatch", self._codes("T.repair.1"))
+
+    def test_a_hand_authored_child_of_a_landed_ticket_is_still_refused(self):
+        self._arm_repair_round()
+        self.assertNotIn("graph-direct-members", self._codes("T"))
+        (self.ticket_path().parent / "T.extra.md").write_text(
+            AUTHORED_CHILD, encoding="utf-8",
+        )
+        self.assertIn("graph-direct-members", self._codes("T"))
+
+    def test_a_round_whose_landing_the_seal_does_not_name_is_refused(self):
+        self._arm_repair_round()
+        self.assertEqual(set(), self._codes("T.repair.1"))
+        parent = self.ticket_path()
+        parent.write_text(tickets._set_frontmatter_field(
+            parent.read_text(encoding="utf-8"), "assignment_seal",
+            "sha256:" + "0" * 64,
+        ), encoding="utf-8")
+        self.assertIn("sealed-landing-mismatch", self._codes("T.repair.1"))
+
+    def test_the_minted_done_judge_binds_through_the_landed_ticket(self):
+        self.stand_up(_done("check", "the Goal clause no oracle covers"))
+        landed = self.land()
+        self.assertEqual("await-done-check", self.steps(landed)["done"]["outcome"])
+        self.assertNotIn("graph-direct-members", self._codes("T"))
+        # The two lane refusals are gone; what stands is the judge's own
+        # dependency on the still-claimed ticket it judges, a readiness
+        # wedge the admission door does not own. Pinned exactly so the fix
+        # that clears it retires this line too.
+        self.assertEqual({"dependency-incomplete"}, self._codes("T.done"))
 
 
 class LandIntegratesTheCandidateTest(unittest.TestCase):


### PR DESCRIPTION
Follow-on to #147. The loop-admission fix anchored the post-seal round exemption on the `loop: true` marker, so the rounds `land` mints under an ordinary ticket after a failing done predicate — the `<id>.repair.NN` round a refused command arms and the `<id>.done` judge the check form mints, both via `tickets_done.resolve` through the loop-advance machinery — still refused `sealed-assignment-mismatch` (the sealed cut is written before the round exists) and `graph-direct-members` (a round is an id-descendant of the landed ticket by construction).

- `tickets_format.round_parent` now answers for a landing's judge: a `.done` id names the subject it was minted beside, and a subject that is not itself a round binds through itself.
- `tickets_admission.landing_round_parent` is the second licence beside the loop marker: the sealed done-bearing ticket whose landing minted the id. One `sealed_round_target` (replacing `sealed_loop_target`) binds either minter's round through its parent under the unchanged reading — the parent's own generations, a self-seal still matching the round's current bytes, and a parent the sealed set still names.
- Tamper refusals carry over verbatim: an edited round falls to the sealed-set door (`sealed-assignment-mismatch`), a hand-authored child matches no round grammar and still refuses the parent's shape (`graph-direct-members`), and a parent the seal no longer binds refuses the new `sealed-landing-mismatch`.
- `LandRoundAdmissionTest` drives a failing command-form done through `land` into the armed repair round and across `ready` and the dispatch admission door. The check-form case pins its honest residue: the minted `<id>.done` judge depends on the still-claimed ticket it judges, a readiness wedge the admission door does not own — filed as friction in the sink.

Gate: `tools/run_required.py --no-cache` exit 0 (86 modules, 2064 tests, 0 failures) and `tools/preflight.py` exit 0; serial manifest regenerated last with the two renamed-owner rulings carried (`selected-module-boundary`, byte-identical restoration code, only the class name moved).

🤖 Generated with [Claude Code](https://claude.com/claude-code)