### PR TITLE
Read a work item's isolation before its adapter's strategy

### DIFF
--- a/scripts/workspace_candidate.py
+++ b/scripts/workspace_candidate.py
@@ -117,23 +117,29 @@ def _adapter(data: dict):
         raise Refused(f"{error.code}: {error.detail}") from error
 
 
-def _evidence(run, ticket_id, path, prior_text, adapter, held, seams) -> dict:
-    """A research lane's workspace is the run-scoped evidence store."""
+def _unisolated(run, ticket_id, path, prior_text, adapter, held, seams, where) -> dict:
+    """Record the workspace of a lane that gives no item a tree of its own.
 
-    store = (state_root.state_root() / "research" / run).resolve()
-    store.mkdir(parents=True, exist_ok=True)
+    Two such lanes, one act: a research lane's workspace is the run-scoped
+    evidence store, created here because nothing else creates it, and a
+    document lane's is the tree its caller already stands in. Branch and
+    baseline go in as ``None`` -- a document revision is no commit, and a
+    stamped HEAD would hand the join a Git grade for work Git never carried.
+    """
+
+    if adapter.workspace_strategy == EVIDENCE_STRATEGY:
+        root = (state_root.state_root() / "research" / run).resolve()
+        root.mkdir(parents=True, exist_ok=True)
+    else:
+        root = Path(where or Path.cwd()).expanduser().resolve()
     outcome = seams["record"](
-        path, prior_text, None, None, str(store), run=run, lock_held=held
+        path, prior_text, None, None, str(root), run=run, lock_held=held
     )
     if "error" in outcome:
         raise Refused(outcome["error"])
     return {
-        "run": run,
-        "id": ticket_id,
-        "ticket": str(path),
-        "mechanism": adapter.key,
-        PATH_KEY: str(store),
-        "workspace_root": str(store),
+        "run": run, "id": ticket_id, "ticket": str(path), "mechanism": adapter.key,
+        PATH_KEY: str(root), "workspace_root": str(root), "isolated": False,
     }
 
 
@@ -326,15 +332,15 @@ def _derived(run, ticket_id, path, data, prior_text, held, source, seams):
 def _establishment(run, ticket_id, key, held, seams, source, where):
     path, data, prior_text = _loaded(run, ticket_id)
     adapter = _adapter(data)
-    strategy = adapter.workspace_strategy
-    if strategy == EVIDENCE_STRATEGY:
-        return {key: _evidence(run, ticket_id, path, prior_text, adapter, held, seams)}, EXIT_OK
-    if strategy != GIT_STRATEGY:
-        raise Refused(
-            f"adapter-not-establishable: {adapter.key} does not establish a "
-            "candidate workspace"
-        )
+    # The item's isolation before the adapter's strategy, never after. Judged
+    # the other way round, a document lane refused at the dispatch trunk over
+    # a tree of its own -- which only an explicit override ever asks it for.
     isolation = tickets_adapters.derived_isolation(data.get(ISOLATION_KEY), data.get("pack"))
+    if isolation == REQUIRED and not adapter.establishes_isolation:
+        raise Refused(f"adapter-not-establishable: {adapter.key} does not "
+                      "establish a candidate workspace")
+    if adapter.workspace_strategy != GIT_STRATEGY:
+        return {key: _unisolated(run, ticket_id, path, prior_text, adapter, held, seams, where)}, EXIT_OK
     if source is None or isolation != REQUIRED:
         body, code = _observed(run, ticket_id, path, data, prior_text, held, seams, where)
         return {key: body}, code

