### PR TITLE
super-research: read the video's publish date where YouTube still publishes it

### DIFF
--- a/.orchflows/skills/super-research/references/evidence.md
+++ b/.orchflows/skills/super-research/references/evidence.md
@@ -161,3 +161,40 @@ What this sweep does not cover: no read touched TikTok or Instagram search
 (TikTok's `oembed` answered 400; Instagram's hashtag pages are login-walled),
 Mastodon's status search (empty without a credential), or Lemmy, and none of
 those ships. Every row is one host, one network, one moment.
+
+## The player metadata measurement of 2026-08-31
+
+One Windows 11 host, unauthenticated, through this package's own transport,
+after the `youtube_innertube` smoke reported its video row missing
+`published_at`. Bounded player reads of one held video (`dQw4w9WgXcQ`) across
+nine clients, and one read of an eleven-character id the origin does not hold.
+Two rows here supersede claims above.
+
+- **Every client answered `OK` with caption tracks has lost `microformat`.**
+  `ANDROID 20.10.38` (the pinned version), `ANDROID 20.34.42`, `IOS 20.10.4`
+  and `ANDROID_VR 1.62.27` all answered 200 `OK` with `videoDetails`, six
+  caption tracks, and no `microformat` key; a whole-body scan of the `ANDROID`
+  answer found no `publishDate`, no `uploadDate`, and no date value anywhere in
+  its 247 KB. The publish date is gone from the app-client player surface
+  entirely, not moved within it.
+- **`WEB` and `MWEB` still carry the date, and now as a full instant.**
+  Both answered 200 `UNPLAYABLE`, reason `Video unavailable`, **with** the
+  complete `videoDetails` (`title`, exact `viewCount`, `author`,
+  `shortDescription`) and `microformat.playerMicroformatRenderer` —
+  `publishDate: 2009-10-24T23:57:33-07:00`, an offset instant where the
+  2026-08-10 era wrote a bare day — and no caption track and no
+  `streamingData`. The origin serves the row and withholds the playback.
+  `WEB_REMIX` answered `UNPLAYABLE` without `microformat`; `TVHTML5`,
+  `WEB_EMBEDDED_PLAYER`, `TVHTML5_SIMPLY_EMBEDDED_PLAYER` and `WEB_CREATOR`
+  refused with no `videoDetails` at all. No client carries both halves: date
+  and captions now live on disjoint client families, which is why the `player`
+  metadata operation presents `WEB` and the transcript's player read presents
+  `ANDROID`.
+- **The unheld side of the 2026-08-12 axis is now measured.** The unheld id
+  answered 200 `ERROR` with no `videoDetails` and no `microformat`; the held
+  video's refusal carried both. The reason string was byte-identical on the
+  two sides, so the reason and the status still decide nothing — the served or
+  unserved row beside them is the discriminator, and it is the one
+  `_player_page` branches on.
+
+Every row is one host, one network, one moment.

--- a/.orchflows/skills/super-research/scripts/super_research/adapters/_support/youtube_innertube_contract.py
+++ b/.orchflows/skills/super-research/scripts/super_research/adapters/_support/youtube_innertube_contract.py
@@ -6,6 +6,16 @@ from .. import AdapterDescriptor, VolatileIdentifier
 
 CLIENT_NAME = "WEB"
 CLIENT_VERSION = "2.20260808.00.00"
+
+# The client the transcript operation's player read presents, and the only
+# read that presents it. Measured 2026-08-17: `ANDROID` at this version
+# answers playability `OK` with a populated caption track list, keyless,
+# where `WEB` is served none. Measured 2026-08-31: that same answer carries
+# no `microformat` — a whole-body scan found no date field anywhere in it,
+# on `IOS` and `ANDROID_VR` alike — while `WEB` still carries `publishDate`
+# beside a complete `videoDetails`. So the `player` metadata operation
+# presents the web client above, and this one exists for the caption listing
+# alone.
 PLAYER_CLIENT_NAME = "ANDROID"
 PLAYER_CLIENT_VERSION = "20.10.38"
 

