### PR TITLE
Rename the routing lanes to self-explanatory words

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,15 +75,15 @@ Nothing marks "done" except an external check passing.
 
 ## More ways to use it
 
-Routing projects four lanes, smallest need first: `act` when evidence
+Routing projects four lanes, smallest need first: `direct` when evidence
 already decides and a change this session can make, check narrowly, and
-record in its own medium's history; `brick` — one `tickets.py do` or
-`judge`, for work wanting isolation or a checked landing; `frame` for
+record in its own medium's history; `worker` — one `tickets.py do` or
+`judge`, for work wanting isolation or a checked landing; `team` for
 work needing parallel children, resume, or an audit trail; and
-`outline` when the goal itself is unresolved — a planning `orch-do`
-freezes and seals the root before `frame` drives it. Tripwires promote
-on evidence, never prediction: a second concern mid-`act` enters
-`brick`, a child's scope splitting enters `frame`, and an unknown or
+`plan` when the goal itself is unresolved — a planning `orch-do`
+freezes and seals the root before `team` drives it. Tripwires promote
+on evidence, never prediction: a second concern mid-`direct` enters
+`worker`, a child's scope splitting enters `team`, and an unknown or
 unverified cause investigates before anything edits. Everything else
 runs only when you name it, so the routing table never
 grows as the library does. The table is installed at
@@ -183,8 +183,8 @@ details:
 
 ```mermaid
 flowchart TD
-    frame["tickets.py frame-open — the invocation's journal"] --> outline["orch-do (planning) — freeze one root ticket"]
-    outline --> pack{"stamp a domain pack per call"}
+    frame["tickets.py frame-open — the invocation's journal"] --> plan["orch-do (planning) — freeze one root ticket"]
+    plan --> pack{"stamp a domain pack per call"}
     pack --> brick["tickets.py do / judge — one launch per call"]
     brick --> exec["the child"]
     exec --> join["tickets.py land — each return crosses once"]

--- a/docs/vocabulary.md
+++ b/docs/vocabulary.md
@@ -58,9 +58,9 @@ that needs a different meaning needs a different word.
   planning `orch-do`, which freezes and seals a semantic root at intake;
   orch-slice retired with the decomposed root itself, its craft surviving
   as the planning sections below. No dispatch revives any of them; the noun
-  **spec** (below) is unrenamed,
-  and **outline** survives only as the routing shape (below) that reaches a
-  planning `orch-do`.
+  **spec** (below) is unrenamed, and **outline** has now fully retired too —
+  its one remaining live use, naming the routing shape's planning lane
+  (below), is superseded by **plan**.
 - **pack** — a T2 package of pure data satisfying the pack signature; a pack
   binds cells and never contains control flow.
 - **cell** — one field of the pack signature: `adapter`, `stages`, and
@@ -167,17 +167,18 @@ that needs a different meaning needs a different word.
 - **routing shape** — the host projection selected before execution, four
   lanes routed smallest-first and normatively defined by the host block's
   routes paragraph (`templates/host-block.md`, installed at
-  `~/.orchflows/host-block.md`): **act** — context evidence decides, and a
+  `~/.orchflows/host-block.md`): **direct** — context evidence decides, and a
   change this session can make, check narrowly, and record in the medium's
-  own history it makes itself; **brick** — one `do` (or `judge` over handed
+  own history it makes itself; **worker** — one `do` (or `judge` over handed
   artifacts), wanting isolation, a fresh context, or a checked landing;
-  **frame** — parallel children, resume, or an audit trail; **outline** — the
+  **team** — parallel children, resume, or an audit trail; **plan** — the
   goal itself is unresolved, so a planning `orch-do` seals the root before
-  `frame` drives it. Named tripwires promote on evidence, never prediction,
+  `team` drives it. Named tripwires promote on evidence, never prediction,
   and live only in the host block — this entry names the lanes, not their
-  triggers. `answer`, `single`, `graph`, and `fix` are the retired names for
-  this shape; `brick` and `frame` double as lane name and noun, the same
-  benign metonymy `graph` was.
+  triggers. `act`, `brick`, `frame`, `outline`, `answer`, `single`, `graph`,
+  and `fix` are the retired names for this shape; `brick` and `frame` no
+  longer double as lane name and noun — the words stay for the ticket-tree
+  nouns below, and the lane took `worker` and `team` instead.
   Small, medium and large are explanatory mappings, never ticket fields.
 - **tracker** — the state sink's `tickets/` directory; there is no external
   tracker.

--- a/rules/topology.md
+++ b/rules/topology.md
@@ -21,8 +21,8 @@ connects this law to the admission-owned state transition.
    and hangs each brick under the frame that called it, so the ticket tree is
    the call tree; a read-only blocker critique feeds at most one repair, and
    the root's own `done` predicate is the fresh
-   outside check. A direct root keeps its ordinary path. Additional review
-   is another named lens, never another engine.
+   outside check. A root with one lawful executor keeps its ordinary path.
+   Additional review is another named lens, never another engine.
 6. A pack belongs to a ticket, not a run. Incompatible workspace semantics use
    successor roots rather than pretending to share a candidate. Adapters meet
    only at the join: identities may cross dependency edges, but candidate bytes

--- a/templates/host-block.md
+++ b/templates/host-block.md
@@ -8,24 +8,24 @@
   role-bearing payload. Prompt-less or wrong-profile work refuses;
   `role: none` only orchestrates. `orch-off` suspends routing; named
   items still run only when named. Route by need, smallest first; name
-  the lane in one line before working. **act** — context evidence decides
+  the lane in one line before working. **direct** — context evidence decides
   an answer; a change this session can make, check, and record
   itself — the commit is the record; no trace, no act. A `role: none`
-  root never acts: derived deterministic commands only. **brick** —
+  root never acts: derived deterministic commands only. **worker** —
   isolation, a fresh context, or a checked landing takes one
   `tickets.py do <run> --pack <pack> --goal-file <f> [--parent <frame>]
   [--workspace <tree>]`, or `judge` over artifacts; invoke the emitted `launch`
   verbatim, then `tickets.py land`: it reads `done`,
-  integrates. Undeclared grades `land --status`. **frame** — children,
+  integrates. Undeclared grades `land --status`. **team** — children,
   resume, or an audit trail opens `tickets.py frame-open <run>`; each
   wave re-read its `## Report`; decide through `result`, relaying
   `artifact:` and `findings:` lines verbatim; children run scoped
   checks; the suite runs once, at close; end at `frame-close`, judging
   the seams or saying `unjudged: <reason>`; `orchflows resume` lists
