### PR TITLE
tiktok-video: a gallery workflow for 1-120s TikTok marketing videos

### DIFF
--- a/example-workflows/tiktok-video/SKILL.md
+++ b/example-workflows/tiktok-video/SKILL.md
@@ -1,0 +1,59 @@
+---
+name: tiktok-video
+description: Make one 1–120s TikTok marketing video for anything — cited brief, judged hook variants, rendered 9:16 with burned captions.
+disable-model-invocation: true
+---
+
+Require: `subject`, what is being marketed and every asset it comes with
+(URL, screenshots, footage, logo); `goal`, one of awareness, traffic or
+conversion; `length`, the target seconds inside 1–120; `brand`, the voice
+contract plus visual tokens, or `none`; `workspace`, the git-backed render
+project, or `new`; `keys`, the provider keys on hand, or `none`. Every
+call reads [the rules](references/tiktok-video-rules.md); the render
+call also reads [the pipeline](references/tiktok-video-pipeline.md).
+
+    tickets.py frame-open <run> --goal-file <video-goal> --workflow tiktok-video
+
+Re-read the frame's `## Report` and its children before each call, then
+append the decision with `tickets.py result <run> <frame> --by <frame>`.
+Keep every returned `artifact:` and `findings:` line verbatim; the next
+call is handed the line itself.
+
+**Brief**, `do --pack orch-research-pack --bound "<= 40 tool calls"`: one
+evidence packet for `subject` — audience and its stated pains, proof
+points, the hooks and formats competitors run on TikTok now, sounds and
+trends live in the niche — every claim cited and dated, gaps declared.
+
+**Scripts**, `do --pack orch-content-pack` handed the brief's artifact
+line: one document holding three scripts for `length` and `goal`, each a
+beat sheet from a different hook archetype the rules name — timed beats,
+voice lines, on-screen text, shot list, sound, one CTA — plus a six-second
+cutdown of the strongest.
+
+**Script judge**, `judge --pack orch-content-pack` over that document: a
+verdict per script against the rules' hook, structure and CTA checks,
+ranked, blocks named. One repair `do` covers only named blocks, then this
+judge runs once more; two rounds is the bound.
+
+**Render**, `do --pack orch-code-pack --isolation required` in `workspace`,
+handed the passing scripts and `keys`: the pipeline's project — voice,
+word-timed captions, footage or generated shots, music under the voice —
+every passing script rendered to its 1080×1920 MP4 with cover frame,
+contact sheet, captures and the spec probe the pipeline defines, that
+probe the call's `done`.
+
+**Render judge**, `judge --pack orch-design-pack` over the render's
+`git:` line: the captures against the rules' safe zones, caption
+legibility, brand tokens and pacing; one verdict per variant. Blocks earn
+one repair `do --pack orch-code-pack` and one re-judge, then the frame
+closes on what passed.
+
+Never: open on a logo, slate or silence; carry text into a zone the
+TikTok UI covers; render a script the judge did not pass; export outside
+9:16 at 1080×1920; substitute a paid provider `keys` does not name; or
+close on the renderer's own claim.
+
+Return: `tickets.py frame-close <run> <frame> --done <probe>`, whose done
+is the spec probe over every delivered MP4 run outside the render — codec,
+frame size, duration inside `length`, loudness, captions present — as an
+exit code, beside the render judge's verdict per variant.

--- a/example-workflows/tiktok-video/references/tiktok-video-pipeline.md
+++ b/example-workflows/tiktok-video/references/tiktok-video-pipeline.md
@@ -1,0 +1,78 @@
+# tiktok-video pipeline
+
+The stack the `tiktok-video` workflow's render call builds, chosen on
+2026-09-02 from the open-source tools that make short vertical video
+today. Surveyed: Remotion, HyperFrames, Revideo, Motion Canvas, editly,
+MoviePy, MoneyPrinterTurbo, ShortGPT, short-video-maker, NarratoAI,
+OpenShorts, whisper.cpp, faster-whisper, whisperX, Kokoro, Chatterbox,
+edge-tts, Pexels, Wan 2.2, LTX-2, PySceneDetect. The two designs worth
+keeping from that survey are the beat schema every generator converged on
+(one narration line beside its own visual query) and Remotion's caption
+model (word tokens paged into short caption pages). Everything below is a
+default the render call may deviate from when it reports why.
+
+## Run directory
+
+Every stage writes one JSON artifact under `runs/<slug>/`, so any stage
+re-runs alone and a variant reuses every artifact its change does not
+touch:
+
+    brief.json      the research packet's claims the script drew on
+    script.json     {hook, beats[{narration, on_screen, visual, seconds}], cta}
+    assets.json     per beat: file, source, licence, w×h, trimmed range
+    voice/          one WAV per beat plus words[{text, start_ms, end_ms}]
+    captions.json   pages[{text, start_ms, duration_ms, tokens[]}]
+    renders/        <variant>.mp4, <variant>.cover.jpg, <variant>.sheet.jpg
+    probe.json      the spec probe's readings per render
+
+## Stage choices
+
+| stage | keyless path (`keys: none`) | quality path (a key named in `keys`) |
+| --- | --- | --- |
+| voice | Kokoro (Apache-2.0, CPU, no cloning) | Chatterbox Turbo or Multilingual (MIT, cloning, an `exaggeration` knob); ElevenLabs where a brand voice is mandated |
+| word timing | faster-whisper `word_timestamps=True`, int8, over the generated voice | whisperX forced alignment; or ElevenLabs `/with-timestamps` grouped into words, no ASR pass |
+| footage | the caller's own assets; Playwright `recordVideo` at 1080×1920 for product or site demos; FLUX.2 klein stills | Pexels or Pixabay portrait search by each beat's `visual`; one generated hook shot from Wan 2.2 or LTX-2 at most |
+| composition | HyperFrames (Apache-2.0): one HTML file per variant, timing in data attributes, GSAP or CSS motion, frames captured headless | Remotion where its licence fits (free for individuals and teams of three; a company licence above that) |
+| captions | ASS karaoke tags burned by ffmpeg when no browser is wanted | DOM captions in the composition: active token coloured and scaled |
+| music | Pixabay Music or Free Music Archive, licence recorded in `assets.json` | same; a trending sound is the caller's to license, never fetched |
+| render | ffmpeg `libx264 -crf 18 -preset medium -pix_fmt yuv420p -r 30 -movflags +faststart`, AAC 192k | same |
+
+Licence traps the render call refuses: F5-TTS and XTTS weights are
+non-commercial; Fish Speech carries its own terms; edge-tts is unofficial
+and rate-limited. Kokoro, Chatterbox, Qwen3-TTS and OpenVoice are clean.
+
+## Assembly rules
+
+- Write the script's words out in full before voicing them — numerals and
+  currency get no timestamps from the aligners.
+- Page captions at four to six words, tokens combined within about a
+  second of each other, a page break on any silence past 300 ms; hold at
+  least 50 ms between active-token highlights so they read rather than
+  strobe.
+- Duck music under voice with `sidechaincompress` keyed on the voice
+  track, or a flat `volume=0.15` where the mix is simple.
+- Snap cuts to `librosa.beat.beat_track` beats when a track is present;
+  reject any stock clip PySceneDetect finds an internal cut in.
+- Normalise with two-pass `loudnorm` (measure, then apply the measured
+  values) to the loudness and true-peak targets the rules state.
+- Render the cover frame from the hook beat and a contact sheet of one
+  frame per beat plus the CTA frame; the render judge reads the sheet
+  first and the captures second.
+
+## The spec probe
+
+One command in the workspace, `probe`, read by the render call's `done`
+and again by the frame's close. It exits non-zero on any reading outside
+the rules' technical specification and writes `probe.json`. Over each
+MP4 it reads, through ffprobe and ffmpeg: frame size, frame rate, video
+and audio codec, duration against the requested `length`, integrated
+loudness and true peak, silence longer than 1.5 s, the caption track or
+burned captions present, and the cover frame's timestamp inside the
+first second. It runs nothing that needs a key.
+
+## Captures for the render judge
+
+The render call stores, per variant, PNG captures at 0 s, 1 s, 3 s, the
+first frame of every beat, and the final frame, each overlaid with the
+rules' safe-zone rectangles. That set is the view identity list the
+design pack's judge covers, and the only evidence it reads.