--- a/.orchflows/skills/super-research/scripts/super_research/adapters/_support/youtube_innertube_pages.py
+++ b/.orchflows/skills/super-research/scripts/super_research/adapters/_support/youtube_innertube_pages.py
@@ -184,10 +184,11 @@ def _playability_warning(playability: Mapping[str, Any]) -> str:
     if status in ATTESTED_PLAYABILITY:
         return said + (
             " The 2026-08-10 probes recorded this status across five clients and three"
-            " videos and names the cause as PoToken/BotGuard attestation;"
-            " caption retrieval and attestation are deferred by the spec. The"
+            " videos and names the cause as PoToken/BotGuard attestation. The"
             " origin's own reason is quoted above: this status is also what it"
-            " answers for a video it no longer holds."
+            " answers for a video it no longer holds, and the 2026-08-31"
+            " measurement tells the two apart by the payload beside it — a held"
+            " video answers with its videoDetails, an unheld id without them."
         )
     if status in CREDENTIAL_PLAYABILITY:
         return said + (
@@ -207,28 +208,48 @@ def _player_page(response: transport.TransportResponse, payload: Any) -> NativeP
     if not isinstance(playability, Mapping):
         return _drifted(response, PLAYER_OPERATION, "stated no " + PLAYABILITY_KEY)
     status = _text(playability.get(PLAYABILITY_STATUS_KEY))
-    if status != PLAYABLE_STATUS:
-        return _failed(response, _playability_loss(status), _playability_warning(playability))
     details = payload.get(VIDEO_DETAILS_KEY)
     if not isinstance(details, Mapping):
+        # Measured 2026-08-31, both sides on the web client: a held video
+        # answers its non-`OK` playability *with* `videoDetails` beside it,
+        # and an id the origin does not hold answers without them, under a
+        # byte-identical reason string. The details are the one part of the
+        # answer that tells the two apart, so a refusal is only a refusal of
+        # the whole read when it carried none.
+        if status != PLAYABLE_STATUS:
+            return _failed(
+                response, _playability_loss(status), _playability_warning(playability)
+            )
         return _drifted(response, PLAYER_OPERATION, "stated no " + VIDEO_DETAILS_KEY)
     withheld = captions_withheld(payload)
-    return _answered(
-        response,
-        (_player_record(payload, withheld),),
-        "ok",
-        warnings=(
-            "{0} answered 200 listing no caption track at {1}. The 2026-08-10 probes"
-            " measured that on every client and every video probed and names"
-            " the cause as PoToken/BotGuard attestation: the tracks are"
-            " withheld from a client that cannot attest, and this is not a"
+    loss: Tuple[str, ...] = ()
+    warnings: Tuple[str, ...] = ()
+    if status != PLAYABLE_STATUS:
+        # The origin served the row and refused the playback beside it. That
+        # is the web client's standing keyless posture (measured 2026-08-31),
+        # and the loss is what keeps this answer tellable apart from a healthy
+        # one rather than the row being thrown away with the playback.
+        loss = (_playability_loss(status),)
+        warnings = (_playability_warning(playability),)
+    if withheld and ATTESTATION_REQUIRED not in loss:
+        loss = loss + (ATTESTATION_REQUIRED,)
+    if withheld:
+        warnings = warnings + (
+            "{0} answered 200 listing no caption track at {1}. Measured"
+            " 2026-08-31: the web-family clients are served no track on any"
+            " video — the tracks sit behind an attestation this package does"
+            " not perform — while the Android client the transcript operation"
+            " presents is served them where a video has them. This is not a"
             " statement that the video has none.".format(
                 PLAYER_OPERATION, ".".join(CAPTION_TRACKS_PATH)
             ),
         )
-        if withheld
-        else (),
-        loss=(ATTESTATION_REQUIRED,) if withheld else (),
+    return _answered(
+        response,
+        (_player_record(payload, withheld),),
+        "ok",
+        warnings=warnings,
+        loss=loss,
     )
 
 

--- a/.orchflows/skills/super-research/scripts/super_research/adapters/youtube_innertube.py
+++ b/.orchflows/skills/super-research/scripts/super_research/adapters/youtube_innertube.py
@@ -247,12 +247,17 @@ def fetch_native_page(
             native_order=NATIVE_ORDER,
         )
 
+    # Every metadata operation presents the web client, `player` included.
+    # Measured 2026-08-31: the app clients' player answers — `ANDROID` at the
+    # pinned version and a newer one, `IOS`, `ANDROID_VR` — stopped carrying
+    # `microformat`, and a whole-body scan found no date field anywhere in
+    # them, while `WEB` still carries `publishDate` beside a complete
+    # `videoDetails`. What `WEB` is not served is captions, which is why the
+    # transcript branch above alone presents the Android client.
     params = {
         "endpoint": operation,
-        "client_name": PLAYER_CLIENT_NAME if operation == PLAYER_OPERATION else CLIENT_NAME,
-        "client_version": (
-            PLAYER_CLIENT_VERSION if operation == PLAYER_OPERATION else CLIENT_VERSION
-        ),
+        "client_name": CLIENT_NAME,
+        "client_version": CLIENT_VERSION,
     }
     if request.cursor:
         params["continuation"] = request.cursor

--- a/.orchflows/skills/super-research/tests/fixtures/youtube/attestation_cases.json
+++ b/.orchflows/skills/super-research/tests/fixtures/youtube/attestation_cases.json
@@ -1,6 +1,6 @@
 {
-  "source": "route measurements of 2026-08-10, (YouTube)",
-  "note": "The false-capability trap this whole half exists for. Across WEB, MWEB, TVHTML5, ANDROID and IOS on three videos, captionTracks came back empty every time, and playability degraded to UNPLAYABLE after the first metadata call. The evidence names the cause: PoToken/BotGuard attestation. An adapter that reported that as 'this video has no captions' would assert something false about the video, and one that reported the UNPLAYABLE as a credential problem would call a keyless route credentialed. `captions_withheld` is the column the caption oracle reads: true where the response listed no caption track, false where it listed some, and null where the case is not a player call at all. The row listing tracks is not a shape this package has ever measured - it exists so that 'empty means withheld' can be false, without which the claim would be satisfied by typing every player response the same way.",
+  "source": "route measurements of 2026-08-10, (YouTube), amended by the player metadata measurement of 2026-08-31",
+  "note": "The false-capability trap this whole half exists for. Across WEB, MWEB, TVHTML5, ANDROID and IOS on three videos, captionTracks came back empty every time, and playability degraded to UNPLAYABLE after the first metadata call. The evidence names the cause: PoToken/BotGuard attestation. An adapter that reported that as 'this video has no captions' would assert something false about the video, and one that reported the UNPLAYABLE as a credential problem would call a keyless route credentialed. Measured 2026-08-31: the WEB client answers UNPLAYABLE on a held video *with* the complete videoDetails and microformat beside it, and ERROR on an unheld id with neither, under a byte-identical reason string — so a refusal carrying the row is a served answer with its playback withheld, and only one carrying no videoDetails refuses the read. `captions_withheld` is the column the caption oracle reads: true where the response listed no caption track, false where it listed some, and null where the case is not a player call at all. The row listing tracks is not a shape this package has ever measured - it exists so that 'empty means withheld' can be false, without which the claim would be satisfied by typing every player response the same way.",
   "cases": [
     {
       "case_name": "search_results_200",
@@ -65,8 +65,30 @@
       "body_fixture": "player_unplayable.json",
       "captions_withheld": true,
       "expected_loss": "attestation_required",
+      "expected_outcome": "ok",
+      "evidence": "measured 2026-08-31: the WEB client answers UNPLAYABLE with the complete videoDetails beside it on every held video, keylessly — the origin serves the row and withholds the playback. The row is kept and the loss says what was withheld, so a degraded answer stays tellable apart from a healthy one by its loss rather than by throwing the served row away. The body's 'Sign in to confirm you're not a bot' is still not read: a keyless route is not called credentialed because a body used the word sign in"
+    },
+    {
+      "case_name": "player_web_metadata_unplayable_200",
+      "target_id": "player:dQw4w9WgXcQ",
+      "cursor": "",
+      "status": 200,
+      "body_fixture": "player_web_metadata_unplayable.json",
+      "captions_withheld": true,
+      "expected_loss": "attestation_required",
+      "expected_outcome": "ok",
+      "evidence": "measured 2026-08-31 on the WEB client against a held video: 200, UNPLAYABLE, reason 'Video unavailable', and the complete videoDetails and microformat beside it — publishDate now a full instant with an offset rather than a bare day. This is the shape the player metadata operation reads since the app clients' answers dropped microformat entirely (ANDROID at two versions, IOS and ANDROID_VR, a whole-body scan finding no date field in any of them)"
+    },
+    {
+      "case_name": "player_unheld_200",
+      "target_id": "player:aaaaaaaaaa1",
+      "cursor": "",
+      "status": 200,
+      "body_fixture": "player_unheld.json",
+      "captions_withheld": true,
+      "expected_loss": "attestation_required",
       "expected_outcome": "failed",
-      "evidence": "measured: later player calls answered 200 with UNPLAYABLE across five clients and three videos, and the evidence names the cause. The body carries a full videoDetails and the words 'Sign in to confirm you're not a bot'; neither is read — a degraded response is not mined for metadata, and a keyless route is not called credentialed because a body used the word sign in"
+      "evidence": "measured 2026-08-31 on the WEB client against an id the origin does not hold: 200, ERROR, reason 'Video unavailable' — byte-identical to the held video's — and no videoDetails at all. The absent details are what refuse this read; the reason string decides nothing"
     },
     {
       "case_name": "stale_client_version_400",

--- a/.orchflows/skills/super-research/tests/fixtures/youtube/player_unheld.json
+++ b/.orchflows/skills/super-research/tests/fixtures/youtube/player_unheld.json
@@ -1,0 +1,21 @@
+{
+  "responseContext": {
+    "visitorData": "CgtSaWNrQXN0bGV5EgQIARgA"
+  },
+  "playabilityStatus": {
+    "status": "ERROR",
+    "reason": "Video unavailable",
+    "errorScreen": {
+      "playerErrorMessageRenderer": {
+        "reason": {
+          "simpleText": "Video unavailable"
+        },
+        "icon": {
+          "iconType": "ERROR_OUTLINE"
+        }
+      }
+    },
+    "contextParams": "Q0FBU0FnZ0E="
+  },
+  "trackingParams": "CAAQu2kiEwjB0YKZlMuWAxWcxRYJHTvjGiw="
+}

--- a/.orchflows/skills/super-research/tests/fixtures/youtube/player_web_metadata_unplayable.json
+++ b/.orchflows/skills/super-research/tests/fixtures/youtube/player_web_metadata_unplayable.json
@@ -1,0 +1,56 @@
+{
+  "responseContext": {
+    "visitorData": "CgtSaWNrQXN0bGV5EgQIARgA"
+  },
+  "playabilityStatus": {
+    "status": "UNPLAYABLE",
+    "reason": "Video unavailable",
+    "errorScreen": {
+      "playerErrorMessageRenderer": {
+        "subreason": {
+          "simpleText": "The page needs to be reloaded."
+        },
+        "reason": {
+          "runs": [
+            {
+              "text": "The page needs to be reloaded."
+            }
+          ]
+        }
+      }
+    }
+  },
+  "videoDetails": {
+    "videoId": "dQw4w9WgXcQ",
+    "title": "Rick Astley - Never Gonna Give You Up (Official Video) (4K Remaster)",
+    "lengthSeconds": "213",
+    "channelId": "UCuAXFkgsw1L7xaCfnd5JJOw",
+    "author": "Rick Astley",
+    "viewCount": "1810202961",
+    "shortDescription": "The official video for “Never Gonna Give You Up” by Rick Astley.",
+    "isCrawlable": true,
+    "isPrivate": false,
+    "isLiveContent": false
+  },
+  "microformat": {
+    "playerMicroformatRenderer": {
+      "publishDate": "2009-10-24T23:57:33-07:00",
+      "uploadDate": "2009-10-24T23:57:33-07:00",
+      "ownerChannelName": "Rick Astley",
+      "externalChannelId": "UCuAXFkgsw1L7xaCfnd5JJOw",
+      "externalVideoId": "dQw4w9WgXcQ",
+      "viewCount": "1810202961",
+      "category": "Music",
+      "isFamilySafe": true,
+      "isUnlisted": false,
+      "lengthSeconds": "214",
+      "likeCount": "19364969",
+      "canonicalUrl": "https://www.youtube.com/watch?v=dQw4w9WgXcQ",
+      "embed": {
+        "iframeUrl": "https://www.youtube.com/embed/dQw4w9WgXcQ",
+        "width": 1280,
+        "height": 720
+      }
+    }
+  }
+}

--- a/.orchflows/skills/super-research/tests/test_adapters_cases/youtube_attestation.py
+++ b/.orchflows/skills/super-research/tests/test_adapters_cases/youtube_attestation.py
@@ -213,7 +213,7 @@ class AttestationIsNotAnAbsenceTest(unittest.TestCase):
         warning = " ".join(page.warnings)
 
         self.assertEqual(page.loss, (youtube_innertube.ATTESTATION_REQUIRED,))
-        self.assertEqual(page.outcome, "failed")
+        self.assertEqual(page.outcome, "ok")
         self.assertNotIn(youtube_innertube.AUTH_REQUIRED, page.loss)
         self.assertIn("UNPLAYABLE", warning)
         self.assertIn("bot", warning)
@@ -257,16 +257,39 @@ class AttestationIsNotAnAbsenceTest(unittest.TestCase):
                     status in youtube_innertube.ATTESTED_PLAYABILITY,
                 )
 
-    def test_a_degraded_answer_is_not_mined_for_the_metadata_it_still_carries(self):
-        # That fixture carries a complete videoDetails. The origin said it was
-        # not serving this client, so reporting its contents as a successful
-        # read would make a degraded response indistinguishable from a healthy
-        # one at exactly the moment a caller needs to tell them apart.
+    def test_a_degraded_answer_keeps_the_row_the_origin_served(self):
+        # Measured 2026-08-31: `UNPLAYABLE` with `videoDetails` beside it is
+        # the web client's standing keyless posture on a held video — the
+        # origin serves the row and withholds the playback. The row is kept,
+        # and the loss is what keeps a degraded answer tellable apart from a
+        # healthy one at exactly the moment a caller needs to tell them apart
+        # — throwing the served row away told nothing apart and cost the date
+        # the roster row names.
         page, _ = youtube_page("player_unplayable.json")
+        record = page.records[0]
 
-        self.assertEqual(page.records, ())
-        self.assertIn(
-            "Running a 70B locally", read_youtube("player_unplayable.json")
+        self.assertEqual(page.outcome, "ok")
+        self.assertEqual(page.loss, (youtube_innertube.ATTESTATION_REQUIRED,))
+        self.assertEqual(record.title, "Running a 70B locally on two consumer GPUs")
+        self.assertIn(youtube_innertube.ATTESTATION_REQUIRED, record.loss)
+
+    def test_the_web_answer_of_2026_08_31_carries_the_row_with_a_full_instant(self):
+        # The shape the metadata operation reads now that the app clients'
+        # answers carry no date at all. The origin writes `publishDate` as an
+        # instant with an offset rather than a bare day, so the record
+        # converts it to UTC and claims no day-precision loss.
+        page, _ = youtube_page("player_web_metadata_unplayable.json")
+        record = page.records[0]
+
+        self.assertEqual(page.outcome, "ok")
+        self.assertEqual(page.loss, (youtube_innertube.ATTESTATION_REQUIRED,))
+        self.assertEqual(record.published_at, "2009-10-25T06:57:33Z")
+        self.assertNotIn(youtube_innertube.DATE_PRECISION_ONLY, record.loss)
+        self.assertEqual(
+            dict(record.engagement), {youtube_innertube.VIEW_COUNT_METRIC: 1810202961}
+        )
+        self.assertEqual(
+            record.canonical_locator, "https://www.youtube.com/embed/" + YOUTUBE_VIDEO_ID
         )
 
     def test_a_refused_request_names_the_rotating_part_and_the_way_back(self):

--- a/.orchflows/skills/super-research/tests/test_adapters_cases/youtube_oracles_and_calls.py
+++ b/.orchflows/skills/super-research/tests/test_adapters_cases/youtube_oracles_and_calls.py
@@ -1,32 +1,24 @@
 from tests.test_adapters_cases.youtube_attestation import *  # noqa: F401,F403
 
-class TheUnheldVideoIsNotToldFromTheWithheldOneTest(unittest.TestCase):
-    """The measured negative, pinned: these two answers arrive as one answer.
+class TheUnheldVideoIsToldByItsAbsentDetailsTest(unittest.TestCase):
+    """The measured discriminator: absent details refuse the read, present ones do not.
 
-    Measured 2026-08-12, the only live player reads this package has ever made.
-    An id the origin does not hold answered 200 with playability ``ERROR``;
-    ``dQw4w9WgXcQ``, attested, answered 200 with ``UNPLAYABLE``. The reason
-    string was byte-identical on both sides. ``videoDetails`` was absent from
-    the unheld answer and its presence on the attested one was never observed —
-    :func:`_player_page` returns at the playability branch before it reads that
-    key — so that axis has one measured side and no comparison.
-
-    So this package does not tell a video the origin no longer holds from one it
-    withholds, and nothing here may imply that it does. ``ERROR`` is not a
-    signature of "gone": the 2026-08-10 probes recorded it across five clients and
-    three videos that existed. One observation of one id is not a law either,
-    which is why these rows pin the fusion and nothing beyond it — **no loss
-    code is named**, so a later, better-warranted typing that moves both
-    statuses together stays green here, and one that moves only one of them
-    reddens.
-
-    Reopening it takes one bounded read of a video the origin certainly holds,
-    capturing ``videoDetails`` presence beside ``playabilityStatus.status`` in
-    the raw payload. Until that read is made, this is the record of what is not
-    known.
+    The 2026-08-12 record left the ``videoDetails`` axis measured on one side
+    only, and this class used to pin that nothing branched on it. The reopen
+    condition it named — one bounded read of a video the origin certainly
+    holds, capturing ``videoDetails`` presence beside
+    ``playabilityStatus.status`` in the raw payload — was met 2026-08-31, on
+    the web client, on both sides: ``dQw4w9WgXcQ`` answered 200 ``UNPLAYABLE``
+    *with* its complete ``videoDetails`` and ``microformat``, and an
+    eleven-character id the origin does not hold answered 200 ``ERROR`` with
+    neither. The reason string was byte-identical on both sides — "Video
+    unavailable" — so the reason still decides nothing, and the statuses still
+    do not either: what tells a held video's degraded answer from an unheld
+    id's refusal is the row the origin served or did not serve beside it.
     """
 
-    # Both sides of the probe answered with this string, byte for byte.
+    # Both sides of the probe answered with this string, byte for byte —
+    # measured 2026-08-12 and again 2026-08-31.
     MEASURED_REASON = "Video unavailable"
 
     def refusal(self, status, details=None):
@@ -46,6 +38,10 @@ class TheUnheldVideoIsNotToldFromTheWithheldOneTest(unittest.TestCase):
         return page
 
     def test_the_two_measured_statuses_reach_a_caller_as_one_answer(self):
+        # Without details, `ERROR` and `UNPLAYABLE` are still one answer:
+        # neither carried anything to keep, and neither status alone is a
+        # signature of "gone" — the 2026-08-10 probes recorded both on videos
+        # that existed.
         unheld = self.refusal("ERROR")
         attested = self.refusal("UNPLAYABLE")
 
@@ -57,19 +53,24 @@ class TheUnheldVideoIsNotToldFromTheWithheldOneTest(unittest.TestCase):
         for page in (unheld, attested):
             self.assertIn("a video it no longer holds", " ".join(page.warnings))
 
-    def test_the_axis_measured_on_one_side_only_is_not_branched_on(self):
-        # A refused playability carrying `videoDetails` is a shape nobody has
-        # measured, constructed for the same reason
-        # `player_with_caption_tracks.json` is: so that "this package reads that
-        # key to decide which refusal this is" can be false. Presence is the
-        # candidate signal the probe could only see one side of, and reading it
-        # here would be the mirror of the inference this module refuses.
+    def test_a_refusal_carrying_the_row_is_a_served_answer_and_one_without_is_not(self):
+        # The 2026-08-31 measurement, replayed on the shapes it recorded: the
+        # held side keeps its record with the withholding named as loss, and
+        # the unheld side is the refusal of the whole read.
         absent = self.refusal("ERROR")
-        present = self.refusal("ERROR", details={youtube_innertube.VIDEO_ID_KEY: "x"})
+        present = self.refusal(
+            "UNPLAYABLE",
+            details={
+                youtube_innertube.VIDEO_ID_KEY: YOUTUBE_VIDEO_ID,
+                youtube_innertube.TITLE_KEY: "held",
+            },
+        )
 
-        self.assertEqual(tuple(present.loss), tuple(absent.loss))
-        self.assertEqual(present.outcome, absent.outcome)
-        self.assertEqual(present.records, ())
+        self.assertEqual(absent.outcome, "failed")
+        self.assertEqual(absent.records, ())
+        self.assertEqual(present.outcome, "ok")
+        self.assertEqual(len(present.records), 1)
+        self.assertIn(youtube_innertube.ATTESTATION_REQUIRED, present.loss)
 
 
 class AttestationOracleCanFailTest(unittest.TestCase):

--- a/.orchflows/skills/super-research/tests/test_adapters_cases/youtube_viewmodels_and_player.py
+++ b/.orchflows/skills/super-research/tests/test_adapters_cases/youtube_viewmodels_and_player.py
@@ -331,11 +331,12 @@ class InnerTubeDescriptorTest(unittest.TestCase):
         declared = youtube_innertube.DESCRIPTOR.volatile_identifiers
 
         # Two clients rotate on this route since 2026-08-17: the web one every
-        # operation but `player` presents, and the Android one `player` and the
-        # transcript operation present because it is the one served caption
-        # tracks. Each is a separate identifier with a separate procedure —
-        # they rotate on separate schedules and are recovered from separate
-        # places.
+        # metadata operation presents — `player` included since 2026-08-31,
+        # when the app clients' answers dropped the publish date — and the
+        # Android one the transcript operation's player read presents because
+        # it is the one served caption tracks. Each is a separate identifier
+        # with a separate procedure — they rotate on separate schedules and
+        # are recovered from separate places.
         self.assertEqual(len(declared), 2)
         self.assertIn(youtube_innertube.CLIENT_VERSION, declared[0].name)
         self.assertIn(youtube_innertube.CLIENT_NAME, declared[0].name)
@@ -349,21 +350,31 @@ class InnerTubeDescriptorTest(unittest.TestCase):
         self.assertIn("_INNERTUBE_CLIENTS", declared[1].recovery)
 
     def test_the_client_version_goes_out_in_the_body_the_route_shapes(self):
-        # `player` presents the Android client, which is the one served caption
-        # tracks; `search` presents the web client whose key the route carries.
-        # Both go out in the body the route shapes, and neither is anywhere a
-        # caller could set.
+        # `player` and `search` present the web client — since 2026-08-31 the
+        # app clients' player answers carry no date at all, so the metadata
+        # operations share one client. The transcript operation's player read
+        # alone presents the Android client, which is the one served caption
+        # tracks. All go out in the body the route shapes, and none is
+        # anywhere a caller could set.
         _, player_opener = youtube_page("player_metadata.json")
         played = json.loads(player_opener.opened[0].body)["context"]["client"]
         _, search_opener = youtube_page(
             "search_results.json", target_id=YOUTUBE_SEARCH_TARGET
         )
         searched = json.loads(search_opener.opened[0].body)["context"]["client"]
+        _, transcript_opener = youtube_page(
+            "player_android_captions.json", target_id="transcript:ggdyD2Un5zo"
+        )
+        transcribed = json.loads(transcript_opener.opened[0].body)["context"]["client"]
 
-        self.assertEqual(played["clientName"], youtube_innertube.PLAYER_CLIENT_NAME)
-        self.assertEqual(played["clientVersion"], youtube_innertube.PLAYER_CLIENT_VERSION)
+        self.assertEqual(played["clientName"], youtube_innertube.CLIENT_NAME)
+        self.assertEqual(played["clientVersion"], youtube_innertube.CLIENT_VERSION)
         self.assertEqual(searched["clientName"], youtube_innertube.CLIENT_NAME)
         self.assertEqual(searched["clientVersion"], youtube_innertube.CLIENT_VERSION)
+        self.assertEqual(transcribed["clientName"], youtube_innertube.PLAYER_CLIENT_NAME)
+        self.assertEqual(
+            transcribed["clientVersion"], youtube_innertube.PLAYER_CLIENT_VERSION
+        )
 
     def test_it_declares_the_reply_metric_it_reports_and_no_comment_metric(self):
         # A comment carries a count of its replies; nothing in these three

--- a/.orchflows/skills/super-research/tests/test_cli_cases/liveness.py
+++ b/.orchflows/skills/super-research/tests/test_cli_cases/liveness.py
@@ -201,10 +201,18 @@ class TheRecoveryLineFitsTheLossTest(LedgerHoldingCase):
         self.assertIn(cli.READ_AND_ROW_UNMET, printed)
 
     def test_an_origin_withholding_from_an_unattested_client_is_not_one_either(self):
-        # Read 9 of the thirteen.
+        # Read 9 of the thirteen: 200, `UNPLAYABLE`, and no `videoDetails`
+        # beside it — the shape that read recorded. A held video's
+        # `UNPLAYABLE` now arrives *with* its row and is a served answer
+        # (measured 2026-08-31), so the row-less refusal is built here as the
+        # 2026-08-12 read saw it rather than seeded from a fixture that
+        # carries the row.
         seeds = probe_seeds()
         seeds["youtube_innertube"] = (
-            200, payload("youtube/player_unplayable.json"), "application/json"
+            200,
+            '{"playabilityStatus": {"status": "UNPLAYABLE",'
+            ' "reason": "Sign in to confirm you\'re not a bot"}}',
+            "application/json",
         )
 
         code, printed, _ = run_cli(


### PR DESCRIPTION
The `youtube_innertube` smoke failed its roster row on `published_at`. Measured 2026-08-31, both halves of the cause: every app client (ANDROID at two versions, IOS, ANDROID_VR) answers `player` OK with caption tracks and **no date field anywhere in the body**, while WEB/MWEB still carry `microformat.playerMicroformatRenderer.publishDate` — now a full offset instant — beside a complete `videoDetails`, answering UNPLAYABLE keylessly with no captions. No client carries both halves.

- The `player` metadata operation presents the WEB client; the transcript's player read alone keeps ANDROID (the one family still served caption tracks).
- `_player_page` gates the row on `videoDetails` presence: a refusal carrying the row is a served answer with its playback withheld (`ok` + `attestation_required`), one carrying none refuses the read. The 2026-08-12 unheld-vs-withheld axis was measured on both sides the same day — held answers with details, unheld without, reason string byte-identical — meeting the reopen condition the old covenant test named for itself.
- New evidence.md section records the measurement; two fixtures trimmed from the live captures pin both shapes in the measured case table.

Verification: live smoke exits 0 with the roster row carried in full (`published_at = 2009-10-25T06:57:33Z`), the offline suite passes (1262 tests), and all five required checks pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)