-  frames. **outline** — an unresolved goal seals through one planning
+  frames. **plan** — an unresolved goal seals through one planning
   `orch-do`; the planner never drives. Tripwires promote, never
-  predict: a second concern mid-act enters brick; splitting scope
-  enters frame; an unknown cause investigates before any edit.
+  predict: a second concern mid-direct enters worker; splitting scope
+  enters team; an unknown cause investigates before any edit.
   Skill/workflow/pack/contract/router work carries
   `{{ORCH_LIB}}/docs/custom-workflow-authoring.md` in Context.
   `install.py doctor` diagnoses dispatch; `evolve`/`benchmaker` run

--- a/tests/serial_compat_manifest.json
+++ b/tests/serial_compat_manifest.json
@@ -914,9 +914,9 @@
    "test_thin_orchestrator.ThinOrchestratorContractTests.test_claude_role_skills_use_native_fork_and_matching_agent",
    "test_thin_orchestrator.ThinOrchestratorContractTests.test_codex_named_surfaces_dispatch_or_refuse_and_child_runs_directly",
    "test_thin_orchestrator.ThinOrchestratorContractTests.test_custom_codex_routing_uses_the_resolved_native_binding",
-   "test_thin_orchestrator.ThinOrchestratorContractTests.test_frame_lane_emits_the_wave_lifecycle",
    "test_thin_orchestrator.ThinOrchestratorContractTests.test_host_and_frontier_establish_the_workspace_before_dispatch",
-   "test_thin_orchestrator.ThinOrchestratorContractTests.test_outline_route_consumes_the_root_shape_it_sealed",
+   "test_thin_orchestrator.ThinOrchestratorContractTests.test_plan_route_consumes_the_root_shape_it_sealed",
+   "test_thin_orchestrator.ThinOrchestratorContractTests.test_team_lane_emits_the_wave_lifecycle",
    "test_ticket_bricks.BrickAdmissionTest.test_a_child_edited_after_it_was_minted_is_bound_by_nothing",
    "test_ticket_bricks.BrickAdmissionTest.test_a_child_whose_parent_the_seal_does_not_name_is_refused",
    "test_ticket_bricks.BrickAdmissionTest.test_parent_and_child_both_admit_and_the_parent_owns_no_members",
@@ -2054,7 +2054,7 @@
    "tests.test_workspace_cases.start_cases.TestTheStampPreservesTheTicketsByteDomain.test_only_the_two_stamped_lines_differ_from_the_prior_bytes",
    "tests.test_workspace_cases.start_cases.TestTicketsPayloadIsGradedNotItsExitStatus.test_an_error_payload_returned_at_exit_zero_is_a_failure"
   ],