--- a/example-workflows/tiktok-video/references/tiktok-video-rules.md
+++ b/example-workflows/tiktok-video/references/tiktok-video-rules.md
@@ -1,0 +1,133 @@
+# tiktok-video rules
+
+The craft every call in the `tiktok-video` workflow reads: what a TikTok
+marketing video has to be for the platform's own data to favour it, stated
+as checks. Sources are TikTok's Creative Codes, its creative best-practice
+help article, its conversion study over auction ads, and the in-feed ad
+specification, read 2026-09-02; marketer benchmarks are marked as such.
+The script judge reads §§1–4 and §8; the render judge §§5–7 and §9; the
+spec probe reads only §7.
+
+## 1. The hook, 0–3 s
+
+TikTok's structure code is hook, body, close, and its help article puts
+the offer inside the first three seconds and holds attention through the
+first six; ninety percent of ad recall lands in those six. The viewer's
+decision falls between one and three seconds, and TikTok's own hook metric
+is the two-second view.
+
+- A hook is spoken, on screen and visual at once. Its text is eight words
+  or fewer; its visual stimulus — a face meeting the lens, the product in
+  motion, or the result shown first — is in frame by one second.
+- Archetypes a script names and a judge recognises: pattern interrupt,
+  result first, direct address or POV, bold or contrarian claim, curiosity
+  question, qualified "stop scrolling if", text tease with an open loop.
+  A pattern interrupt disconnected from the body wins the first second
+  and loses completion; the result-first open holds three-second
+  retention best (marketer studies).
+- Nothing opens on a logo, slate, title card, black frame or silence.
+
+## 2. Structure by length
+
+TikTok's conversion study: 21–34 s ads lifted conversion 280 percent over
+shorter and longer; multiple scenes lifted it 38 percent; text on screen
+inside seven seconds, 43 percent. Cold audiences fall off sharply past
+60 s; the paid-policy ceiling is 60 s, so 61–120 s is for explainers,
+tutorials, founder stories and retargeting only, and only when `goal`
+says so.
+
+| length | use | beats | scenes | voice words |
+| --- | --- | --- | --- | --- |
+| 6 s | awareness bumper, reminder | hook visual + text; one benefit with the product; brand + CTA | 2–3 | ≤ 15 |
+| 15 s | awareness, impulse, install | hook 0–2; context 2–5; demo 5–12; CTA 12–15 | 5–8 cuts | 28–42 |
+| 30 s | conversion, the default | hook 0–3; problem 3–10; solution and proof 10–25; CTA and offer 25–30 | ≥ 5 scenes, 10–15 cuts | 60–84 |
+| 60 s | consideration, mechanism, comparison | as 30 s with story 13–28 and proof 48–55; re-hook near 20 s and 40 s | 20–35 cuts | 130–160 |
+| 120 s | explainer, tutorial, warm retarget | three chapters each opened by a text re-hook; payoff before 60 s; CTA teased near 40 s, closed 110–120 s | ≥ 40 cuts | 250–300 |
+
+Defaults when `length` is a band: conversion 21–34 s, awareness 9–15 s.
+Body shots run 1.5–3 s; no shot exceeds 5 s without a punch-in, a caption
+change or a b-roll insert; every video past 30 s re-hooks every 15–20 s.
+
+## 3. Script formulas
+
+A script names one formula and its beats fall inside the table above:
+problem–agitate–solution–proof–CTA; attention–interest–desire–action;
+problem–solution–demo–CTA, the default ad shape; before–after–bridge,
+after shown first; the numbered list, one scene per item; tutorial,
+outcome promised then steps then result; testimonial or skeptic, low
+expectation then surprise then invitation. Each beat carries its
+narration, its on-screen text, its visual and its seconds; the product or
+offer is visible or named by three seconds and on screen for at least
+thirty percent of the runtime.
+
+## 4. The close
+
+Text CTAs lifted conversion 152 percent and CTA cards lifted recall 45
+percent in TikTok's study. The close is the last three to five seconds:
+a spoken line and a two-or-three-word on-screen action verb that matches
+the button label TikTok offers (Shop Now, Learn More, Sign Up, Download,
+Order Now, Book Now). No "swipe up", no drawn button, no induced gesture —
+policy rejects them — and "link in bio" only for a Spark ad, where a
+profile exists to tap. Specific beats vague: "free to try, link below"
+over "check it out".
+
+## 5. The frame
+
+- Canvas 9:16 at 1080×1920. Vertical lifted conversion 91 percent over
+  letterboxed; 720p and above, 312 percent.
+- Safe box: x 60–940, y 200–1436. The top 200 px carries the tabs and the
+  sponsored mark, the right 140 px the action column, the bottom 484 px
+  the account, caption, sound and button. No text or key visual lands
+  outside the box; a violation costs about a fifth of completion (marketer
+  data over 170k posts).
+- Backgrounds behind the UI regions are never white or transparent; the
+  UI is white.
+- Hierarchy: hook text upper-centre for 0–3 s; benefit callouts
+  lower-centre from 3 s; CTA bottom-centre inside the box for the last
+  seconds. Brand marks appear only after the hook.
+- Native beats polished for cold audiences: TikTok-first creative earns
+  3.3× the action. Handheld or selfie framing, natural light, in-app text
+  style, jump and zoom cuts; polish is for warm and premium.
+- No static stretch past one second without motion or audio; static
+  frames stay under half the runtime; no third-party watermark, blurred
+  or otherwise.
+
+## 6. Captions
+
+Word-by-word or one-to-three-word pop captions in a bold sans-serif —
+TikTok Sans is open source, Montserrat or Inter serve — white with a
+black stroke or a highlight colour, lower-middle, never over a face. Cap
+height 48 px or more at 1080 wide, stroke or shadow 4 px or more, one to
+seven words a chunk, one to three seconds a chunk, at most ten words a
+second, breaks at speech pauses. Burn captions in: the platform's own
+caption can be hidden and cannot be styled.
+
+## 7. Technical specification
+
+MP4, H.264 video and AAC audio at 48 kHz and 192 kbps or better;
+1080×1920; 30 fps, 60 only where motion demands; 6–12 Mbps; under 500 MB.
+Duration inside `length`, and inside 5–60 s unless `goal` licenses more.
+An audio track is mandatory: voice at −14 LUFS integrated, −1 dBTP true
+peak; music 18–25 dB under the voice while it speaks; voice at 140–160
+words a minute; no silence past 1.5 s except one deliberate beat before
+the CTA. The first frame is the cover: subject and hook text inside the
+centre block, not a black or transition frame.
+
+## 8. Variants
+
+Hold the body and swap only the first three seconds: three hook variants
+per body, each a different archetype, and a six-second cutdown of the
+strongest. The manifest names each variant's archetype and the readings a
+marketer takes — two-second and six-second view rates, views at each
+quarter, average play time. A near-vertical drop inside 1–3 s is a hook
+failure; a good hook losing half by the midpoint is a body failure.
+
+## 9. Render judge findings that block
+
+A blocking finding is one of: any text or key visual outside the safe
+box; caption cap height under 48 px or no stroke; a logo, slate or static
+frame inside the first three seconds; hook text absent by one second; the
+product absent past three seconds; no CTA text in the last five seconds
+or a CTA that contradicts the button; a white or transparent UI region;
+a watermark; a shot past five seconds with nothing changing. Other
+findings are weighed against the goal, not blocking.

