### PR TITLE
Claude host bindings: fable-5-1/high planner, opus-5/high worker

### DIFF
--- a/hosts/claude.json
+++ b/hosts/claude.json
@@ -29,7 +29,7 @@
   "role_profiles": {
     "planner": {
       "name": "orch-planner",
-      "binding": {"model": "claude-opus-5", "effort": "max"}
+      "binding": {"model": "claude-fable-5-1", "effort": "high"}
     },
     "worker": {
       "name": "orch-worker",

--- a/hosts/claude.json
+++ b/hosts/claude.json
@@ -33,7 +33,7 @@
     },
     "worker": {
       "name": "orch-worker",
-      "binding": {"model": "claude-sonnet-5", "effort": "xhigh"}
+      "binding": {"model": "claude-opus-5", "effort": "high"}
     }
   },
   "capabilities": {"isolation": "requested", "effort": "native"}

--- a/installer/host_adapters/claude.json
+++ b/installer/host_adapters/claude.json
@@ -55,8 +55,8 @@
     "role_profiles": {
       "planner": {
         "binding": {
-          "effort": "max",
-          "model": "claude-opus-5"
+          "effort": "high",
+          "model": "claude-fable-5-1"
         },
         "name": "orch-planner"
       },
@@ -71,5 +71,5 @@
     "schema_version": 1
   },
   "source": "hosts/claude.json",
-  "source_sha256": "f31741b17a0f11a95be07b5baed62b873b925a28c8d57073f39e77175f056b17"
+  "source_sha256": "952610d4a9c691fc92af329326be49cfefdf163761688eac11deb116b463d352"
 }

--- a/installer/host_adapters/claude.json
+++ b/installer/host_adapters/claude.json
@@ -62,8 +62,8 @@
       },
       "worker": {
         "binding": {
-          "effort": "xhigh",
-          "model": "claude-sonnet-5"
+          "effort": "high",
+          "model": "claude-opus-5"
         },
         "name": "orch-worker"
       }
@@ -71,5 +71,5 @@
     "schema_version": 1
   },
   "source": "hosts/claude.json",
-  "source_sha256": "952610d4a9c691fc92af329326be49cfefdf163761688eac11deb116b463d352"
+  "source_sha256": "4c9cc0a564f554213a3cbdcbb10c8448b660fad8875262667ae3ce4aedec6709"
 }

--- a/tests/test_dispatch_launch.py
+++ b/tests/test_dispatch_launch.py
@@ -481,7 +481,7 @@ class DispatchLaunchTest(unittest.TestCase):
         result = self.dispatch(run="planned")
 
         self.assertEqual("orch-planner", result["launch"]["agent"])
-        self.assertEqual("claude-opus-5", result["launch"]["model"])
+        self.assertEqual("claude-fable-5-1", result["launch"]["model"])
 
     def test_an_unknown_host_refuses_before_the_attempt_is_opened(self):
         before = self.ticket_path().read_text(encoding="utf-8")

--- a/tests/test_dispatch_launch.py
+++ b/tests/test_dispatch_launch.py
@@ -78,7 +78,7 @@ class LaunchResolutionTest(unittest.TestCase):
 
     def test_the_effort_is_the_one_this_host_spells_however_it_spells_it(self):
         for host, role, expected in (
-            ("claude", "worker", "xhigh"), ("codex", "planner", "ultra"),
+            ("claude", "worker", "high"), ("codex", "planner", "ultra"),
             ("grok", "worker", "high"),
         ):
             with self.subTest(host=host, role=role):

--- a/tests/test_installer_cases/planning/scoped_hosts.py
+++ b/tests/test_installer_cases/planning/scoped_hosts.py
@@ -114,7 +114,7 @@ class HostAdapterRenderingTest(unittest.TestCase):
 
         self.assertIn("host records beside this file", profiles)
         self.assertNotIn("| Profile |", profiles)
-        for binding in ("gpt-5.6-sol", "claude-opus-5", "grok-4.6"):
+        for binding in ("gpt-5.6-sol", "claude-fable-5-1", "grok-4.6"):
             self.assertNotIn(binding, profiles)
         self.assertIn("../hosts/", authoring)
         self.assertNotIn("A Claude adapter keeps", authoring)

