### PR TITLE
super-research workflow: a rendered dossier is the frame's last callable

### DIFF
--- a/example-workflows/super-research/SKILL.md
+++ b/example-workflows/super-research/SKILL.md
@@ -4,38 +4,35 @@ description: Answer one bounded, keyless research question with cited, dated, ga
 disable-model-invocation: true
 ---
 
-Require: one bounded `question` naming the live sources it reaches, the
-`window` it is asked over where it has one, a frozen `as_of` at or after
-this run's own reads, and a hard per-step item cap.
+Require: one bounded `question` naming its live sources, its `window`
+where it has one, a frozen `as_of` at or after the run's own reads, and a
+hard per-step cap.
 
-Open the frame first, its goal the answered question:
+Open the frame, its goal the answered question:
 
     tickets.py frame-open <run> --goal-file <question-goal> --workflow super-research
 
-The frame's `## Report` is your working memory, not a courtesy. Begin every
-wave by re-reading the frame and its children from the sink, then append
-that wave's decision with `tickets.py result <run> <frame> --by <frame>`.
+The frame's `## Report` is your working memory: re-read it and its
+children before every wave, then append the wave's decision with
+`tickets.py result <run> <frame> --by <frame>`.
 
-**Acquisition — one call per named source, all launched together.** For
-each source the question names, one line:
+**Acquisition — one call per named source, launched together.**
 
     tickets.py do <run> --pack orch-research-pack --parent <frame>
       --goal-file <source-goal> --bound "<= 40 tool calls"
 
-Each source goal names exactly one source, the window, the frozen `as_of`
-and the cap, and directs the child to enter the `super-research` skill by
-name, forwarding its own launch prompt verbatim, at the `SKILL.md` path
-`orchflows list --kind skill` resolves — the goal carries that path, so no
-child searches for it, and a body that opens a frame is this workflow's
-adapter sharing the name, never the skill. That skill's own Require,
-Preparation, Never and Return bind the child and are not restated here; its
-Return is what fills the `artifact: evidence:` line. Time-bounding is
-declared per operation, not per source — that skill's own `WINDOW_REACH`
-table is the authority — so a windowed call whose operation cannot bound
-time at its origin comes back carrying `window_not_honored`.
-Name that in the goal, so the child files a declared gap rather than a
-silence. Keep each returned `artifact: evidence:<store-id>` line verbatim;
-it is what the next call is handed.
+Each goal names one source, the window, the `as_of` and the cap, and
+directs the child to enter the `super-research` skill by name with its
+launch prompt forwarded verbatim, at the `SKILL.md` path
+`orchflows list --kind skill` resolves — carry that path, so no child
+searches; a body that opens a frame is this workflow's same-named
+adapter. That skill's Require, Preparation, Never and Return bind the
+child; its Return fills the `artifact: evidence:` line. Time-bounding is
+per operation — the skill's `WINDOW_REACH` table decides — so a windowed
+call whose operation cannot bound time at its origin returns
+`window_not_honored`; name it in the goal, so the child files a gap, not
+a silence. Keep each returned `artifact: evidence:<store-id>` line
+verbatim; the next call is handed it.
 
 **Coverage loop, at most two rounds.**
 
@@ -43,11 +40,22 @@ it is what the next call is handed.
       --artifacts evidence:<id> [--artifacts ...] --goal-file <coverage-goal>
 
 The coverage goal asks one thing: which sub-questions no record answers,
-and which typed losses the acquisition returned. Keep the returned
-`findings: <path>` line verbatim. Round two exists only for the gaps that
-judge named — one further `do` per named gap, quoting the finding and the
-source that can close it, then one final `judge` over the enlarged set.
-Two rounds is the bound; a gap still open is declared in the answer.
+and which typed losses came back. Keep the `findings: <path>` line
+verbatim. Round two exists only for the gaps judge named — one `do` per
+gap, quoting the finding and the source that closes it, then one final
+`judge` over the enlarged set; a gap still open is declared.
+
+**Report, one call, the frame's last.**
+
+    tickets.py do <run> --pack orch-content-pack --parent <frame>
+      --goal-file <report-goal> --bound "<= 40 tool calls"
+
+Its goal hands every `artifact:` and `findings:` line verbatim and asks
+for one self-contained rendered dossier — one HTML file, no external
+fetch, legible in light and dark — answering first, then each source's
+evidence dated and cited from its `normalized_locator`, every typed loss,
+contradiction and open sub-question, under the skill's five report rules.
+Keep its `artifact: doc:` line verbatim.
 
 Never: average contradicting sources, read a typed loss as an absence,
 quote a community comment without its author and count, or close over the
@@ -55,6 +63,6 @@ acquisition children with neither a coverage judge nor an
 `unjudged: <reason>` journal line.
 
 Return: `tickets.py frame-close <run> <frame> --done <verifier>`, whose
-done is the dossier verifier — every load-bearing claim cited from its
-`normalized_locator` and dated, every loss stated, every unanswered
+done is the dossier verifier over that `doc:` identity — every
+load-bearing claim cited and dated, every loss stated, every unanswered
 sub-question declared.


### PR DESCRIPTION
## What changed

The super-research workflow ended at `frame-close --done <verifier>`, a "dossier verifier" over a dossier nothing in the workflow produced. The worker skill's five report rules govern content only; no step rendered anything.

This adds **Report** as the frame's last callable in `example-workflows/super-research/SKILL.md`: one `do --pack orch-content-pack` handed every `artifact:` and `findings:` line verbatim, asking for one self-contained HTML dossier (no external fetch, legible in light and dark) that answers first, then lays out each source's evidence dated and cited from its `normalized_locator`, every typed loss, contradiction and open sub-question, under the skill's five report rules. `frame-close`'s done now verifies that `doc:` identity.

**Why the content pack.** A dossier is a document read by humans. The design pack's craft is breakpoints, captures and golden identities, which is interface machinery.

Body trimmed to 448 of the 450-word workflow budget.

## Worked example
PANW short-term sentiment dossier, 2026-09-02, from a 136-record discovery run plus a 38-record depth pass (7 transcripts, 17 Reddit comments): https://claude.ai/code/artifact/fca9f69a-144c-4651-9b50-ec79adc21625

## Checks
`tools/run_required.py --no-cache` → all five 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