--- a/reader/docs/workflow-summary-manifest.json
+++ b/reader/docs/workflow-summary-manifest.json
@@ -122,6 +122,23 @@
         {"source": "resolve", "target": "apply", "kind": "sequence"},
         {"source": "apply", "target": "evidence", "kind": "sequence"}
       ]
+    },
+    "tiktok-video": {
+      "nodes": [
+        {"id": "brief", "label": "Research the cited brief"},
+        {"id": "scripts", "label": "Write three hook variants"},
+        {"id": "script-judge", "label": "Judge and rank the scripts"},
+        {"id": "render", "label": "Render every passing script"},
+        {"id": "render-judge", "label": "Judge captures against the rules"}
+      ],
+      "edges": [
+        {"source": "brief", "target": "scripts", "kind": "sequence"},
+        {"source": "scripts", "target": "script-judge", "kind": "sequence"},
+        {"source": "script-judge", "target": "scripts", "kind": "loop"},
+        {"source": "script-judge", "target": "render", "kind": "sequence"},
+        {"source": "render", "target": "render-judge", "kind": "sequence"},
+        {"source": "render-judge", "target": "render", "kind": "loop"}
+      ]
     }
   }
 }

--- a/reader/scripts/ui_workflows_summary.py
+++ b/reader/scripts/ui_workflows_summary.py
@@ -29,6 +29,7 @@ CANONICAL_WORKFLOW_IDS = frozenset({
     "self-improve",
     "skill-tournament",
     "super-research",
+    "tiktok-video",
 })
 EDGE_KINDS = frozenset({"sequence", "branch", "loop"})
 NODE_ID_RE = re.compile(r"[a-z][a-z0-9]*(?:-[a-z0-9]+)*\Z")