--- a/tests/test_installer_cases/planning/scoped_hosts.py
+++ b/tests/test_installer_cases/planning/scoped_hosts.py
@@ -97,7 +97,7 @@ class HostAdapterRenderingTest(unittest.TestCase):
             rendered_profiles = install.load_role_profiles(adapters)
         expected_worker_bindings = {
             "codex": {"model": "gpt-5.6-luna", "model_reasoning_effort": "xhigh"},
-            "claude": {"model": "claude-sonnet-5", "effort": "xhigh"},
+            "claude": {"model": "claude-opus-5", "effort": "high"},
             "grok": {"model": "grok-4.6", "effort": "high"},
         }
         for host, binding in expected_worker_bindings.items():
@@ -339,8 +339,8 @@ class TestScopedHostConfiguration(unittest.TestCase):
                 self.assertEqual(home / ".claude" / "agents", dest.parent)
                 self.assertIn("name: orch-", content)
                 if "name: orch-worker" in content:
-                    self.assertIn("model: claude-sonnet-5", content)
-                    self.assertIn("effort: xhigh", content)
+                    self.assertIn("model: claude-opus-5", content)
+                    self.assertIn("effort: high", content)
             for dest, content in plan.codex_agents:
                 self.assertEqual(home / ".codex" / "agents", dest.parent)
                 parsed = install.tomllib.loads(content)

--- a/tests/test_installer_cases/receipt/install_receipt.py
+++ b/tests/test_installer_cases/receipt/install_receipt.py
@@ -224,7 +224,7 @@ class TestInstallReceipt(unittest.TestCase):
             {"model": "claude-fable-5-1", "effort": "high"}, profiles["orch-planner"]["claude"]
         )
         self.assertEqual(
-            {"model": "claude-sonnet-5", "effort": "xhigh"}, profiles["orch-worker"]["claude"]
+            {"model": "claude-opus-5", "effort": "high"}, profiles["orch-worker"]["claude"]
         )
 
     def test_reinstall_removes_receipt_owned_hyphenated_codex_agent(self):

--- a/tests/test_installer_cases/receipt/install_receipt.py
+++ b/tests/test_installer_cases/receipt/install_receipt.py
@@ -221,7 +221,7 @@ class TestInstallReceipt(unittest.TestCase):
         profiles = install.load_role_profiles()
 
         self.assertEqual(
-            {"model": "claude-opus-5", "effort": "max"}, profiles["orch-planner"]["claude"]
+            {"model": "claude-fable-5-1", "effort": "high"}, profiles["orch-planner"]["claude"]
         )
         self.assertEqual(
             {"model": "claude-sonnet-5", "effort": "xhigh"}, profiles["orch-worker"]["claude"]

--- a/tests/test_live_harnesses_cases/grok_profile_cases.py
+++ b/tests/test_live_harnesses_cases/grok_profile_cases.py
@@ -43,7 +43,7 @@ class TestGrokRoleProfiles(unittest.TestCase):
         )
         self.assertEqual(
             {
-                "orch-planner": ("gpt-5.6-sol", "ultra", "claude-opus-5", "max"),
+                "orch-planner": ("gpt-5.6-sol", "ultra", "claude-fable-5-1", "high"),
                 "orch-worker": ("gpt-5.6-luna", "xhigh", "claude-sonnet-5", "xhigh"),
             },
             {

--- a/tests/test_live_harnesses_cases/grok_profile_cases.py
+++ b/tests/test_live_harnesses_cases/grok_profile_cases.py
@@ -44,7 +44,7 @@ class TestGrokRoleProfiles(unittest.TestCase):
         self.assertEqual(
             {
                 "orch-planner": ("gpt-5.6-sol", "ultra", "claude-fable-5-1", "high"),
-                "orch-worker": ("gpt-5.6-luna", "xhigh", "claude-sonnet-5", "xhigh"),
+                "orch-worker": ("gpt-5.6-luna", "xhigh", "claude-opus-5", "high"),
             },
             {
                 name: (


### PR DESCRIPTION
## Summary
- Rebind the Claude host's `orch-planner` profile (planning, critique, adjudication, review) from `claude-opus-5`/`max` to `claude-fable-5-1`/`high`.
- Rebind the Claude host's `orch-worker` profile from `claude-sonnet-5`/`xhigh` to `claude-opus-5`/`high`.
- Adapters regenerated via `tools/regen.py`; the tests that pinned the shipped defaults follow the record.

## Verification
`python tools/run_required.py --no-cache` green (validate, run_tests, run_serial_compat, install --dry-run, diff --check). Reinstalled locally at the tip; both live agent files carry the new bindings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)