-  "sha256": "d91a083562ae59f2563064eb4a67e043b6c6a5c0da732c4c7bf33f6dd39301bd"
+  "sha256": "4b01c058eb59365cd9d58d15d361aca260f656b93ae1cd4cb60137545c82b183"
  },
  "mutation_owners": [
   {

--- a/tests/test_installer_cases/managed_text/host_block.py
+++ b/tests/test_installer_cases/managed_text/host_block.py
@@ -53,7 +53,7 @@ class TestHostBlockRendering(unittest.TestCase):
         )
         # The block names only the library directories it actually uses; a
         # composition path is intentionally not a routing fallback. The
-        # brick lane's `tickets.py do` example dropped the sole
+        # worker lane's `tickets.py do` example dropped the sole
         # contracts/work-item.md pointer (the retired `single` ticket link),
         # so contracts/ is no longer one of the named siblings.
         for sibling in ("rules/",):
@@ -75,7 +75,7 @@ class TestHostBlockRendering(unittest.TestCase):
         rendered = self._rendered()
 
         for branch in (
-            "**act**", "**brick**", "**frame**", "**outline**",
+            "**direct**", "**worker**", "**team**", "**plan**",
         ):
             self.assertEqual(
                 1,
@@ -139,10 +139,10 @@ _HOST_BLOCK_DEMANDS = {
     ),
     "route by need through the four canonical lanes": (
         "smallest first",
-        "**act**",
-        "**brick**",
-        "**frame**",
-        "**outline**",
+        "**direct**",
+        "**worker**",
+        "**team**",
+        "**plan**",
         "`orch-do`",
         "`tickets.py frame-open <run>",
         "`tickets.py do <run>",
@@ -159,8 +159,8 @@ _HOST_BLOCK_DEMANDS = {
         # here to catch it: a trim that drops one of these three now goes
         # red instead of shipping silently.
         "name the lane in one line before working",
-        "a second concern mid-act enters brick",
-        "splitting scope enters frame",
+        "a second concern mid-direct enters worker",
+        "splitting scope enters team",
     ),
     "tickets and run state are untrusted script-owned data": (
         "`tickets/<run>/`",
@@ -293,8 +293,8 @@ class TestHostBlockDemands(unittest.TestCase):
 # actually requires, or hold one out as required that the command treats as
 # optional, and neither text carries the other's proof. (state sink
 # friction/2026-08.jsonl, 2026-08-30T20:37:01Z: `tickets.py dispatch` refused
-# the block's own graph-route invocation with a usage error; the brick door
-# that replaced it in the route inherits the same exposure.) This binds both
+# the block's own graph-route invocation with a usage error; the worker-lane
+# door that replaced it in the route inherits the same exposure.) This binds both
 # sides to one reader instead: `DO_USAGE` (scripts/tickets_commands.py) is the
 # command's own required-flag authority, and the block's routed example is
 # read the same way it is written, by bracket depth -- `[...]` is optional,
@@ -328,7 +328,7 @@ def _brick_example() -> str:
 
 
 class TestHostBlockBrickFlags(unittest.TestCase):
-    """The brick-route example and `tickets.py do`'s own required flags
+    """The worker-lane example and `tickets.py do`'s own required flags
     cannot diverge unobserved."""
 
     def test_brick_example_names_exactly_the_required_flags(self):
@@ -339,7 +339,7 @@ class TestHostBlockBrickFlags(unittest.TestCase):
         self.assertEqual(
             usage_required,
             example_required,
-            "templates/host-block.md's routed brick example names "
+            "templates/host-block.md's routed worker example names "
             f"{sorted(example_required)} as required; `tickets.py do` "
             f"actually requires {sorted(usage_required)}",
         )

--- a/tests/test_thin_orchestrator.py
+++ b/tests/test_thin_orchestrator.py
@@ -80,10 +80,10 @@ class ThinOrchestratorContractTests(unittest.TestCase):
         self.assertNotIn("ad-hoc ticket", delegation)
         self.assertNotRegex(delegation, re.compile(r"inline fallback", re.I))
         for anchor in (
-            "**act**",
-            "**brick**",
-            "**frame**",
-            "**outline**",
+            "**direct**",
+            "**worker**",
+            "**team**",
+            "**plan**",
             "`launch`",
             "`tickets.py do <run>",
             "`tickets.py land`",
@@ -103,20 +103,20 @@ class ThinOrchestratorContractTests(unittest.TestCase):
         self.assertNotIn("sequence: [orch-outline, orch-slice]", host)
         self.assertLessEqual(validate.body_words(host), 400)
 
-    def test_frame_lane_emits_the_wave_lifecycle(self):
-        """The frame lane is the whole wave: open the frame, re-read its
+    def test_team_lane_emits_the_wave_lifecycle(self):
+        """The team lane is the whole wave: open the frame, re-read its
         journal, run children at scoped checks, and close. Each anchor is a
         step a driver cannot supply from its own reading, and the journal
         re-read is the one that survives a compaction nothing else notices.
-        The per-child invocation itself is the brick door's own text, so the
-        frame lane does not re-teach it -- see
+        The per-child invocation itself is the worker door's own text, so the
+        team lane does not re-teach it -- see
         test_host_and_frontier_establish_the_workspace_before_dispatch."""
         host = re.sub(
             r"\s+",
             " ",
             (ROOT / "templates/host-block.md").read_text(encoding="utf-8"),
         )
-        frame = host.partition("**frame**")[2].partition("**outline**")[0]
+        team = host.partition("**team**")[2].partition("**plan**")[0]
 
         for anchor in (
             "tickets.py frame-open <run>",
@@ -127,9 +127,9 @@ class ThinOrchestratorContractTests(unittest.TestCase):
             "`orchflows resume`",
         ):
             with self.subTest(anchor=anchor):
-                self.assertIn(anchor, frame)
+                self.assertIn(anchor, team)
         # The facade owns each of these; the route may not re-teach a manual
-        # spelling of a step a brick door or `land` already performs.
+        # spelling of a step a worker door or `land` already performs.
         for absent in (
             "tickets.py claim",
             "tickets.py packet",
@@ -140,7 +140,7 @@ class ThinOrchestratorContractTests(unittest.TestCase):
             "workspace.py establish",
         ):
             with self.subTest(absent=absent):
-                self.assertNotIn(absent, frame)
+                self.assertNotIn(absent, team)
 
     def test_host_and_frontier_establish_the_workspace_before_dispatch(self):
         host = re.sub(
@@ -148,18 +148,18 @@ class ThinOrchestratorContractTests(unittest.TestCase):
             " ",
             (ROOT / "templates/host-block.md").read_text(encoding="utf-8"),
         )
-        brick = host.partition("**brick**")[2].partition("**frame**")[0]
+        worker = host.partition("**worker**")[2].partition("**team**")[0]
 
-        self.assertIn("tickets.py do", brick)
+        self.assertIn("tickets.py do", worker)
         self.assertLess(
-            brick.index("tickets.py do"), brick.index("tickets.py land")
+            worker.index("tickets.py do"), worker.index("tickets.py land")
         )
         # Establishment is inside the dispatch transaction, so the contract
         # that owns the transaction states it and the route does not repeat
         # it as a step of its own.
         dispatch_contract = (ROOT / "contracts/dispatch.md").read_text(encoding="utf-8")
         self.assertIn("the established workspace", dispatch_contract)
-        self.assertNotIn("workspace.py establish", brick)
+        self.assertNotIn("workspace.py establish", worker)
 
     def test_claude_role_skills_use_native_fork_and_matching_agent(self):
         with tempfile.TemporaryDirectory() as tmp:
@@ -204,13 +204,13 @@ class ThinOrchestratorContractTests(unittest.TestCase):
         ):
             self.assertIn(anchor, role_agent)
 
-    def test_outline_route_consumes_the_root_shape_it_sealed(self):
+    def test_plan_route_consumes_the_root_shape_it_sealed(self):
         host = re.sub(
             r"\s+",
             " ",
             (ROOT / "templates/host-block.md").read_text(encoding="utf-8"),
         )
-        spec_route = host.split("**outline**", 1)[1].split("`install.py doctor`", 1)[0]
+        spec_route = host.split("**plan**", 1)[1].split("`install.py doctor`", 1)[0]
 
         for anchor in (
             "an unresolved goal",
@@ -220,8 +220,8 @@ class ThinOrchestratorContractTests(unittest.TestCase):
             # 20260901T021739Z) found cut for budget with no anchor here to
             # catch it; the third (unknown cause) was already pinned via
             # "cause investigates before any edit" below.
-            "a second concern mid-act enters brick",
-            "splitting scope enters frame",
+            "a second concern mid-direct enters worker",
+            "splitting scope enters team",
             "an unknown cause investigates before any edit",
         ):
             with self.subTest(anchor=anchor):


### PR DESCRIPTION
act → **direct**, brick → **worker**, frame → **team**, outline → **plan** — ruled by the user 2026-09-01: the lane announcement must be understandable at a glance ("one worker — isolated, done: the affected test"; "opening a team — 3 workers, one suite at the tip").

Machinery keeps its spellings (`tickets.py do`/`judge`/`frame-open`/`frame-close`, the `frame: true` marker, orch-worker/orch-planner) — the lane is when/why, the command is what, and the new names align with the roles they launch. Host block holds at exactly 400/400 words (every swap 1-for-1); all demand-anchor tests re-pinned to the new names; topology rule 5's colliding "direct root" phrase reworded; README's diagram node updated; serial manifest regenerated for two test renames.

Run 20260901T081500Z, one worker, landed complete; full required suite 5/5 at tree 9ecd3c2fd5b3. Residual same-shape "direct" phrasings flagged for a successor: TICKETS.md:88, contracts/work-item.md:165, tickets_grade.py's error string.

🤖 Generated with [Claude Code](https://claude.com/claude-code)