--- a/reader/tests/test_ui_cases/workflows_catalog.py
+++ b/reader/tests/test_ui_cases/workflows_catalog.py
@@ -48,7 +48,7 @@ class WorkflowCatalogTests(unittest.TestCase):
         self.assertEqual(
             [
                 "benchmaker", "browser-game", "drift-canary", "evolve", "renovate",
-                "self-improve", "skill-tournament", "super-research",
+                "self-improve", "skill-tournament", "super-research", "tiktok-video",
                 "orch-do", "orch-judge",
             ],
             [workflow["id"] for workflow in projected],

--- a/reader/tests/test_ui_cases/workflows_summary.py
+++ b/reader/tests/test_ui_cases/workflows_summary.py
@@ -22,6 +22,7 @@ EXPECTED_WORKFLOWS = {
     "self-improve",
     "skill-tournament",
     "super-research",
+    "tiktok-video",
 }
 
 

--- a/research/tiktok-video-craft-2026-09-02.md
+++ b/research/tiktok-video-craft-2026-09-02.md
@@ -1,0 +1,210 @@
+# What makes TikTok marketing videos perform
+
+Research packet behind `example-workflows/references/tiktok-video-rules.md`.
+Gathered 2026-09-02 by a web-research lane over TikTok's own docs (Creative
+Codes, ads help centre, For Business blog) and marketer analyses from the last
+18 months. Third-party numbers are labelled; several vendor stats are
+uncorroborated. Not a library owner: the rules reference is what the workflow
+reads, this file is its evidence.
+
+## 1. Hook craft (0–3 s)
+
+TikTok: structure is hook → body → close; "90% of ad recall impact is captured
+within the first six seconds"
+([Creative Codes](https://ads.tiktok.com/business/en-US/creative-codes);
+[blog](https://ads.tiktok.com/business/en-US/blog/creative-best-practices-top-performing-ads));
+offer inside the first 3 s, hold through 6
+([help article](https://ads.tiktok.com/help/article/creative-best-practices?lang=en)).
+Marketers converge on a 1.3–3 s decision; TikTok's hook metric is the 2-second
+view ([Sepia](https://sepia-lab.com/en/blog/hook-rate-benchmarks);
+[video play metrics](https://ads.tiktok.com/help/article/video-play?lang=en)).
+
+| Archetype | Form | Evidence (third party) |
+|---|---|---|
+| Pattern interrupt | motion-heavy, unexpected frame, mid-action open | ~89% 1-s retention, weaker completion when disconnected from body; mid-action +31% completion |
+| Result-first | finished outcome or unresolved visual | 2.4× 3-s retention vs text-only hooks |
+| Direct address / POV | naming the viewer's situation | faces with eye contact lift hook rate 4–8 pts |
+| Bold / contrarian claim | "the advice everyone gives is wrong" | 1.8× comments |
+| Question / curiosity gap | "why does nobody talk about X?" | dominant in finance/education |
+| "Stop scrolling if…" | interrupt + specific qualifier | UGC staple |
+| Text-on-screen tease | 2–8 words, open loop | verbal+visual beats words alone by +47% 3-s retention |
+
+Sources: [Sink or Swim](https://sink-or-swim-marketing.com/blog/tiktok-creative-center-best-practices-hook-retention-2025/),
+[mbadv](https://www.mbadv.agency/tiktok-ads/creative-best-practices),
+[Green Frog Labs](https://greenfroglabs.com/blog/video-hooks-scroll-stopping-2026),
+[DansUGC](https://dansugc.com/blog/ugc-hooks-tiktok-ads-formulas),
+[April Ford](https://www.aprilford.com/insights/9-tiktok-ad-mistakes-that-are-draining-your-budget).
+
+## 2. Structure by length
+
+TikTok's conversion study: 21–34 s +280% conversion; multiple scenes +38%;
+5+ scenes +171% (gaming); text within 7 s +43%
+([blog](https://ads.tiktok.com/business/en-US/blog/creative-that-drives-conversions)).
+Third parties: 9–15 s for awareness, 15–34 s for conversion; 60–90 s tolerated
+for warm explainers; non-follower engagement drops past 60 s
+([SocialBu](https://socialbu.com/blog/ideal-lenghth-of-tiktok-videos),
+[Zelios](https://zelios.agency/best-video-length/)). Cut every 1.5–3 s; 1-s
+b-roll bridge between jump cuts
+([Shortzly](https://shortzly.com/blog/short-form-video-pacing-editing-guide)).
+
+| Length | Use | Beats | Scenes | VO words |
+|---|---|---|---|---|
+| 6 s | bumper, reminder | 0–1.5 hook; 1.5–4.5 one benefit; 4.5–6 brand + CTA | 2–3 | ≤15 |
+| 15 s | awareness, impulse, install | 0–2 hook; 2–5 context; 5–12 demo; 12–15 CTA | 5–8 cuts | 28–42 |
+| 30 s | conversion sweet spot | 0–3 hook; 3–10 problem; 10–25 solution + proof; 25–30 CTA | 10–15 cuts, ≥5 scenes | 60–84 |
+| 60 s | consideration, mechanism | hook; problem 3–13; story 13–28; product 28–48; proof 48–55; CTA; re-hooks ~20 s, ~40 s | 20–35 cuts | 130–160 |
+| 120 s | explainer, founder story, retargeting | three chapters with text re-hooks; payoff before 60 s; CTA teased ~40 s, closed 110–120 s | ≥40 cuts | 250–300 |
+
+Policy states 5–60 s
+([ad-format policy](https://ads.tiktok.com/help/article/tiktok-ads-policy-ad-format-and-functionality));
+the auction in-feed spec allows up to 10 minutes
+([in-feed spec](https://ads.tiktok.com/help/article/tiktok-auction-in-feed-ads?lang=en)).
+Word budgets from [InReels](https://www.inreels.ai/blog/video-ad-scripts-by-duration-15s-30s-60s-templates)
+and [TikAdTools](https://tikadtools.com/blog/tiktok-15-second-ad/).
+
+## 3. Script formulas and CTA phrasing
+
+Ten UGC structures at [Reloop](https://reloop.so/blog/article/ugc-script-templates/).
+Most cited: PAS; AIDA; problem-solution-demo-CTA (hook 0–3, problem 3–10,
+solution 10–20, CTA last 3–5 s); before-after-bridge; "3 reasons" listicle;
+testimonial/skeptic; tutorial.
+
+CTA: text CTAs +152% conversion, CTA cards +45% recall (TikTok). Button text is
+preset-only (Shop Now, Learn More, Sign Up, Download, Order Now, Get Quote, Book
+Now); spoken/on-screen CTA matches the button
+([TikAdSuite](https://tikadsuite.com/blog/tiktok-ad-cta/)). "Link in bio" only
+for Spark Ads ([TikAdTools](https://tikadtools.com/blog/tiktok-ads-cta/)).
+Policy bans invalid buttons and induced gestures.
+
+## 4. Visual conventions
+
+9:16, 1080×1920 (spec minimum 540×960; policy ≥720p); 9:16 +91% and 720p+ +312%
+conversion (TikTok). Safe zones, conservative envelope: top 200 px, right 140 px,
+bottom 484 px, left 60 px → safe box x 60–940, y 200–1436
+([Koro](https://getkoro.app/blog/tiktok-safe-zone-guide),
+[Recharm](https://www.recharm.com/blog/tiktok-video-ad-specs),
+[Zeely](https://zeely.ai/blog/tiktok-safe-zones/),
+[House of Marketers](https://houseofmarketers.com/guide-to-safe-zones-tiktok-facebook-instagram-stories-reels/)).
+Violations correlate with 22% lower completion (170K-post analysis via
+[quso](https://quso.ai/blog/tiktok-dimensions)). TikTok warns against white or
+transparent backgrounds because UI text is white (in-feed spec).
+
+Captions: word-by-word or 1–3-word pop captions, bold sans-serif (TikTok Sans
+open-sourced July 2025 —
+[TikTok developers](https://developers.tiktok.com/blog/tiktok-sans-open-source)),
+white with black stroke or a highlight, lower-middle
+([Blitzcut](https://blitzcutai.com/blog/best-caption-style-tiktok)); 48–64 px at
+1080 wide ([AI Vid Genie](https://www.aividgenie.com/blog/caption-styles-that-boost-engagement));
+3–7 words, 1–3 s per chunk
+([OpusClip](https://www.opus.pro/blog/tiktok-caption-subtitle-best-practices));
+≤5–10 words per second on screen (TikTok help). Text hierarchy: hook 6–10 words
+upper-centre; benefit callouts lower-centre; CTA 2–3 words last seconds (mbadv).
+
+Native vs polished: TikTok-first content earns attention from 74% of viewers and
+3.3× more action (Creative Codes); lo-fi beats studio for cold audiences
+([Creative Clicks](https://www.creativeclicks.com/blog/ugly-ads-beautiful-roas-the-lo-fi-creative-effect-and-when-to-ditch-polish),
+[Search Engine Land](https://searchengineland.com/ugly-ads-outperforming-polished-creative-475007)).
+
+## 5. Audio conventions
+
+Sound mandatory in paid ads (policy); 88% of users call sound vital (Creative
+Codes); voiceover + offer text +87% conversion (TikTok). Speech 140–160 WPM
+([FlowShorts](https://flowshorts.app/blog/words-per-minute-speaking)). −14 LUFS
+integrated, −1 dBTP; music ducked 18–25 dB under voice
+([Mr Vocal](https://mrvocal.com/posts/loudness-for-shorts),
+[OpenClip](https://openclip.app/learn/audio-ducking)). Assume sound-off views
+too: captions carry the message.
+
+## 6. Technical specs
+
+| Item | Value | Source |
+|---|---|---|
+| Aspect / resolution | 9:16, 1080×1920; min 540×960 / ≥720p | in-feed spec, policy |
+| Container / codec | MP4/MOV, H.264 + AAC 44.1/48 kHz ≥192 kbps | [Triple Whale](https://www.triplewhale.com/blog/tiktok-ad-spec) |
+| Bitrate | ≥516 kbps minimum; export 6–8.5 Mbps @30 fps, 8–12 @60 | in-feed spec, [Conbersa](https://www.conbersa.ai/learn/vertical-video-export-settings-by-platform) |
+| Frame rate | 23–60 fps; 30 standard | mbadv |
+| File size | ≤500 MB | in-feed spec |
+| Duration | policy 5–60 s; auction up to 10 min; Spark unrestricted | policy, in-feed spec |
+| Static content | ≤50% static; no motionless ads | policy |
+| Captions | burn in for ads | [Video Captions AI](https://www.videocaptions.ai/how-to/caption-video-ads) |
+| Cover | first frame is the thumbnail | [TikAdSuite](https://tikadsuite.com/blog/create-thumbnails-for-tiktok-video-ads/) |
+
+## 7. TikTok's own guidance
+
+Creative Codes (six): TikTok-first, trends, production, structure, stimulation,
+sound. Help article: hook in first 6 s, offer in first 3 s, 5–10 words/sec, real
+people, DIY aesthetic, 3–5 creatives per ad group. Spark Ads: 134% higher
+completion, 157% higher 6-s VTR
+([Spark Ads 101](https://ads.tiktok.com/business/en-US/blog/spark-ads-101-make-tiktoks-into-ads)).
+Creative Center Top Ads shows CTR buckets and run length
+([AdLibrary](https://adlibrary.com/posts/tiktok-creative-center-guide),
+[Stackmatix](https://www.stackmatix.com/blog/tiktok-creative-center-guide)).
+
+## 8. Variant / A-B practice
+
+Keep the body identical, swap the first 2–3 s; 3–6 hook variants per body
+(Sink or Swim; [Stackmatix](https://www.stackmatix.com/blog/tiktok-ad-creative-best-practices-2026);
+DansUGC). Refresh every 10–14 days
+([RocketshipHQ](https://www.rocketshiphq.com/how-to-test-ad-creatives-on-tiktok/)).
+Metrics: 2-s and 6-s video views, views at 25/50/75/100%, average play time.
+Benchmarks (third party): 2-s hook rate 30–39% good, 40%+ exceptional; hold rate
+>60% strong; completion 25–35% average (Sepia;
+[Dataslayer](https://www.dataslayer.ai/blog/tiktok-ads-reporting-metrics-dashboards-2025)).
+Retention curve: near-vertical drop at 1–3 s = hook failure; half lost by
+midpoint = body failure.
+
+## 9. Failure modes
+
+Logo/slate opening; repurposed 16:9 asset; studio polish on cold audiences;
+text in the right rail or bottom 484 px; white background under white UI;
+captions <40 px or without stroke; static image >50%; no sound; no CTA or CTA
+only in the caption; CTA contradicting the button; other-platform watermarks
+(blurred ones are a policy violation —
+[SocialKit](https://socialk.it/en/blog/tiktok-watermark-reach-guide)); product
+absent past 6 s; >60 s to cold; realistic AI avatar without a label
+([Be Bold](https://www.bebolddigital.com/blog/ai-ugc-tiktok-ads)).
+
+## Rules a generator should enforce
+
+1. 1080×1920, 9:16, H.264/AAC MP4, 30 fps (60 if motion demands), 6–12 Mbps, ≤500 MB.
+2. 5–60 s for paid; 61–120 s only for explainer/tutorial/retargeting with the flag explicit. Default conversion 21–34 s; awareness 9–15 s.
+3. Hook in 0–3 s on all three channels: spoken line, on-screen text ≤8 words, visual stimulus within 1 s.
+4. No logo, slate, title card or static frame in the first 3 s.
+5. Product or offer visible or named by 3 s and on screen ≥30% of runtime.
+6. On-screen text within the first 7 s.
+7. Text and key visuals inside x 60–940, y 200–1436.
+8. Captions: bold sans-serif ≥48 px cap height, ≥4 px stroke, 1–7 words per chunk, 1–3 s per chunk, ≤10 words/sec, never covering a face.
+9. Mean shot length 1.5–3 s; ≥5 scenes for ≥15 s; no shot >5 s without change.
+10. No static image >50%; no interval >1 s without motion or audio.
+11. Audio required: −14 LUFS, −1 dBTP; music 18–25 dB under voice; 140–160 WPM; no silence >1.5 s except a pre-CTA beat.
+12. CTA in the last 3–5 s, spoken + on-screen 2–3 words, matching the button; no "swipe up"; "link in bio" only for Spark.
+13. One named formula; beats inside the length table.
+14. Re-hook every 15–20 s past 30 s.
+15. Word budget: 6 s ≤15, 15 s ≤42, 30 s ≤84, 60 s ≤160, 120 s ≤300.
+16. First frame is a deliberate cover.
+17. No third-party watermarks.
+18. No pure-white or transparent background near the UI.
+19. AI face or voice labelled.
+20. ≥3 hook variants per body differing only in 0–3 s, with a manifest naming each archetype.
+
+## QA checklist
+
+- ffprobe: 1080×1920, h264/aac, 23–60 fps, ≥6 Mbps, ≤500 MB, duration in band.
+- Frames at 0, 1, 2, 3 s each contain a face, product or motion; none a logo, slate or text card.
+- ASR first utterance ≤0.5 s and matches an archetype; hook overlay ≤8 words by 1 s.
+- Product visible or named by 3 s; cumulative on-screen ≥30%.
+- Any overlay present ≤7 s.
+- Overlay bounding boxes within the safe box (overlay a safe-zone PNG and check intersections).
+- Caption cap height ≥48 px, stroke present, chunk 1–7 words, 1–3 s, ≤10 words/sec, no overlap with a face box.
+- Shot boundaries: mean 1.5–3 s; longest ≤5 s; ≥5 scenes for ≥15 s.
+- No run of identical frames >1 s; static ≤50%.
+- Audio present; −16 to −12 LUFS; true peak ≤−1 dBTP; music ≥18 dB under speech; no gap >1.5 s; 130–170 WPM.
+- Last 5 s: CTA verb in ASR and overlay; equals button label; no forbidden gestures.
+- Script manifest names a formula; beats inside the table; words within budget.
+- Past 30 s: a re-hook in every 15–20 s window.
+- Frame 0: subject and text inside the centre 60%, luminance not near black.
+- Zero third-party marks; no blurred rectangles.
+- Right-rail and bottom regions not near-white at every sampled second.
+- AI label present where a synthetic face or voice is used.
+- Variant set: ≥3 files with identical body after 3 s and distinct hooks; manifest lists archetypes and the metrics to read.
+- Phone-size visual review with the ads UI overlay.

--- a/research/tiktok-video-tools-survey-2026-09-02.md
+++ b/research/tiktok-video-tools-survey-2026-09-02.md
@@ -1,0 +1,253 @@
+# Open-source toolchain survey: programmatic short-form vertical marketing video
+
+Research packet behind `example-workflows/references/tiktok-video-pipeline.md`.
+Surveyed 2026-09-02 by a web-research lane; star counts are as read from GitHub
+repo pages or star-history that day and are approximate. Not a library owner:
+the pipeline reference is what the workflow reads, this file is its evidence.
+
+## 1. Composition / rendering engines
+
+### Remotion — https://github.com/remotion-dev/remotion
+- ~58.0k stars, TypeScript/React. **Not OSI open source**: source-available, free
+  for individuals, non-profits, and companies with ≤3 employees; larger companies
+  need a Company License ($25/seat/mo "Creators" or $0.01/render with $100/mo
+  minimum for "Automators", i.e. any pipeline)
+  ([license FAQ](https://www.remotion.dev/docs/license/faq),
+  [pricing](https://www.remotion.dev/docs/license/pricing)).
+- Steal: the frame-as-function-of-time model (`useCurrentFrame()`, `<Sequence>`,
+  `<Series>`, `interpolate`) makes every animation deterministic and testable;
+  `@remotion/captions` defines the cleanest caption data model in the ecosystem —
+  a flat array of `{text, startMs, endMs, timestampMs, confidence}` tokens fed to
+  `createTikTokStyleCaptions({combineTokensWithinMilliseconds,
+  breakOnSilenceAfterMilliseconds})` returning
+  `pages[{text, startMs, durationMs, tokens[{fromMs,toMs}]}]`; active-word
+  highlighting compares playback time to `token.fromMs/toMs`
+  ([docs](https://www.remotion.dev/docs/captions/create-tiktok-style-captions)).
+  `@remotion/install-whisper-cpp` and `@remotion/whisper-web` normalise Whisper
+  output into that shape. The official
+  [template-tiktok](https://github.com/remotion-dev/template-tiktok) is the
+  reference implementation of word-by-word TikTok captions;
+  [remotion-dev/skills](https://github.com/remotion-dev/skills) packages
+  captions/transitions/rendering guidance as agent skills.
+- Weakness: licensing cost at company scale; Chromium rendering is CPU-heavy;
+  React is mandatory.
+
+### HyperFrames (HeyGen) — https://github.com/heygen-com/hyperframes
+- ~43.6k stars, TypeScript, **Apache-2.0**. Plain `index.html` + CSS + data
+  attributes for timing, animations through adapters (GSAP, CSS, Lottie,
+  Three.js, WAAPI), frames captured deterministically via headless Chrome and
+  encoded with FFmpeg.
+- Steal: HTML as the composition format so any LLM authors it without a build
+  step; the bundled agent skills with a router (`/product-launch-video`,
+  `/faceless-explainer`, `/motion-graphics`) are the marketing-video taxonomy;
+  targets 30–90 s clips.
+- Weakness: young; animations must stay seekable (no wall-clock time) or frames
+  drift; Lambda rendering adds deployment overhead; HeyGen-controlled roadmap.
+
+### Motion Canvas — https://github.com/motion-canvas/motion-canvas
+- ~19k stars, TypeScript, MIT. Generator-function animation with a live editor
+  and audio-sync timeline. Steal: generator sequencing reads like a storyboard.
+  Weakness: explainer/vector oriented, no headless render API in core, slower
+  maintenance.
+
+### Revideo — https://github.com/midrender/revideo
+- ~4.0k stars, TypeScript, MIT. Motion Canvas fork with `renderVideo()` headless
+  API, parallel workers, React `<Player/>` with dynamic inputs. Steal: preview
+  and final render share one scene definition with typed inputs — the
+  template-plus-variables model variant generation needs. Weakness: small
+  community, commercial-product priorities, telemetry on by default.
+
+### editly — https://github.com/mifi/editly
+- ~5.5k stars, Node, MIT. Declarative JSON edit spec → ffmpeg, streaming.
+  Steal: the JSON spec shape `{outPath, width, height, fps, defaults, clips[{duration,
+  transition, layers[{type: video|image|title|subtitle|...}]}], audioTracks[],
+  audioNorm}` — the simplest Creatomate-like model in OSS;
+  [vidapi](https://github.com/moshehbenavraham/vidapi) wraps it as a self-hosted
+  render API. Weakness: dormant for years (new maintainer, RC); no word-level
+  caption layer; GL/canvas layers need headless GPU deps.
+
+### Diffusion Studio core — https://github.com/diffusionstudio/core
+- ~1.2k stars, TypeScript, MPL-2.0. Browser-only WebCodecs compositor. Steal: the
+  hardware-accelerated render path and a CapCut-like caption API. Weakness: no
+  server rendering.
+
+### OpenCut — https://github.com/OpenCut-app/OpenCut
+- ~88.4k stars, MIT. The "open-source CapCut"; a rewrite is in progress with a
+  planned Editor API, plugin system, MCP server and headless batch rendering.
+  Steal: watch its headless mode as the human-in-the-loop editor. Weakness:
+  pre-release; nothing to build a pipeline on today.
+
+### MoviePy — https://github.com/Zulko/moviepy
+- ~14.9k stars, Python, MIT. Fastest way to prototype captions in Python;
+  captacity and MoneyPrinter v1 build on it. Weakness: numpy round-trips make
+  renders far slower than ffmpeg filtergraphs; v1→v2 breaks.
+
+### ffmpeg wrappers
+- [ffmpeg-python](https://github.com/kkroening/ffmpeg-python): ~11k stars,
+  Apache-2.0, last release 2019 — frozen.
+  [PyAV](https://github.com/PyAV-Org/PyAV) (~3.2k, BSD) is the maintained
+  frame-level alternative. Winning pattern: generate the ffmpeg CLI string
+  yourself.
+
+## 2. AI short-video generators (topic → finished video)
+
+### MoneyPrinterTurbo — https://github.com/harry0703/MoneyPrinterTurbo
+- ~119.6k stars, Python, MIT. LLM script → search terms → Pexels/Pixabay/Coverr
+  clips (or generated) → Edge TTS / Azure / ElevenLabs → subtitles from Whisper
+  or TTS timestamps → ffmpeg assembly with BGM; 9:16 and 16:9, batch, CLI +
+  WebUI + API + MCP.
+- Steal: subtitle source = TTS timestamps first, Whisper as fallback; the
+  search-terms step (LLM emits per-scene keywords beside the narration) is the
+  data model everyone copies; config-as-preset export.
+- Weakness: generic stock-footage-plus-robot-voice output; basic captions;
+  Python 3.11 + 3 GB Whisper download.
+
+### MoneyPrinter (v1) — https://github.com/FujiwaraChoki/MoneyPrinter
+- ~13.9k stars, MIT. Ollama → Pexels → TikTok TTS/EdgeTTS → MoviePy →
+  AssemblyAI; Postgres-backed restart-safe queue. V2 (~31.5k) is AGPL-3.0.
+  Steal: the job queue.
+
+### ShortGPT — https://github.com/RayVentura/ShortGPT
+- ~7.9k stars, Python, MIT. Stepwise engines with TinyDB-persisted state so
+  reruns skip done steps; an LLM-readable editing markup; translation/dubbing.
+  Weakness: largely unmaintained, dated captions.
+
+### NarratoAI — https://github.com/linyqh/NarratoAI
+- ~11k stars, Python, MIT. Commentary over existing footage: VLM frame analysis
+  → LLM screenplay → clip selection → TTS → subtitles. Steal: vision-model shot
+  analysis as script input, so a script references what is on screen.
+
+### short-video-maker — https://github.com/gyoridavid/short-video-maker
+- ~1.3k stars, TypeScript, MIT. Remotion + Kokoro.js + whisper.cpp + Pexels +
+  ffmpeg as MCP + REST. Scene model `{text, searchTerms}`; caption position,
+  music mood, orientation, 28 Kokoro voices. Steal: the most modern near-keyless
+  stack and the minimal scene schema. Weakness: English-only, Pexels-only, no own
+  media.
+
+### Faceless generators (illustrative)
+- VUZA, Viral-Faceless-Shorts-Generator, SaarD00/AI-Youtube-Shorts-Generator:
+  steal only the manual approval gate between script and render.
+
+## 3. Auto-clippers (long video → shorts)
+
+- [OpenShorts](https://github.com/mutonby/openshorts) (~3.8k, MIT): Gemini
+  moment detection → MediaPipe + YOLOv8 face tracking with
+  TRACK/GENERAL/SPLIT/SCREENCAST layouts → faster-whisper word subtitles;
+  MCP + REST + webhooks. Steal: the layout-mode enum (SCREENCAST is what
+  product-demo reframing needs).
+- [AI-Youtube-Shorts-Generator](https://github.com/SamurAIGPT/AI-Youtube-Shorts-Generator)
+  (~4.8k, MIT): rank → dedupe overlaps → top-N selection loop.
+- [ClipsAI](https://github.com/ClipsAI/clipsai) (538, MIT): clean library API.
+- [opensource-clipping](https://github.com/NaufalRizqullah/opensource-clipping)
+  (85, MIT): the one small repo implementing ducking + b-roll + karaoke captions
+  together.
+
+## 4. Subtitles / captions
+
+- [whisper.cpp](https://github.com/ggml-org/whisper.cpp) (~53.4k, MIT): `-ml 1`
+  word timestamps, CPU-friendly; heuristic timing.
+- [faster-whisper](https://github.com/SYSTRAN/faster-whisper) (~25.2k, MIT):
+  `word_timestamps=True`, Silero VAD, int8 CPU; default ASR for Python.
+- [whisperX](https://github.com/m-bain/whisperX) (~23.8k, BSD-2): wav2vec2
+  forced alignment (sub-100 ms words). Numerals and currency get no timestamps —
+  pre-normalise the script to words.
+- [captacity](https://github.com/unconv/captacity) (138, MIT): style dict (font,
+  size, colour, stroke, shadow, `highlight_current_word`, `line_count`) — a
+  caption theme schema.
+- Rendering options: DOM captions (Remotion/HyperFrames); ASS/libass `\k`/`\kf`
+  karaoke tags burned via `ffmpeg -vf "ass=captions.ass"` — no browser, 4–6
+  words per page, 50–100 ms gaps between highlights
+  ([guide](https://vidno.ai/blog/karaoke-style-word-highlight-captions)); PIL
+  PNG overlays.
+
+## 5. TTS
+
+| Tool | Stars | License | Notes |
+|---|---|---|---|
+| [Kokoro](https://github.com/hexgrad/kokoro) | ~8.7k | Apache-2.0 | 82M params, 9 languages, CPU; no cloning; espeak-ng/misaki. Best default keyless voice. |
+| [edge-tts](https://github.com/rany2/edge-tts) | ~11.8k | GPL-3.0 | Edge Read Aloud, `--write-subtitles` word boundaries; unofficial, ToS risk. |
+| [Piper](https://github.com/OHF-Voice/piper1-gpl) | ~5.4k | GPL-3.0 | Fast CPU; robotic vs Kokoro. |
+| [Chatterbox](https://github.com/resemble-ai/chatterbox) | ~26.2k | MIT | Turbo/Nano/Multilingual V3 (23+ langs); zero-shot cloning, `exaggeration` knob, watermark; blind test 65% preferred vs ElevenLabs ([source](https://findskill.ai/blog/best-open-source-tts-2026/)). |
+| [Qwen3-TTS](https://github.com/QwenLM/Qwen3-TTS) | ~13.2k | Apache-2.0 | 10 langs, 3-s cloning, voice design from a description. |
+| [Fish Speech](https://github.com/fishaudio/fish-speech) | ~32.5k | bespoke | check commercial terms. |
+| [F5-TTS](https://github.com/SWivid/F5-TTS) | ~15.2k | MIT code, CC-BY-NC weights | non-commercial. |
+| [OpenVoice](https://github.com/myshell-ai/OpenVoice) | ~37.4k | MIT | tone-colour converter over a base TTS. |
+| [XTTS-v2 fork](https://github.com/idiap/coqui-ai-TTS) | ~2.3k | CPML weights | non-commercial; avoid. |
+| ElevenLabs (hosted) | — | commercial | `/with-timestamps` returns character alignment ([API](https://elevenlabs.io/docs/api-reference/text-to-speech/convert-with-timestamps)). |
+
+## 6. Stock, b-roll, generative
+
+- [Pexels](https://www.pexels.com/api/documentation/): `/videos/search?orientation=portrait`,
+  200 req/h, 20k/mo; attribution when possible.
+  [Pixabay](https://pixabay.com/api/docs/): `orientation=vertical`, 100 req/min.
+- Local generative video: [Wan 2.2](https://github.com/Wan-Video/Wan2.2) (~17.4k,
+  Apache-2.0; TI2V-5B does 5 s 720p in under 9 min on a 24 GB card; later Wan
+  versions are API-only); [LTX-2](https://github.com/Lightricks/LTX-2) (~9.3k,
+  synchronised audio + video, ~66 GiB);
+  [HunyuanVideo-1.5](https://github.com/Tencent-Hunyuan/HunyuanVideo-1.5);
+  [CogVideoX-1.5](https://github.com/zai-org/CogVideo) (cheapest, ~3.6–5 GB int8);
+  [Wan2GP](https://github.com/deepbeepmeep/Wan2GP) for 6 GB VRAM. Stills:
+  [FLUX.2 klein 4B](https://github.com/black-forest-labs/flux2) (Apache-2.0).
+- For marketing videos generative video is an accent (a 3–5 s hook shot), not the
+  b-roll backbone.
+
+## 7. Music
+
+- Pixabay Music (no attribution, TikTok-ad OK), Free Music Archive (filter NC),
+  Incompetech (CC-BY), YouTube Audio Library.
+- Beat detection: `librosa.beat.beat_track` → `frames_to_time`
+  ([docs](https://librosa.org/doc/0.11.0/generated/librosa.beat.beat_track.html)).
+- Ducking: `[music][voice]sidechaincompress=threshold=0.03:ratio=8:attack=20:release=300[duck];[voice][duck]amix=inputs=2`
+  ([FFmpegLab](https://www.ffmpeglab.com/articles/ffmpeg-audio-mixing-amix-guide.html)),
+  or a static `volume=0.15`.
+
+## 8. Screen / product capture
+
+- Playwright `recordVideo`: set `viewport` to 1080x1920 and `recordVideo.size`
+  ([docs](https://playwright.dev/docs/videos)) — deterministic SaaS demo shots.
+- [Screenity](https://github.com/alyssaxuu/screenity) (~18.7k, GPL-3.0) and OBS +
+  [obs-websocket](https://github.com/obsproject/obs-websocket) for human-driven
+  capture.
+
+## 9. QA
+
+- [PySceneDetect](https://github.com/Breakthrough/PySceneDetect) (~5.1k, BSD-3):
+  verify b-roll has no internal cuts; cuts-per-10 s as a pacing metric.
+- Loudness: two-pass `loudnorm` (`I=-14:TP=-1.5:LRA=11:print_format=json`, then
+  feed `measured_*`)
+  ([guide](https://dev.to/masonwritescode/two-pass-loudness-normalization-with-ffmpeg-loudnorm-the-right-way-1nm3)).
+- Specs: 1080x1920, H.264 + AAC, 30 fps, 8–15 Mbps upload; 15–30 s highest
+  engagement; safe zones top ~150–250 px, right ~120–240 px, bottom ~300–500 px
+  ([Zeely](https://zeely.ai/blog/tiktok-safe-zones/),
+  [Recharm](https://www.recharm.com/blog/tiktok-video-ad-specs)).
+
+## 10. Synthesis
+
+Convergent data model across the strong repos:
+
+    Brief → Script{hook, beats[{narration, on_screen_text, visual_query|asset_ref, duration_hint}], cta}
+          → Assets{per beat: file, source, licence, w×h, trimmed_range}
+          → Voice{wav per beat + word_timestamps[]}
+          → Captions{tokens[{text,startMs,endMs}] → pages[]}
+          → Composition (typed template + inputs) → Render → QA report → Variants
+
+Every stage writes a JSON artifact to a run directory so any stage is
+re-runnable (ShortGPT's TinyDB idea, MoneyPrinter's queue idea).
+
+| Stage | Zero-API-key path | Quality path |
+|---|---|---|
+| Brief → Script | Local LLM emitting the schema; hook ≤10 words; manual approval gate | Claude/GPT with the same schema; VLM pass over product footage |
+| Assets | Own footage via Playwright at 1080x1920 + FLUX.2 klein stills; Pexels/Pixabay need a free key | Same plus 1–2 generative hook shots (Wan 2.2 / LTX-2 locally) |
+| Voice | Kokoro | Chatterbox or Qwen3-TTS; ElevenLabs for brand voices |
+| Captions | faster-whisper over the generated audio | whisperX alignment, or ElevenLabs timestamps |
+| Composition | HyperFrames, or ASS karaoke burned by ffmpeg | Remotion where the licence fits; Revideo for MIT typed inputs |
+| Render | ffmpeg libx264 crf 18–20, yuv420p, 30 fps, faststart, AAC 192k; sidechain ducking | Same; Lambda fan-out |
+| QA | ffprobe, two-pass loudnorm, PySceneDetect pacing, caption bbox inside safe zone, hook text in frames 0–90, CTA in last 3 s, no silence >1.5 s | Add a VLM frame-grid review |
+| Variants | Matrix over hook line × voice × music × caption theme; shared beats cached | Per-platform re-exports and per-language dubs |
+
+Recommendation: HyperFrames (composition) + Kokoro (voice) +
+faster-whisper/whisperX (word timing) + Pexels/Playwright (assets) + ffmpeg
+(render, ducking, loudnorm) + PySceneDetect/ffprobe (QA), adopting
+MoneyPrinterTurbo's `{narration, search_terms}` beat schema and Remotion's
+caption token→pages model as interchange formats; Remotion only where its
+licence fits; Chatterbox/ElevenLabs when the brief demands a branded voice.

--- a/tests/test_static_tree_invariants_cases/compositions.py
+++ b/tests/test_static_tree_invariants_cases/compositions.py
@@ -36,7 +36,7 @@ class TestWorkflowSkills(unittest.TestCase):
 
     WORKFLOWS = (
         "benchmaker", "browser-game", "drift-canary", "evolve", "renovate",
-        "self-improve", "skill-tournament", "super-research",
+        "self-improve", "skill-tournament", "super-research", "tiktok-video",
     )
 
     def test_every_workflow_directory_holds_exactly_one_body(self):


### PR DESCRIPTION
## Summary

Adds `example-workflows/tiktok-video`, a manual-only workflow that turns any subject into judged, rendered 9:16 TikTok marketing videos of 1–120 s. Designed from a two-lane research pass (open-source video tooling; TikTok's own creative codes, conversion study and in-feed spec), both packets saved under `research/`.

Five calls under one frame:

- **Brief** (`orch-research-pack`): cited audience pains, proof points, competitor hooks, live trends.
- **Scripts** (`orch-content-pack`): three hook-archetype variants for the length and goal, plus a six-second cutdown.
- **Script judge** (`orch-content-pack`): ranks against the rules' hook/structure/CTA checks; one repair round.
- **Render** (`orch-code-pack`, isolated): voice, word-timed captions, footage, ducked music, MP4s, cover, contact sheet, safe-zone captures; `done` is a spec probe over every MP4.
- **Render judge** (`orch-design-pack`): captures against safe zones, caption legibility, brand tokens, pacing; one repair round.

Two references sit beside the body: `tiktok-video-rules.md` (TikTok craft written as checks — hook spoken + on-screen + visual by 1 s, 21–34 s for conversion, safe box x 60–940 / y 200–1436, word-pop captions ≥ 48 px with stroke, −14 LUFS, CTA matching the button; blocking-finding list) and `tiktok-video-pipeline.md` (stack per stage with keyless and quality paths: HyperFrames or Remotion, Kokoro or Chatterbox, faster-whisper/whisperX, Pexels or Playwright, ffmpeg loudnorm + sidechain ducking, PySceneDetect; licence traps named).

The reader catalog manifest, `CANONICAL_WORKFLOW_IDS`, its two tests, and the static-tree invariant gain the new gallery name.

## Verification

`python tools/run_required.py --no-cache`: all five checks 0 (validate, run_tests 90 modules / 2156 tests, serial-compat, install dry-run, diff-check). Body is 435/450 words, description 124/140 chars.

## Not done

Not yet dogfooded: no run has invoked it. Suggested first run is a 15 s subject with `keys: none`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