--- a/tests/serial_compat_manifest.json
+++ b/tests/serial_compat_manifest.json
@@ -1,6 +1,6 @@
 {
  "discovery": {
-  "count": 2059,
+  "count": 2064,
   "identities": [
    "test_affected_tests.TestDiscoveryCache.test_a_new_commit_is_a_new_key_and_is_discovered_again",
    "test_affected_tests.TestDiscoveryCache.test_a_tree_that_cannot_answer_for_a_commit_falls_back_and_says_so",
@@ -1982,6 +1982,11 @@
    "tests.test_workspace_cases.contract_cases.TestScriptShape.test_the_module_docstring_names_what_the_deviation_is_read_against",
    "tests.test_workspace_cases.contract_cases.TestScriptShape.test_the_resolvers_are_imported_never_copied",
    "tests.test_workspace_cases.contract_cases.TestScriptShape.test_the_script_is_stdlib_only_and_network_free",
+   "tests.test_workspace_cases.document_cases.TestTheDocumentLaneObservesTheTreeItStandsIn.test_it_records_the_callers_tree_and_claims_no_git_fact",
+   "tests.test_workspace_cases.document_cases.TestTheDocumentLaneObservesTheTreeItStandsIn.test_start_observes_the_same_tree_establish_does",
+   "tests.test_workspace_cases.document_cases.TestTheRefusalSurvivesForWhatCannotBeGiven.test_an_explicit_required_override_is_still_refused_unstamped",
+   "tests.test_workspace_cases.document_cases.TestTheRefusalSurvivesForWhatCannotBeGiven.test_an_unconsulted_isolation_reproduces_the_field_refusal",
+   "tests.test_workspace_cases.document_cases.TestTheTrunkDispatchesAndLandsADocumentItem.test_a_content_pack_ticket_dispatches_and_lands_unisolated",
    "tests.test_workspace_cases.emission_cases.TestBaselineIsWrittenOnce.test_a_first_establishment_still_records_what_it_observed",
    "tests.test_workspace_cases.emission_cases.TestBaselineIsWrittenOnce.test_an_empty_stamp_is_no_stamp",
    "tests.test_workspace_cases.emission_cases.TestBaselineIsWrittenOnce.test_re_establishment_preserves_the_stamp_and_reports_what_it_saw",
@@ -2062,7 +2067,7 @@
    "tests.test_workspace_cases.start_cases.TestTheStampPreservesTheTicketsByteDomain.test_only_the_two_stamped_lines_differ_from_the_prior_bytes",
    "tests.test_workspace_cases.start_cases.TestTicketsPayloadIsGradedNotItsExitStatus.test_an_error_payload_returned_at_exit_zero_is_a_failure"
   ],
-  "sha256": "5dcd42bebcfc7c76d68a99e9da3259f7966c5ec0af26318e6137b966b76ad593"
+  "sha256": "3478f96357e4f3bc0d388053dbeb155e4ba3335e5caea0a64c27e14e343e4daf"
  },
  "mutation_owners": [
   {
@@ -5145,6 +5150,14 @@
    "restoration": "sharded-module-guard",
    "seams": [
     "environment"
+   ]
+  },
+  {
+   "module": "tests.test_workspace_cases.document_cases",
+   "owner": "TestTheRefusalSurvivesForWhatCannotBeGiven.test_an_unconsulted_isolation_reproduces_the_field_refusal",
+   "restoration": "selected-module-boundary",
+   "seams": [
+    "monkeypatch"
    ]
   },
   {

--- a/tests/test_workspace.py
+++ b/tests/test_workspace.py
@@ -16,6 +16,11 @@ from tests.test_workspace_cases.cli_cases import (  # noqa: F401
     NoFormatCallsTest,
     TestHelpAndVantage,
 )
+from tests.test_workspace_cases.document_cases import (  # noqa: F401
+    TestTheDocumentLaneObservesTheTreeItStandsIn,
+    TestTheRefusalSurvivesForWhatCannotBeGiven,
+    TestTheTrunkDispatchesAndLandsADocumentItem,
+)
 from tests.test_workspace_cases.contract_cases import (  # noqa: F401
     TestContractKeySeam,
     TestScriptShape,

--- a/tests/test_workspace_cases/document_cases.py
+++ b/tests/test_workspace_cases/document_cases.py
@@ -1,0 +1,229 @@
+"""The document lane: an adapter that establishes no candidate still dispatches.
+
+``document-tree`` gives no item a tree of its own -- its
+``establishes_isolation`` is False, so the item's derived isolation is
+``none`` -- and the establishment used to judge the adapter's strategy before
+it read that. Every content-pack ticket therefore refused at the dispatch
+trunk with ``adapter-not-establishable``, which is the refusal a live run hit
+and which nothing here had ever driven. What the lane records instead is the
+tree its caller stands in, carrying no branch and no baseline, and the return
+side skips integration and retirement as ``not isolated``.
+"""
+
+from datetime import datetime, timedelta, timezone
+from unittest import mock
+
+from .common import *  # noqa: F401,F403
+
+from scripts import workspace_candidate  # noqa: F401
+from scripts.tickets_format import parse_canonical_json
+
+REFUSAL = (
+    "adapter-not-establishable: document-tree does not establish a "
+    "candidate workspace"
+)
+CONTENT_PACK = "orch-content-pack"
+
+
+def document_fixture(tmp: Path, isolation=None):
+    """A sealed content-pack work item, and the plain tree it is dispatched in.
+
+    The tree is no checkout, deliberately: the whole claim of this lane is
+    that a document workspace needs no Git, and a fixture that handed it one
+    would prove nothing about the tickets that refused in the field.
+    """
+
+    sink = use_sink(tmp)
+    run_dir = sink / "tickets" / "testrun"
+    run_dir.mkdir(parents=True)
+    prose = tmp / "prose"
+    prose.mkdir()
+    ticket = make_ticket(run_dir, "T1", pack=CONTENT_PACK, isolation=isolation)
+    return ticket, prose
+
+
+class TestTheDocumentLaneObservesTheTreeItStandsIn(unittest.TestCase):
+    def test_it_records_the_callers_tree_and_claims_no_git_fact(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp = Path(tmp)
+            ticket, prose = document_fixture(tmp)
+
+            done = run_workspace(
+                prose, "establish", "testrun", "T1", "--repo", str(prose)
+            )
+
+            self.assertEqual(0, done.returncode, done.stdout + done.stderr)
+            self.assertEqual(
+                {
+                    "run": "testrun", "id": "T1", "ticket": str(ticket),
+                    "mechanism": "document-tree", "isolated": False,
+                    workspace.PATH_KEY: str(prose.resolve()),
+                    "workspace_root": str(prose.resolve()),
+                },
+                payload_of(done)["establish"],
+            )
+            self.assertEqual(str(prose.resolve()), recorded_workspace(ticket))
+            # a document revision is no commit: the two Git-only stamps are
+            # what `check` and `cutcheck` grade a candidate branch by, and an
+            # item that never had a branch may not carry either
+            stamped = ticket.read_text(encoding="utf-8")
+            self.assertNotIn(workspace.BRANCH_KEY, stamped)
+            self.assertNotIn(workspace.BASELINE_KEY, stamped)
+
+    def test_start_observes_the_same_tree_establish_does(self):
+        """`start` and `establish` are one lane here -- neither creates a
+        tree -- so the verb a caller reaches for may not change the answer."""
+
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp = Path(tmp)
+            ticket, prose = document_fixture(tmp)
+
+            done = run_workspace(prose, "start", "testrun", "T1")
+
+            self.assertEqual(0, done.returncode, done.stdout + done.stderr)
+            self.assertEqual(
+                str(prose.resolve()), payload_of(done)["start"][workspace.PATH_KEY]
+            )
+            self.assertEqual(str(prose.resolve()), recorded_workspace(ticket))
+
+
+class TestTheTrunkDispatchesAndLandsADocumentItem(unittest.TestCase):
+    """The path the field repro took, end to end: `tickets.py dispatch` on a
+    content-pack ticket, and then the return that has to answer for a tree
+    nothing cut and nothing can retire."""
+
+    def setUp(self):
+        self.temporary = tempfile.TemporaryDirectory()
+        self.sink = use_sink(Path(self.temporary.name))
+        self.tree = Path(self.temporary.name) / "prose"
+        self.tree.mkdir()
+
+    def tearDown(self):
+        self.temporary.cleanup()
+
+    def command(self, *arguments):
+        result = tickets._dispatch(list(arguments))
+        self.assertNotIn("error", result, result)
+        return result
+
+    def ticket_path(self) -> Path:
+        return self.sink / "tickets" / "run" / "T.md"
+
+    def sealed(self) -> str:
+        """This attempt's assignment seal, which `land` is identified by."""
+
+        data = tickets._parse_frontmatter(
+            self.ticket_path().read_text(encoding="utf-8")
+        )
+        state = parse_canonical_json(data["dispatch_v1"])
+        return state["attempts"][0]["assignment_seal"]
+
+    def test_a_content_pack_ticket_dispatches_and_lands_unisolated(self):
+        self.command(
+            "new", "run", "T", "--executor", "orch-execute",
+            "--goal", "Deliver the document.",
+            "--context", "The brief is authoritative.",
+            "--pack", CONTENT_PACK,
+        )
+        self.command("stamp-generation", "run", "T")
+        validated = self.command("draft-validate", "run", "T")
+        self.command(
+            "seal", "run", "T",
+            "--cut-generation", validated["draft_validation"]["cut_generation"],
+        )
+        self.command("ready", "--run", "run")
+        lease = (
+            datetime.now(timezone.utc) + timedelta(hours=1)
+        ).isoformat().replace("+00:00", "Z")
+
+        dispatched = self.command(
+            "dispatch", "run", "T", "--by", "worker", "--dispatch-id", "D1",
+            "--lease-expires-at", lease, "--workspace", str(self.tree),
+        )
+
+        # the launch names the tree the caller stands in, and it is the tree
+        # the establishment itself recorded -- not the `--workspace` argument
+        # relayed around it
+        self.assertIn(str(self.tree.resolve()), dispatched["launch"]["prompt"])
+        self.assertEqual(
+            str(self.tree.resolve()), recorded_workspace(self.ticket_path())
+        )
+        seal = self.sealed()
+        self.command("dispatch-outcome", "run", "T", "--note", "delivered")
+
+        landed = self.command(
+            "land", "run", "T", "--assignment-seal", seal, "--dispatch-id", "D1",
+            "--outcome-record-id", "outcome", "--by", "root-join",
+            "--status", "complete",
+        )
+
+        self.assertEqual("complete", landed["land"]["status"])
+        self.assertEqual(
+            [
+                {"step": "workspace-integrate", "outcome": "skipped",
+                 "reason": "not isolated"},
+                {"step": "workspace-retire", "outcome": "skipped",
+                 "reason": "not isolated"},
+            ],
+            [step for step in landed["land"]["steps"]
+             if step["step"].startswith("workspace-")],
+        )
+
+
+class TestTheRefusalSurvivesForWhatCannotBeGiven(unittest.TestCase):
+    """Two readings of the one refusal this fix narrowed rather than removed.
+
+    The first is a real ticket asking a non-establishing adapter for a
+    candidate outright. The second is the ordering the field repro came from,
+    restored by making the isolation answer what the pre-fix establishment
+    never asked it.
+    """
+
+    def test_an_explicit_required_override_is_still_refused_unstamped(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp = Path(tmp)
+            ticket, prose = document_fixture(tmp, isolation="required")
+            before = ticket.read_bytes()
+
+            done = run_workspace(
+                prose, "establish", "testrun", "T1", "--repo", str(prose)
+            )
+
+            self.assertEqual(1, done.returncode, done.stdout + done.stderr)
+            self.assertEqual(
+                {"code": 1, "error": REFUSAL, "verdict": "error"}, payload_of(done)
+            )
+            self.assertEqual(before, ticket.read_bytes())
+
+    def test_an_unconsulted_isolation_reproduces_the_field_refusal(self):
+        """The mutant. The pre-fix establishment never read the item's
+        isolation before judging the adapter's strategy, which is the same
+        answer as an isolation that always reads ``required``; restore that
+        one reading and the refusal a live run hit comes straight back.
+
+        Patched through the facade's own attribute, not through
+        ``scripts.tickets_adapters``: the flat installed layout gives the
+        facade its own copy of both modules, and that copy is the one the
+        establishment under test actually calls.
+        """
+
+        with tempfile.TemporaryDirectory() as tmp:
+            tmp = Path(tmp)
+            ticket, prose = document_fixture(tmp)
+            noise = io.StringIO()
+
+            with mock.patch.object(
+                workspace.workspace_candidate.tickets_adapters,
+                "derived_isolation",
+                return_value=workspace_candidate.REQUIRED,
+            ), redirect_stdout(noise), redirect_stderr(noise):
+                code = workspace.main(
+                    ["establish", "testrun", "T1", "--repo", str(prose)]
+                )
+
+            self.assertEqual(1, code, noise.getvalue())
+            self.assertEqual(
+                {"code": 1, "error": REFUSAL, "verdict": "error"},
+                json.loads(noise.getvalue().splitlines()[0]),
+            )
+            self.assertIsNone(recorded_workspace(ticket))


### PR DESCRIPTION
Blocking regression: dispatching any content-pack (document-tree adapter) ticket through the trunk refused `adapter-not-establishable` — `workspace_candidate._establishment` judged the adapter's strategy before reading the derived isolation, so a derived-none read-only ticket could never dispatch, though land already handles the not-isolated case. The content lane had never been driven through the trunk; found by the first self-improve run on the new machinery.

- Isolation is read first; the refusal narrows to its real subject: an explicit `isolation: required` override on an adapter that establishes none (can-fail pinned verbatim).
- `_evidence` generalized to `_unisolated` — the one owner of recording a directory as a workspace claiming no Git fact; a document observation carries `isolated: false` and neither branch nor baseline (a stamped HEAD would hand the join a Git grade for work Git never carried).
- New trunk-path tests drive a content ticket end-to-end; the pre-fix source fails them with the field repro verbatim.
- No contract changed — `work-item.md`'s existing T0 record already promised recording for every supported adapter; the code was narrower than its own law.

Gates: `run_required --no-cache` 0 + `preflight` 0 at the tip. Known and chipped: `workspace_candidate.py` now at 509/510 lines; the integrate/retire seam is the split.

🤖 Generated with [Claude Code](https://claude.com/claude-code)