### PR TITLE
Dynamic routing: the shape line and the research cut door

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -42,7 +42,8 @@ family's five owner modules.
   `tickets_join.py` reserved outcome import and outcome-fenced lifecycle joins;
   `tickets_emission.py` emission grading; `tickets_issue_render.py`
   issuance markdown; `tickets_mint.py` and `tickets_frame.py` the callable
-  and frame minting commands;
+  and frame minting commands; `tickets_shape.py` the shape-line grammar a
+  frame states its wave plan in;
   `tickets_dispatch_launch.py` the host binding,
   `tickets_dispatch_launch_lines.py` the prompt's lines. `cutcheck.py`
   owns structural graph validation.

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -33,17 +33,16 @@ family's five owner modules.
 - [`scripts/`](scripts/) owns repository automation. Programs use Python
   3.9+, Windows and POSIX, then no network. An unprefixed family module is
   the public command and import facade; same-family helpers own internal concerns.
-  `tickets_format.py` owns syntax, closed parsers, and the pack registry;
+  `tickets_format.py` owns syntax, closed parsers, the pack registry;
   `tickets_markdown.py` semantic payload parsing and byte preservation;
   `tickets_admission.py` receipt lifecycle; `tickets_generations.py` immutable
   generation and seal identities; `tickets_project.py` run-project binding;
-  `tickets_dispatch_schema.py` validates dispatch grammar; `tickets_attempts.py`
+  `tickets_dispatch_schema.py` dispatch-grammar validation; `tickets_attempts.py`
   mutates atomically;
   `tickets_join.py` reserved outcome import and outcome-fenced lifecycle joins;
   `tickets_emission.py` emission grading; `tickets_issue_render.py`
   issuance markdown; `tickets_mint.py` and `tickets_frame.py` the callable
-  and frame minting commands; `tickets_shape.py` the shape-line grammar a
-  frame states its wave plan in;
+  and frame minting commands; `tickets_shape.py` shape-line grammar;
   `tickets_dispatch_launch.py` the host binding,
   `tickets_dispatch_launch_lines.py` the prompt's lines. `cutcheck.py`
   owns structural graph validation.

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -42,7 +42,7 @@ family's five owner modules.
   `tickets_join.py` reserved outcome import and outcome-fenced lifecycle joins;
   `tickets_emission.py` emission grading; `tickets_issue_render.py`
   issuance markdown; `tickets_mint.py` and `tickets_frame.py` the callable
-  and frame minting commands; `tickets_shape.py` shape-line grammar;
+  and frame minting commands; `tickets_shape_line.py` shape-line grammar;
   `tickets_dispatch_launch.py` the host binding,
   `tickets_dispatch_launch_lines.py` the prompt's lines. `cutcheck.py`
   owns structural graph validation.

--- a/docs/custom-workflow-authoring.md
+++ b/docs/custom-workflow-authoring.md
@@ -114,7 +114,12 @@ it. A frame is pack-less and lease-less: it is a journal, not
 craft-governed work, and its driver is the session you are already talking
 to. Write the calls in whatever order, parallelism, branching or bounded
 repetition the job needs — that prose *is* the control flow, and there is no
-engine under it to keep in step.
+engine under it to keep in step. That prose is also the frame's shape, so a
+saved workflow's root `frame-open` names `--workflow <name>` instead of
+`--shape "<line>"`: the body a reader can already open is the wave plan, and
+restating it on the command line would be the same plan in two places. Only
+a driver improvising the waves writes the line itself
+([vocabulary](vocabulary.md)'s **routing shape** owns its grammar).
 
 Two obligations your body has to state for its driver, both defined
 elsewhere: the **typed artifact line**

--- a/docs/vocabulary.md
+++ b/docs/vocabulary.md
@@ -228,7 +228,12 @@ invented for this library.
   is refused to the `worker` lane and one that is `direct` opens no frame
   at all. `--workflow NAME` stands in for a line when a saved workflow's
   body is the plan, and a `--parent` frame states none: it is already one
-  wave of its caller's.
+  wave of its caller's. Before writing the line, a root asks in order: one
+  independent unit is `do`; two or more — sub-questions, files, features
+  needing no result of each other's — are one `[...]` wave. A goal whose
+  done predicate cannot be written yet opens with the lanes that would
+  settle it and an `outline` over what they find. A wrong result dearer
+  than one more child ends the line `> judge`.
 - **tracker** — the state sink's `tickets/` directory; there is no external
   tracker.
 - **executor** — the named skill a work item's frontmatter binds to do the

--- a/docs/vocabulary.md
+++ b/docs/vocabulary.md
@@ -216,6 +216,19 @@ invented for this library.
   below, and the lane took `worker` and `team` instead. `brick` is retired
   outright, noun and all: see **callable**, above.
   Small, medium and large are explanatory mappings, never ticket fields.
+  A **shape line** is how a `team` frame states its wave plan before its
+  first dispatch, and this entry is its whole grammar: names are free
+  identifiers; `>` separates waves in order; `[a, b]` is one wave run in
+  parallel; `name[*]` is a count an `outline` decides; `do`, `outline` and
+  `judge` are the reserved names, binding the kernel verbs of those names.
+  `tickets.py frame-open --shape "<line>"` parses it, files it as the
+  frame's first journal record, and `frame-close` prints it beside the
+  census it actually minted — printed for a reader, never refused on, since
+  a plan the work outgrew is the ordinary case. A line that is exactly `do`
+  is refused to the `worker` lane and one that is `direct` opens no frame
+  at all. `--workflow NAME` stands in for a line when a saved workflow's
+  body is the plan, and a `--parent` frame states none: it is already one
+  wave of its caller's.
 - **tracker** — the state sink's `tickets/` directory; there is no external
   tracker.
 - **executor** — the named skill a work item's frontmatter binds to do the

--- a/example-workflows/benchmaker/SKILL.md
+++ b/example-workflows/benchmaker/SKILL.md
@@ -13,7 +13,7 @@ rule or contract owns is [the protocol](../references/benchmaker-protocol.md);
 the manifest's field set is [its own](../references/benchmaker-manifest.md);
 acquisition's lane cut is [the charter's](../references/benchmaker-research.md).
 
-    tickets.py frame-open <run> --goal-file <benchmark-goal>
+    tickets.py frame-open <run> --goal-file <benchmark-goal> --workflow benchmaker
 
 Re-read the frame's `## Report` and its children before each call, and
 append every decision back with `tickets.py result <run> <frame> --by

--- a/example-workflows/browser-game/SKILL.md
+++ b/example-workflows/browser-game/SKILL.md
@@ -25,7 +25,7 @@ never become defaults: an empirical gap becomes a declared experiment, a
 `kind: user-only` gap one verbatim question for the root to relay, and
 neither blocks the other.
 
-    tickets.py frame-open <run> --goal-file <program-goal>
+    tickets.py frame-open <run> --goal-file <program-goal> --workflow browser-game
 
 Re-read the frame's `## Report` and its children before each call, append
 the decision with `tickets.py result <run> <frame> --by <frame>`, and keep
@@ -61,14 +61,14 @@ trigger identity stays `inactive`.
 **Checkpoint**, one `judge --pack orch-content-pack` over both artifact
 lines: exactly one disposition — `advance`, `revise`, `experiment`,
 `user-decision-required` or `stop` — bound to its governing requirement, the
-fixed record revision and the evidence identity. Its findings validate
+fixed record revision and evidence identity. Its findings validate
 against the
 [checkpoint contract](../references/browser-game-checkpoint.schema.json).
 Only where that disposition is lawful does one further
 `do --pack orch-content-pack` materialize the
 [pack-separated successor plan](../references/browser-game-program-record.schema.json#/$defs/successorPlanRevision),
 each ordered entry preserving its artifact identity, artifact kind, matching
-pack, proposed run/root identities, dependencies and `planned`/`opened`
+pack, run/root identities, dependencies and `planned`/`opened`
 status.
 
 Never: invent a stack, cohort, support promise, budget, fallback, provider

--- a/example-workflows/drift-canary/SKILL.md
+++ b/example-workflows/drift-canary/SKILL.md
@@ -10,7 +10,7 @@ reads against. There is no scheduler: a profiles change or an announced
 model update is a person invoking this by name, which is why it never
 model-invokes.
 
-    tickets.py frame-open <run> --goal-file <drift-goal>
+    tickets.py frame-open <run> --goal-file <drift-goal> --workflow drift-canary
 
 Re-read the frame's `## Report` and its children before each wave, and
 append the wave's decision with `tickets.py result <run> <frame> --by

--- a/example-workflows/evolve/SKILL.md
+++ b/example-workflows/evolve/SKILL.md
@@ -11,7 +11,7 @@ identity — mode, criteria, promotion rule, margin and search policy — or
 is written through; `bound`, the campaign's budget; and `mutation_scope`,
 the candidate workspace, which is the campaign call's alone.
 
-    tickets.py frame-open <run> --goal-file <campaign-goal> --bound <bound>
+    tickets.py frame-open <run> --goal-file <campaign-goal> --bound <bound> --workflow evolve
 
 The frame's `## Report` is the campaign ledger. Re-read it and every child's
 state from the sink before each generation, then append that generation's

--- a/example-workflows/renovate/SKILL.md
+++ b/example-workflows/renovate/SKILL.md
@@ -9,7 +9,7 @@ maintainer's lens, which stands in for the spec nobody wrote; `audit_bound`
 and `brief_bound`, the two budgets; and `pack`, the stamp every call here
 carries.
 
-    tickets.py frame-open <run> --goal-file <renovation-goal>
+    tickets.py frame-open <run> --goal-file <renovation-goal> --workflow renovate
 
 Re-read the frame's `## Report` and its children before each call, then
 append the decision with `tickets.py result <run> <frame> --by <frame>`.

--- a/example-workflows/skill-tournament/SKILL.md
+++ b/example-workflows/skill-tournament/SKILL.md
@@ -16,7 +16,7 @@ before the first candidate existed, and that no candidate and no generation
 may touch afterwards. Both halves are workflows, not calls: each opens its
 own frame under this one, and the ticket tree is the call tree.
 
-    tickets.py frame-open <run> --goal-file <tournament-goal> --bound <bound>
+    tickets.py frame-open <run> --goal-file <tournament-goal> --bound <bound> --workflow skill-tournament
 
 Re-read this frame's `## Report` and its children before each half, and
 append the decision with `tickets.py result <run> <frame> --by <frame>`.

--- a/packs/orch-research-pack/references/craft.md
+++ b/packs/orch-research-pack/references/craft.md
@@ -38,6 +38,9 @@ that must exist for it
 
 - One question rather than a topic, plus the sub-questions its answer has to
   reach before coverage can be claimed.
+- Those sub-questions sit under a heading whose text carries `sub-questions`,
+  as a numbered list with one item per sub-question — the form a `do` is
+  counted against, since each item is a lane.
 - Source policy and rigor bar together; the bar is the evidence a load-bearing
   claim must have, never an adjective.
 - The recency window that policy admits, and the store its packets land in.

--- a/scripts/orchflows_scaffold.py
+++ b/scripts/orchflows_scaffold.py
@@ -82,7 +82,7 @@ disable-model-invocation: true
 
 Require: what the caller supplies before {name} can start.
 
-    tickets.py frame-open <run> --goal-file <goal>
+    tickets.py frame-open <run> --goal-file <goal> --workflow {name}
 
 Re-read the frame's `## Report` and its children before each wave, then
 append that wave's decision with `tickets.py result <run> <frame> --by

--- a/scripts/tickets_frame.py
+++ b/scripts/tickets_frame.py
@@ -53,7 +53,7 @@ if __package__:
     from .tickets_result import (
         RESULT_ATTRIBUTION_PREFIX, _append_event, _cmd_result,
     )
-    from .tickets_shape import (
+    from .tickets_shape_line import (
         SHAPE_PREFIX, SHAPE_RECORD_ID, SHAPE_USAGE, journal_shape,
         shape_for, shape_record,
     )
@@ -83,7 +83,7 @@ else:  # pragma: no cover - direct/installed flat script path
     from tickets_result import (
         RESULT_ATTRIBUTION_PREFIX, _append_event, _cmd_result,
     )
-    from tickets_shape import (
+    from tickets_shape_line import (
         SHAPE_PREFIX, SHAPE_RECORD_ID, SHAPE_USAGE, journal_shape,
         shape_for, shape_record,
     )

--- a/scripts/tickets_frame.py
+++ b/scripts/tickets_frame.py
@@ -50,7 +50,13 @@ if __package__:
     from .tickets_lifecycle import _cmd_ready
     from .tickets_outcome import _cmd_dispatch_outcome
     from .tickets_project import recorded_project
-    from .tickets_result import _append_event
+    from .tickets_result import (
+        RESULT_ATTRIBUTION_PREFIX, _append_event, _cmd_result,
+    )
+    from .tickets_shape import (
+        SHAPE_PREFIX, SHAPE_RECORD_ID, SHAPE_USAGE, journal_shape,
+        shape_for, shape_record,
+    )
     from .tickets_store import (
         NO_SINK_ERROR, UTC_STAMP, _run_lock, _same_project, _segment_error,
         _tickets_root, _writer_identity, segment_refusal,
@@ -74,7 +80,13 @@ else:  # pragma: no cover - direct/installed flat script path
     from tickets_lifecycle import _cmd_ready
     from tickets_outcome import _cmd_dispatch_outcome
     from tickets_project import recorded_project
-    from tickets_result import _append_event
+    from tickets_result import (
+        RESULT_ATTRIBUTION_PREFIX, _append_event, _cmd_result,
+    )
+    from tickets_shape import (
+        SHAPE_PREFIX, SHAPE_RECORD_ID, SHAPE_USAGE, journal_shape,
+        shape_for, shape_record,
+    )
     from tickets_store import (
         NO_SINK_ERROR, UTC_STAMP, _run_lock, _same_project, _segment_error,
         _tickets_root, _writer_identity, segment_refusal,
@@ -82,7 +94,8 @@ else:  # pragma: no cover - direct/installed flat script path
 
 FRAME_OPEN_USAGE = (
     "frame-open <run> --goal-file F [--details-file D] [--parent ID] "
-    "[--done <canonical-json>] [--bound B] [--workflow NAME]"
+    "[--done <canonical-json>] [--bound B] [--workflow NAME] "
+    f"[{SHAPE_USAGE}]"
 )
 FRAME_CLOSE_USAGE = (
     "frame-close <run> <id> [--status S] [--done <canonical-json>]"
@@ -126,6 +139,7 @@ def _cmd_frame_open(rest):
     done = _extract_flag(args, "--done")
     bound = _extract_flag(args, "--bound") or NEW_DEFAULT_BOUND
     workflow = _extract_flag(args, "--workflow")
+    shape = _extract_flag(args, "--shape")
     stray = next((arg for arg in args if arg.startswith("-")), None)
     if stray is not None:
         return {"error": f"frame-open does not accept {stray}. usage: {FRAME_OPEN_USAGE}"}
@@ -137,6 +151,9 @@ def _cmd_frame_open(rest):
         if invalid is not None:
             return invalid
     refusal = _done_refusal(done)
+    if refusal is not None:
+        return refusal
+    plan, refusal = shape_for(shape, workflow, parent)
     if refusal is not None:
         return refusal
     goal, failure = _read_utf8(goal_file, "goal file")
@@ -170,17 +187,29 @@ def _cmd_frame_open(rest):
     opened = _opened(run, frame_id, bound)
     if "error" in opened:
         return {**opened, "id": frame_id}
+    if plan is not None:
+        filed = _cmd_result([
+            run, frame_id,
+            "--assignment-seal", opened["assignment_seal"],
+            "--dispatch-id", opened["dispatch_id"],
+            "--record-id", SHAPE_RECORD_ID, "--by", frame_id,
+            "--text", shape_record(plan),
+        ])
+        if "error" in filed:
+            return {**filed, "id": frame_id}
     goal_lines = goal.strip().splitlines()
     _append_event(run, frame_id, "frame-open", {
-        "workflow": workflow, "goal_head": (goal_lines[0].strip() if goal_lines else "")[:200],
+        "workflow": workflow, "shape": plan,
+        "goal_head": (goal_lines[0].strip() if goal_lines else "")[:200],
     })
     return {"frame_open": {
         "run": run, "id": frame_id, "parent": parent,
         "path": str(run_dir / f"{frame_id}.md"),
         "assignment_seal": opened["assignment_seal"],
         "dispatch_id": opened["dispatch_id"],
-        "journal_by": frame_id,
+        "journal_by": frame_id, "shape": plan,
     }}
+
 
 
 def _opened(run: str, frame_id: str, bound: str) -> dict:
@@ -288,8 +317,16 @@ def _judgement_refusal(run: str, frame_id: str, census: dict, reason: str):
     )}
 
 
-def _closing_note(census: dict, reason: str, status: str) -> str:
-    """The evidence the close appends: what it closed over, and who read it."""
+def _closing_note(census: dict, reason: str, status: str, shape: str) -> str:
+    """The evidence the close appends: the plan, the census, and who read it.
+
+    The shape prints and never refuses. A wave plan is a statement of
+    intent written before the work, and work that finds a reason to differ
+    is the ordinary case, not a defect -- so the close puts the plan beside
+    what was actually minted and leaves the reading to the person who has
+    both. A refusal here would only teach drivers to write a shape they
+    already know they will satisfy.
+    """
 
     if not census["do"]:
         read = "no do-children"
@@ -300,7 +337,9 @@ def _closing_note(census: dict, reason: str, status: str) -> str:
     else:
         read = "one do-child, read by its own close"
     return (
-        f"frame closed {status} over {len(census['do'])} do-children; {read}."
+        f"shape {shape or 'not recorded'}; frame closed {status} over "
+        f"{len(census['do'])} do and {len(census['judge'])} judge children; "
+        f"{read}."
     )
 
 
@@ -386,13 +425,15 @@ def _cmd_frame_close(rest):
             "already, or never opened through `tickets.py frame-open`"
         )}
     census = _census(frame_id, _children(run_dir, frame_id))
-    reason = unjudged_reason(_section_body(text, REPORT_SECTION))
+    journal = _section_body(text, REPORT_SECTION)
+    reason = unjudged_reason(journal)
     refusal = _judgement_refusal(run, frame_id, census, reason)
     if refusal is not None:
         return refusal
     with _run_lock(run):
         closed = _closed_under_run_lock(
             run, frame_id, path, attempt, census, reason,
+            shape=journal_shape(journal),
             status=status, done=done or sealed or None,
         )
     if "frame_close" in closed:
@@ -409,7 +450,7 @@ def _cmd_frame_close(rest):
 
 
 def _closed_under_run_lock(run, frame_id, path, attempt, census, reason,
-                           *, status, done):
+                           *, shape, status, done):
     """Evaluate the gate, file the close, and join -- in that order.
 
     The gate runs before anything is written, which is the one place this
@@ -441,7 +482,7 @@ def _closed_under_run_lock(run, frame_id, path, attempt, census, reason,
         if refusal is not None:
             return refusal
     filed = _cmd_dispatch_outcome([
-        run, frame_id, "--note", _closing_note(census, reason, status),
+        run, frame_id, "--note", _closing_note(census, reason, status, shape),
     ], _lock_held=True)
     if "error" in filed:
         return filed
@@ -456,6 +497,7 @@ def _closed_under_run_lock(run, frame_id, path, attempt, census, reason,
         return joined
     return {"frame_close": {
         "run": run, "id": frame_id, "status": joined["join"]["status"],
+        "shape": shape or None,
         "do_children": census["do"], "judges": census["judge"],
         "unjudged": reason or None, "done": reading,
     }}
@@ -525,6 +567,26 @@ def resume_now(text):
     return datetime.now(timezone.utc) if text is None else _parse_iso(text)
 
 
+def _journalled(journal: str) -> bool:
+    """Whether this frame's driver has written a wave down yet.
+
+    Not "is the journal non-empty": `frame-open` files the shape record
+    before any wave exists, so that reading would answer `yes` for every
+    open frame and tell a person scanning `resume` nothing. The shape line
+    and the attributions `result` adds are skipped; anything else is a
+    driver's own writing.
+    """
+
+    for line in str(journal or "").splitlines():
+        text = line.strip()
+        if not text or text.startswith(RESULT_ATTRIBUTION_PREFIX):
+            continue
+        if text.startswith(SHAPE_PREFIX):
+            continue
+        return True
+    return False
+
+
 def open_frames(now=None) -> list:
     """Every open frame of the invoking project, newest first.
 
@@ -557,7 +619,7 @@ def open_frames(now=None) -> list:
             rows.append({
                 "run": run_dir.name, "id": path.stem, "opened_at": opened,
                 "age": _age(opened, now),
-                "journal": bool(_section_body(text, REPORT_SECTION).strip()),
+                "journal": _journalled(_section_body(text, REPORT_SECTION)),
                 "children": children_open, "leases": leased,
                 "goal": goal[0].strip() if goal else "",
             })

--- a/scripts/tickets_mint.py
+++ b/scripts/tickets_mint.py
@@ -23,17 +23,18 @@ sealed, here rather than by a caller.
 
 from __future__ import annotations
 
+import re
 from datetime import datetime, timedelta, timezone
 
 if __package__:
-    from .tickets_adapters import ADAPTER_REGISTRY
+    from .tickets_adapters import ADAPTER_REGISTRY, AdapterError, adapter_id
     from .tickets_admission import ADMISSION_PENDING
     from .tickets_bound import parse_bound
     from .tickets_format import (
         ARTIFACT_CLAUSE, MAKES_FIELD, PLANNING_KINDS,
         REPORT_SECTION, _extract_all, _extract_flag,
-        _parse_frontmatter, _read_utf8, _set_frontmatter_field, done_defects,
-        next_mint_id,
+        _parse_frontmatter, _read_utf8, _set_frontmatter_field, dequote,
+        done_defects, next_mint_id,
     )
     from .tickets_generations import assignment_digest
     from .tickets_issue import (
@@ -45,14 +46,14 @@ if __package__:
         NO_SINK_ERROR, UTC_STAMP, _run_lock, _segment_error, _tickets_root,
     )
 else:  # pragma: no cover - direct/installed flat script path
-    from tickets_adapters import ADAPTER_REGISTRY
+    from tickets_adapters import ADAPTER_REGISTRY, AdapterError, adapter_id
     from tickets_admission import ADMISSION_PENDING
     from tickets_bound import parse_bound
     from tickets_format import (
         ARTIFACT_CLAUSE, MAKES_FIELD, PLANNING_KINDS,
         REPORT_SECTION, _extract_all, _extract_flag,
-        _parse_frontmatter, _read_utf8, _set_frontmatter_field, done_defects,
-        next_mint_id,
+        _parse_frontmatter, _read_utf8, _set_frontmatter_field, dequote,
+        done_defects, next_mint_id,
     )
     from tickets_generations import assignment_digest
     from tickets_issue import (
@@ -99,6 +100,75 @@ JUDGE_KINDS = ARTIFACT_KINDS | frozenset(GENERATION_KINDS)
 # whose call this ticket is, in the section a reader of the ticket alone
 # would otherwise have to infer it from the id.
 PARENT_CLAUSE = "- parent: "
+# The adapter whose workspace *is* lanes -- "isolation is a run-scoped lane
+# directory" -- and so the one whose craft prices a lane at one
+# independently answerable sub-question. Selected off the pack's own
+# declared adapter rather than off a pack name, because machinery stays
+# domain-blind (tools/validate_support/structure.py's domain-blindness
+# check); a pack that adopts this adapter inherits the door with it.
+LANE_ADAPTER = "evidence-store"
+# The marker that adapter's craft root entry states the form of. The door
+# counts it; the craft is where the form is said, and nothing here restates
+# it.
+_SUBQUESTION_MARKER = "sub-questions"
+_HEADING_LINE = re.compile(r"^ {0,3}#{1,6}\s")
+_NUMBERED_ITEM = re.compile(r"^\s*\d+[.)]\s+\S")
+
+
+def subquestion_count(goal: str) -> int:
+    """How many sub-questions one goal declares.
+
+    The marker is the research craft's: a heading at any depth whose text
+    carries `sub-questions`, and under it a numbered list with one item per
+    sub-question. Every such section's items are counted, because a goal
+    that declares its coverage twice declares both halves of it.
+
+    Flat by choice: any numbered line inside the section counts, nesting
+    included. The craft states the one-item-per-sub-question form, so a
+    nested list is a goal off that form rather than a shape this has to
+    disambiguate -- and over-counting there refuses, which is the safe
+    direction.
+    """
+
+    count, inside = 0, False
+    for line in goal.splitlines():
+        if _HEADING_LINE.match(line):
+            inside = _SUBQUESTION_MARKER in line.lower()
+        elif inside and _NUMBERED_ITEM.match(line):
+            count += 1
+    return count
+
+
+def _one_lane(pack, parent, goal: str, goal_file):
+    """The refusal for a parentless lane-adapter `do` carrying several lanes.
+
+    A worker-lane `do` is one child answering one question. The research
+    craft's cut rule already priced a lane at one independently answerable
+    sub-question; run 20260902T140000Z-hn-workflows minted a single `do`
+    over five of them and got back one source called a full packet. The
+    door stands here, ahead of the run directory, so a refusal leaves the
+    sink exactly as it found it.
+
+    A pack that will not resolve passes: `pinned_pack_digest` owns that
+    refusal and names the pack, and two refusals for one cause would make
+    the caller fix the wrong thing first.
+    """
+
+    if parent:
+        return None
+    try:
+        if adapter_id(dequote(pack)) != LANE_ADAPTER:
+            return None
+    except AdapterError:
+        return None
+    lanes = subquestion_count(goal)
+    if lanes < 2:
+        return None
+    return {"error": (
+        f"goal file {goal_file}: {lanes} sub-questions are {lanes} lanes, "
+        "per the research craft's cut rule; open a frame with `--shape` and "
+        "mint one `do` per sub-question under it"
+    )}
 
 
 def _dispatch_facade():
@@ -372,6 +442,10 @@ def _cmd_callable(rest, *, judge: bool):
         return failure
     if not goal.strip():
         return {"error": f"goal file {goal_file} is empty; Goal is one observable end result"}
+    if not judge:
+        crowded = _one_lane(pack, parent, goal, goal_file)
+        if crowded is not None:
+            return crowded
     details = None
     if details_file is not None:
         details, failure = _read_utf8(details_file, "details file")
@@ -437,6 +511,7 @@ def _cmd_judge(rest):
 
 __all__ = (
     "ARTIFACT_KINDS", "MINT_INDEPENDENCE", "DO_EXECUTOR", "DO_USAGE",
-    "JUDGE_EXECUTOR", "JUDGE_USAGE", "_cmd_callable", "_cmd_do", "_cmd_judge",
-    "_launched", "_mint", "_run_dir", "_sealed_root",
+    "JUDGE_EXECUTOR", "JUDGE_USAGE", "LANE_ADAPTER", "_cmd_callable",
+    "_cmd_do", "_cmd_judge", "_launched", "_mint", "_run_dir", "_sealed_root",
+    "subquestion_count",
 )

--- a/scripts/tickets_mint.py
+++ b/scripts/tickets_mint.py
@@ -118,16 +118,15 @@ _NUMBERED_ITEM = re.compile(r"^\s*\d+[.)]\s+\S")
 def subquestion_count(goal: str) -> int:
     """How many sub-questions one goal declares.
 
-    The marker is the research craft's: a heading at any depth whose text
-    carries `sub-questions`, and under it a numbered list with one item per
-    sub-question. Every such section's items are counted, because a goal
-    that declares its coverage twice declares both halves of it.
-
-    Flat by choice: any numbered line inside the section counts, nesting
-    included. The craft states the one-item-per-sub-question form, so a
-    nested list is a goal off that form rather than a shape this has to
-    disambiguate -- and over-counting there refuses, which is the safe
-    direction.
+    The form counted is stated once, in the `### root` entry of the craft
+    belonging to the pack whose adapter is `LANE_ADAPTER`, and nowhere
+    here: a reader who needs it resolves that craft through `packs.py
+    cells <digest>`. What is this module's own is how the count is taken
+    over a goal that departs from that form -- every marked section's
+    items, because a goal declaring its coverage twice declares both
+    halves of it, and any numbered line inside one, nesting included, so
+    an off-form goal over-counts and refuses rather than being
+    disambiguated here.
     """
 
     count, inside = 0, False

--- a/scripts/tickets_shape.py
+++ b/scripts/tickets_shape.py
@@ -1,0 +1,234 @@
+"""The one line a driver writes down before its first dispatch.
+
+A frame's shape is the wave plan stated once, in the open, before anything
+is minted: `outline > [do, do] > judge` says three waves, two of them
+parallel, and a reader who arrives at the ticket tree later can tell what
+the driver meant to do from what it actually did. The grammar itself is
+owned by `docs/vocabulary.md`'s `routing shape` entry; this module is the
+only place it is *parsed*, and the refusals below are the only place its
+notation is spelled back at a caller who got it wrong.
+
+Two names are refused rather than parsed, because both are lawful English
+and neither is a frame. `do` alone is the worker lane -- one ticket, no
+wave plan, nothing to journal -- and `direct` is the lane that opens no
+frame at all. A driver that writes either has picked the wrong command,
+not written a bad shape, so the refusal says which command it wanted.
+
+The parser reports the first token that does not belong where it stands
+rather than "unparseable": a shape line is short and hand-written, and the
+one thing its author cannot derive from a rejection is *where* it went
+wrong.
+"""
+
+from __future__ import annotations
+
+import re
+
+# The reserved names, and what they bind. Free identifiers are the driver's
+# own labels for a wave; these three name kernel verbs, so a reader knows
+# a wave called `judge` is a judge without asking.
+RESERVED_NAMES = ("do", "outline", "judge")
+SHAPE_RECORD_ID = "shape"
+SHAPE_PREFIX = "shape:"
+SHAPE_USAGE = '--shape "<line>"'
+WORKFLOW_SHAPE_PREFIX = "workflow:"
+
+# One line, and a pointer at the owner rather than a second definition:
+# `docs/vocabulary.md`'s `routing shape` entry states what these mean.
+SHAPE_GRAMMAR = (
+    "shape grammar: `a > b` waves in order, `[a, b]` one wave in parallel, "
+    "`a[*]` a count an outline decides, names free except the reserved "
+    "`do`, `outline`, `judge` (docs/vocabulary.md, `routing shape`)"
+)
+
+_NAME = re.compile(r"[A-Za-z0-9_][A-Za-z0-9_.-]*")
+_PUNCTUATION = (">", "[", "]", ",", "*")
+_END = "<end of line>"
+
+
+def missing_shape_refusal() -> dict:
+    """What a root frame minted with neither `--shape` nor `--workflow` gets.
+
+    Before any write: a frame whose plan was never stated is the failure
+    the shape line exists to end, and minting one and then complaining
+    would leave the unplanned frame behind as the record.
+    """
+
+    return {"error": (
+        f"a root frame states its wave plan at open: pass {SHAPE_USAGE}, or "
+        "--workflow NAME when a saved workflow's body is the plan. "
+        + SHAPE_GRAMMAR
+    )}
+
+
+def shape_for(shape, workflow, parent):
+    """`(shape, refusal)`: the wave plan one `frame-open` opens under.
+
+    An explicit `--shape` outranks `--workflow`, because a driver that
+    wrote the line meant the line. A saved workflow's body *is* its plan,
+    so its name stands in for one. Only a root owes one at all: a called
+    frame is already a wave of its caller's shape, and demanding it restate
+    the plan would put the same fact in two places.
+    """
+
+    if shape is not None:
+        return parse_shape(shape)
+    if workflow:
+        return workflow_shape(workflow), None
+    if not parent:
+        return None, missing_shape_refusal()
+    return None, None
+
+
+def workflow_shape(workflow: str) -> str:
+    """The shape a saved workflow's name stands for.
+
+    Not grammar and never parsed as it: the workflow's own body is the wave
+    plan, and this records which body to go read.
+    """
+
+    return f"{WORKFLOW_SHAPE_PREFIX}{workflow}"
+
+
+def shape_record(shape: str) -> str:
+    """The journal line `frame-open` files and `frame-close` reads back."""
+
+    return f"{SHAPE_PREFIX} {shape}"
+
+
+def journal_shape(journal) -> str:
+    """The shape one frame's journal recorded, or ''.
+
+    A prefix match on one line, the way `unjudged_reason` reads its own
+    line: the first `shape:` wins, so a later wave that quotes the shape
+    while discussing it cannot displace the record `frame-open` filed.
+    """
+
+    for line in str(journal or "").splitlines():
+        text = line.strip()
+        if text.startswith(SHAPE_PREFIX):
+            recorded = text[len(SHAPE_PREFIX):].strip()
+            if recorded:
+                return recorded
+    return ""
+
+
+def parse_shape(text):
+    """`(shape, refusal)` for one `--shape` line.
+
+    The shape returned is the caller's own line, stripped: it is prose a
+    person wrote and a person reads back, and normalising its spacing would
+    only make the journal disagree with the command that filed it.
+    """
+
+    line = (text or "").strip()
+    if not line or "\n" in line:
+        return None, {"error": (
+            f"--shape takes one non-empty line. {SHAPE_GRAMMAR}"
+        )}
+    if line == "do":
+        return None, {"error": (
+            "one ticket is the worker lane: run tickets.py do"
+        )}
+    if line == "direct":
+        return None, {"error": (
+            "direct opens no frame: the direct lane makes the change in this "
+            "session and records it in the medium's own history"
+        )}
+    tokens, bad = _tokens(line)
+    if bad is not None:
+        return None, _bad_token(line, bad)
+    bad = _parse(tokens)
+    if bad is not None:
+        return None, _bad_token(line, bad)
+    return line, None
+
+
+def _bad_token(line: str, token: str) -> dict:
+    return {"error": (
+        f"shape `{line}` does not parse at `{token}`. {SHAPE_GRAMMAR}"
+    )}
+
+
+def _tokens(line: str):
+    """`(tokens, bad)`: the line's tokens, or the first character that is none."""
+
+    tokens = []
+    index = 0
+    while index < len(line):
+        character = line[index]
+        if character.isspace():
+            index += 1
+            continue
+        if character in _PUNCTUATION:
+            tokens.append(character)
+            index += 1
+            continue
+        match = _NAME.match(line, index)
+        if match is None:
+            return None, character
+        tokens.append(match.group())
+        index = match.end()
+    return tokens, None
+
+
+def _parse(tokens):
+    """The first token that does not belong where it stands, or ``None``."""
+
+    position = 0
+    while True:
+        position, bad = _parse_wave(tokens, position)
+        if bad is not None:
+            return bad
+        if position == len(tokens):
+            return None
+        if tokens[position] != ">":
+            return tokens[position]
+        position += 1
+        if position == len(tokens):
+            return ">"
+
+
+def _parse_wave(tokens, position):
+    """One wave: a single item, or `[` items separated by `,` `]`."""
+
+    if position >= len(tokens):
+        return position, _END
+    if tokens[position] != "[":
+        return _parse_item(tokens, position)
+    position += 1
+    while True:
+        position, bad = _parse_item(tokens, position)
+        if bad is not None:
+            return position, bad
+        if position >= len(tokens):
+            return position, _END
+        if tokens[position] == "]":
+            return position + 1, None
+        if tokens[position] != ",":
+            return position, tokens[position]
+        position += 1
+
+
+def _parse_item(tokens, position):
+    """One name, optionally carrying the outline-decided count `[*]`."""
+
+    if position >= len(tokens):
+        return position, _END
+    if tokens[position] in _PUNCTUATION:
+        return position, tokens[position]
+    position += 1
+    if position >= len(tokens) or tokens[position] != "[":
+        return position, None
+    if tokens[position + 1:position + 3] == ["*", "]"]:
+        return position + 3, None
+    following = tokens[position + 1:position + 2]
+    return position, following[0] if following else "["
+
+
+__all__ = (
+    "RESERVED_NAMES", "SHAPE_GRAMMAR", "SHAPE_PREFIX", "SHAPE_RECORD_ID",
+    "SHAPE_USAGE", "WORKFLOW_SHAPE_PREFIX", "journal_shape",
+    "missing_shape_refusal", "parse_shape", "shape_for", "shape_record",
+    "workflow_shape",
+)

--- a/scripts/tickets_shape_line.py
+++ b/scripts/tickets_shape_line.py
@@ -28,6 +28,11 @@ import re
 # own labels for a wave; these three name kernel verbs, so a reader knows
 # a wave called `judge` is a judge without asking.
 RESERVED_NAMES = ("do", "outline", "judge")
+# The notation the parser recognises as structure rather than as a name.
+# Public because it is half the anchor set a check reads to hold the owner
+# prose and the echo below to one grammar; `_parse_item` reads it as the
+# "not a name" test.
+GRAMMAR_TOKENS = (">", "[", "]", ",", "*")
 SHAPE_RECORD_ID = "shape"
 SHAPE_PREFIX = "shape:"
 SHAPE_USAGE = '--shape "<line>"'
@@ -42,7 +47,6 @@ SHAPE_GRAMMAR = (
 )
 
 _NAME = re.compile(r"[A-Za-z0-9_][A-Za-z0-9_.-]*")
-_PUNCTUATION = (">", "[", "]", ",", "*")
 _END = "<end of line>"
 
 
@@ -160,7 +164,7 @@ def _tokens(line: str):
         if character.isspace():
             index += 1
             continue
-        if character in _PUNCTUATION:
+        if character in GRAMMAR_TOKENS:
             tokens.append(character)
             index += 1
             continue
@@ -215,7 +219,7 @@ def _parse_item(tokens, position):
 
     if position >= len(tokens):
         return position, _END
-    if tokens[position] in _PUNCTUATION:
+    if tokens[position] in GRAMMAR_TOKENS:
         return position, tokens[position]
     position += 1
     if position >= len(tokens) or tokens[position] != "[":
@@ -227,8 +231,8 @@ def _parse_item(tokens, position):
 
 
 __all__ = (
-    "RESERVED_NAMES", "SHAPE_GRAMMAR", "SHAPE_PREFIX", "SHAPE_RECORD_ID",
-    "SHAPE_USAGE", "WORKFLOW_SHAPE_PREFIX", "journal_shape",
+    "GRAMMAR_TOKENS", "RESERVED_NAMES", "SHAPE_GRAMMAR", "SHAPE_PREFIX",
+    "SHAPE_RECORD_ID", "SHAPE_USAGE", "WORKFLOW_SHAPE_PREFIX", "journal_shape",
     "missing_shape_refusal", "parse_shape", "shape_for", "shape_record",
     "workflow_shape",
 )

--- a/templates/host-block.md
+++ b/templates/host-block.md
@@ -7,20 +7,20 @@
   returns; relay `kind: user-only` questions verbatim. Never author a
   role-bearing payload. Prompt-less or wrong-profile work refuses;
   `role: none` only orchestrates. `orch-off` suspends routing; named
-  items still run only when named. Route by need, smallest first; name
-  the lane in one line before working. **direct** — context evidence decides
-  an answer; a change this session can make, check, and record
+  items still run only when named. Route by need, smallest first; write
+  the run's shape line before the first dispatch. **direct** — context
+  evidence decides; a change this session can make, check, and record
   itself — the commit is the record; no trace, no act. A `role: none`
   root never acts: derived deterministic commands only. **worker** —
-  isolation, a fresh context, or a checked landing takes one
+  isolation, a fresh context, or a checked landing takes
   `tickets.py do <run> --pack <pack> --goal-file <f> [--parent <frame>]
   [--workspace <tree>]`, or `judge` over artifacts; invoke the emitted `launch`
   verbatim, then `tickets.py land`: it reads `done`,
   integrates. Undeclared grades `land --status`. **team** — children,
-  resume, or an audit trail opens `tickets.py frame-open <run>`; each
-  wave re-read its `## Report`; decide through `result`, relaying
-  `artifact:` and `findings:` lines verbatim; children run scoped
-  checks; the suite runs once, at close; end at `frame-close`, judging
+  resume, or an audit trail opens `tickets.py frame-open <run>
+  --shape "<line>"`; each wave re-read its `## Report`; decide through
+  `result`, relaying `artifact:` and `findings:` lines verbatim; children
+  run scoped checks; the suite runs once, at close; end at `frame-close`, judging
   the seams or saying `unjudged: <reason>`; `orchflows resume` lists
   frames. **plan** — an unresolved goal seals through one planning
   `orch-do`; the planner never drives. Tripwires promote, never

--- a/tests/serial_compat_manifest.json
+++ b/tests/serial_compat_manifest.json
@@ -1,6 +1,6 @@
 {
  "discovery": {
-  "count": 2156,
+  "count": 2173,
   "identities": [
    "test_affected_tests.TestDiscoveryCache.test_a_new_commit_is_a_new_key_and_is_discovered_again",
    "test_affected_tests.TestDiscoveryCache.test_a_tree_that_cannot_answer_for_a_commit_falls_back_and_says_so",
@@ -231,6 +231,8 @@
    "test_events.FrameCloseEventTest.test_a_refused_close_writes_no_event",
    "test_events.FrameCloseEventTest.test_an_unjudged_close_names_the_journals_reason",
    "test_events.FrameOpenEventTest.test_a_long_goal_first_line_is_truncated_to_200_chars",
+   "test_events.FrameOpenEventTest.test_a_workflow_frames_shape_names_the_body_that_is_its_plan",
+   "test_events.FrameOpenEventTest.test_frame_open_carries_the_shape_it_opened_under",
    "test_events.FrameOpenEventTest.test_frame_open_names_its_workflow_and_goal_head",
    "test_events.FrameOpenEventTest.test_frame_open_without_workflow_names_none",
    "test_events.LandEventFailureIsSwallowedTest.test_a_broken_append_does_not_fail_the_land",
@@ -1038,6 +1040,18 @@
    "test_ticket_frames.FrameCloseTest.test_land_stays_the_callable_command_and_frame_close_says_so",
    "test_ticket_frames.FrameJournalTest.test_a_journal_append_outlives_the_frames_nominal_expiry",
    "test_ticket_frames.FrameJournalTest.test_a_wave_appends_through_the_result_channel_under_the_frames_identity",
+   "test_ticket_frames.FrameShapeLineTest.test_a_called_frame_is_already_a_wave_of_its_callers_plan",
+   "test_ticket_frames.FrameShapeLineTest.test_a_lawful_line_of_every_construct_opens_the_frame",
+   "test_ticket_frames.FrameShapeLineTest.test_a_plan_the_work_outgrew_prints_and_never_refuses",
+   "test_ticket_frames.FrameShapeLineTest.test_a_root_frame_with_no_plan_is_refused_before_anything_is_minted",
+   "test_ticket_frames.FrameShapeLineTest.test_a_saved_workflows_name_stands_in_for_the_line",
+   "test_ticket_frames.FrameShapeLineTest.test_a_second_record_may_not_reuse_the_shape_record_id",
+   "test_ticket_frames.FrameShapeLineTest.test_an_explicit_line_outranks_the_workflow_it_was_written_beside",
+   "test_ticket_frames.FrameShapeLineTest.test_an_unparseable_line_names_the_first_token_that_does_not_belong",
+   "test_ticket_frames.FrameShapeLineTest.test_one_ticket_is_the_worker_lane_and_the_refusal_says_which_command",
+   "test_ticket_frames.FrameShapeLineTest.test_the_close_prints_the_plan_beside_what_was_actually_minted",
+   "test_ticket_frames.FrameShapeLineTest.test_the_direct_lane_opens_no_frame_at_all",
+   "test_ticket_frames.FrameShapeLineTest.test_the_shape_is_the_frames_first_record_on_the_result_channel",
    "test_ticket_frames.FrameShapeTest.test_a_called_frame_hangs_under_its_caller_and_seals_through_it",
    "test_ticket_frames.FrameShapeTest.test_a_frame_carrying_a_craft_binding_is_off_contract",
    "test_ticket_frames.FrameShapeTest.test_an_ordinary_ticket_still_owes_its_executor",
@@ -1046,6 +1060,9 @@
    "test_ticket_frames.ResumeTest.test_an_empty_sink_says_so_rather_than_printing_a_header",
    "test_ticket_frames.ResumeTest.test_another_projects_run_is_not_this_projects_to_resume",
    "test_ticket_frames.ResumeTest.test_one_open_frame_is_listed_with_its_goal_age_and_children",
+   "test_ticket_frames.ResumeTest.test_the_shape_record_alone_is_not_a_wave_anybody_wrote",
+   "test_ticket_frames.SavedWorkflowShapeTest.test_dropping_the_flag_from_a_copy_fails_the_check",
+   "test_ticket_frames.SavedWorkflowShapeTest.test_every_root_frame_open_line_states_a_plan",
    "test_ticket_protocol.TicketProtocolTest.test_dispatch_attempt_state_does_not_move_assignment",
    "test_ticket_protocol.TicketProtocolTest.test_dispatch_v1_contract_owns_the_closed_public_seam",
    "test_ticket_protocol.TicketProtocolTest.test_dispatch_v1_contract_owns_the_launch",
@@ -2159,7 +2176,7 @@
    "tests.test_workspace_cases.start_cases.TestTheStampPreservesTheTicketsByteDomain.test_only_the_two_stamped_lines_differ_from_the_prior_bytes",
    "tests.test_workspace_cases.start_cases.TestTicketsPayloadIsGradedNotItsExitStatus.test_an_error_payload_returned_at_exit_zero_is_a_failure"
   ],
-  "sha256": "1df1feba4fa51188f5f8071c13285c729fa894ef7c76d93cf350630b8e927cc5"
+  "sha256": "0489858e439d2370a9871ffa40ffbdae330f092135fb6e07086e06d992a3d034"
  },
  "mutation_owners": [
   {

--- a/tests/serial_compat_manifest.json
+++ b/tests/serial_compat_manifest.json
@@ -1,6 +1,6 @@
 {
  "discovery": {
-  "count": 2156,
+  "count": 2162,
   "identities": [
    "test_affected_tests.TestDiscoveryCache.test_a_new_commit_is_a_new_key_and_is_discovered_again",
    "test_affected_tests.TestDiscoveryCache.test_a_tree_that_cannot_answer_for_a_commit_falls_back_and_says_so",
@@ -1013,6 +1013,12 @@
    "test_ticket_callables.GenerationArtifactTest.test_the_three_adapter_kinds_are_admitted_unchanged",
    "test_ticket_callables.GenerationArtifactTest.test_the_untyped_refusal_expects_all_five_kinds",
    "test_ticket_callables.RepairRoundAdmissionTest.test_a_runtime_callables_repair_round_admits_and_dispatches",
+   "test_ticket_callables.ResearchLaneDoorTest.test_a_goal_declaring_no_sub_questions_is_minted_unchanged",
+   "test_ticket_callables.ResearchLaneDoorTest.test_another_packs_parentless_do_takes_the_same_goal_unchanged",
+   "test_ticket_callables.ResearchLaneDoorTest.test_one_sub_question_is_minted_unchanged",
+   "test_ticket_callables.ResearchLaneDoorTest.test_the_count_moves_with_the_marker_and_with_the_items",
+   "test_ticket_callables.ResearchLaneDoorTest.test_the_same_goal_under_a_parent_is_minted_unchanged",
+   "test_ticket_callables.ResearchLaneDoorTest.test_two_sub_questions_are_refused_before_the_run_exists",
    "test_ticket_callables.TypedArtifactGrammarTest.test_each_registered_adapter_names_one_line_kind",
    "test_ticket_done_predicate.DonePredicateGrammarTest.test_the_loops_done_and_a_tickets_done_are_graded_by_one_owner",
    "test_ticket_done_predicate.DonePredicateGrammarTest.test_the_predicate_is_part_of_the_sealed_assignment",
@@ -2159,7 +2165,7 @@
    "tests.test_workspace_cases.start_cases.TestTheStampPreservesTheTicketsByteDomain.test_only_the_two_stamped_lines_differ_from_the_prior_bytes",
    "tests.test_workspace_cases.start_cases.TestTicketsPayloadIsGradedNotItsExitStatus.test_an_error_payload_returned_at_exit_zero_is_a_failure"
   ],
-  "sha256": "1df1feba4fa51188f5f8071c13285c729fa894ef7c76d93cf350630b8e927cc5"
+  "sha256": "b406d3fb1a5568ef7f0614ee8520c1aaea170abbca526c6736031b19155d7ae8"
  },
  "mutation_owners": [
   {

--- a/tests/serial_compat_manifest.json
+++ b/tests/serial_compat_manifest.json
@@ -1,6 +1,6 @@
 {
  "discovery": {
-  "count": 2179,
+  "count": 2182,
   "identities": [
    "test_affected_tests.TestDiscoveryCache.test_a_new_commit_is_a_new_key_and_is_discovered_again",
    "test_affected_tests.TestDiscoveryCache.test_a_tree_that_cannot_answer_for_a_commit_falls_back_and_says_so",
@@ -1069,6 +1069,9 @@
    "test_ticket_frames.ResumeTest.test_the_shape_record_alone_is_not_a_wave_anybody_wrote",
    "test_ticket_frames.SavedWorkflowShapeTest.test_dropping_the_flag_from_a_copy_fails_the_check",
    "test_ticket_frames.SavedWorkflowShapeTest.test_every_root_frame_open_line_states_a_plan",
+   "test_ticket_frames.SavedWorkflowShapeTest.test_the_scaffolded_workflow_states_a_plan",
+   "test_ticket_frames.ShapeGrammarOwnerTest.test_a_construct_dropped_from_either_side_is_caught",
+   "test_ticket_frames.ShapeGrammarOwnerTest.test_the_prose_and_the_printed_notation_carry_the_same_anchors",
    "test_ticket_protocol.TicketProtocolTest.test_dispatch_attempt_state_does_not_move_assignment",
    "test_ticket_protocol.TicketProtocolTest.test_dispatch_v1_contract_owns_the_closed_public_seam",
    "test_ticket_protocol.TicketProtocolTest.test_dispatch_v1_contract_owns_the_launch",
@@ -2182,7 +2185,7 @@
    "tests.test_workspace_cases.start_cases.TestTheStampPreservesTheTicketsByteDomain.test_only_the_two_stamped_lines_differ_from_the_prior_bytes",
    "tests.test_workspace_cases.start_cases.TestTicketsPayloadIsGradedNotItsExitStatus.test_an_error_payload_returned_at_exit_zero_is_a_failure"
   ],
-  "sha256": "843ebe0aa348eae1a2294237f7867ec4d8d63e4fafad093a0ece8101930b4ab7"
+  "sha256": "b8356cbc5f3c6dcd44024d433a24e76ff05095fcf434e3d6b2e698a9fa27cc8d"
  },
  "mutation_owners": [
   {

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -113,6 +113,10 @@ class _FrameEventTestCase(_EventSinkTestCase):
         return answer
 
     def frame(self, *arguments) -> dict:
+        # A root frame states its wave plan at open; a case about `--workflow`
+        # supplies its own, so only the shapeless ones get the default.
+        if not {"--shape", "--workflow"} & set(arguments):
+            arguments = ("--shape", "outline > [do, do] > judge", *arguments)
         opened = self.call(
             "frame-open", self.RUN, "--goal-file", str(self.goal_file), *arguments,
         )
@@ -154,6 +158,22 @@ class FrameOpenEventTest(_FrameEventTestCase):
         entry = self.events()[0]
         self.assertIsNone(entry["workflow"])
         self.assertProvenance(entry, run=self.RUN, ticket=frame["id"])
+
+    def test_frame_open_carries_the_shape_it_opened_under(self):
+        """The wave plan is on the event, not only in the ticket: a harvest
+        reading one run's stream can say what it set out to do without
+        opening the sink's tickets."""
+
+        self.frame("--shape", "outline > [do, do] > judge")
+
+        self.assertEqual(
+            "outline > [do, do] > judge", self.events()[0]["shape"],
+        )
+
+    def test_a_workflow_frames_shape_names_the_body_that_is_its_plan(self):
+        self.frame("--workflow", "self-improve")
+
+        self.assertEqual("workflow:self-improve", self.events()[0]["shape"])
 
     def test_a_long_goal_first_line_is_truncated_to_200_chars(self):
         self.goal_file.write_text("x" * 260 + "\nsecond line\n", encoding="utf-8")

--- a/tests/test_installer_cases/managed_text/host_block.py
+++ b/tests/test_installer_cases/managed_text/host_block.py
@@ -141,13 +141,14 @@ _HOST_BLOCK_DEMANDS = {
         "`land --status`",
         "`install.py doctor`",
         "`evolve`/`benchmaker` run when named",
-        # The say-the-lane sentence and the two named tripwires (the third,
-        # unknown-cause, was already covered by "cause investigates before
-        # any edit" in TestHostBlockRendering below) -- a seam-judge blocker
-        # (F1, run 20260901T021739Z) found these cut for budget with nothing
-        # here to catch it: a trim that drops one of these three now goes
-        # red instead of shipping silently.
-        "name the lane in one line before working",
+        # The write-the-shape sentence (the say-the-lane sentence it
+        # replaced) and the two named tripwires (the third, unknown-cause,
+        # was already covered by "cause investigates before any edit" in
+        # TestHostBlockRendering below) -- a seam-judge blocker (F1, run
+        # 20260901T021739Z) found these cut for budget with nothing here to
+        # catch it: a trim that drops one of these three now goes red
+        # instead of shipping silently.
+        "write the run's shape line before the first dispatch",
         "a second concern mid-direct enters worker",
         "splitting scope enters team",
     ),

--- a/tests/test_thin_orchestrator.py
+++ b/tests/test_thin_orchestrator.py
@@ -87,10 +87,11 @@ class ThinOrchestratorContractTests(unittest.TestCase):
             "`launch`",
             "`tickets.py do <run>",
             "`tickets.py land`",
-            # The UX contract's say-the-lane sentence; a seam-judge blocker
-            # (F1, run 20260901T021739Z) found it cut for budget with no
-            # anchor here to catch it.
-            "name the lane in one line before working",
+            # The UX contract's write-the-shape sentence, which replaced the
+            # say-the-lane one; a seam-judge blocker (F1, run
+            # 20260901T021739Z) found that one cut for budget with no anchor
+            # here to catch it.
+            "write the run's shape line before the first dispatch",
         ):
             self.assertIn(anchor, collapsed_host)
         authoring_pointer = "{{ORCH_LIB}}/docs/custom-workflow-authoring.md"

--- a/tests/test_ticket_callables.py
+++ b/tests/test_ticket_callables.py
@@ -43,8 +43,20 @@ from scripts.tickets_format import _parse_frontmatter, _sections, parse_canonica
 
 CODE_PACK = "orch-code-pack"
 DOC_PACK = "orch-content-pack"
+RESEARCH_PACK = "orch-research-pack"
 GOAL = "Deliver the widget and prove it runs.\n"
 DETAILS = "Read the craft first; report every exit code.\n"
+# The marker the research craft's root entry owns, written the way a real
+# goal writes it: one heading carrying `sub-questions`, one numbered item
+# per lane. Fixtures, not the craft's prose -- the door counts goal text.
+ONE_LANE_GOAL = (
+    "Map the workflow surface hosts install.\n"
+    "\n"
+    "### Sub-questions coverage must reach\n"
+    "\n"
+    "1. Which hosts install the adapter?\n"
+)
+TWO_LANE_GOAL = ONE_LANE_GOAL + "2. Which of them regenerate it on sync?\n"
 
 
 class CallableSinkTest(unittest.TestCase):
@@ -668,6 +680,79 @@ class GenerationArtifactTest(CallableSinkTest):
 
         for kind in ("cut", "doc", "evidence", "git", "root"):
             self.assertIn(f"{kind}:<identity>", refused["error"])
+
+
+class ResearchLaneDoorTest(CallableSinkTest):
+    """A worker-lane research `do` carries one lane, and the door counts them.
+
+    Run 20260902T140000Z-hn-workflows minted one research `do` whose goal
+    carried five numbered sub-questions; the child answered from one source
+    and called its own packet single-lane. The research craft's cut rule
+    already said a lane is one independently answerable sub-question, so
+    what was missing was a door, not a rule.
+    """
+
+    def research(self, goal_text, *arguments, expect_error=False):
+        """One `do` on the research pack, driven against a goal fixture."""
+
+        self.goal_file.write_text(goal_text, encoding="utf-8")
+        return self.callable(
+            "do", "--pack", RESEARCH_PACK, *arguments, expect_error=expect_error,
+        )
+
+    def test_two_sub_questions_are_refused_before_the_run_exists(self):
+        refused = self.research(TWO_LANE_GOAL, expect_error=True)
+
+        self.assertIn("2 sub-questions are 2 lanes", refused["error"])
+        self.assertIn("--shape", refused["error"])
+        self.assertFalse(self.run_dir().exists(), "a refusal left a run directory")
+
+    def test_one_sub_question_is_minted_unchanged(self):
+        answer = self.research(ONE_LANE_GOAL, "--isolation", "required")
+
+        self.assertEqual("B1", answer["do"]["id"])
+        self.assertEqual(
+            ONE_LANE_GOAL.strip(), _sections(self.ticket_text("B1"))["Goal"].strip(),
+        )
+
+    def test_a_goal_declaring_no_sub_questions_is_minted_unchanged(self):
+        answer = self.research(GOAL, "--isolation", "required")
+
+        self.assertEqual("B1", answer["do"]["id"])
+
+    def test_the_same_goal_under_a_parent_is_minted_unchanged(self):
+        self.research(ONE_LANE_GOAL, "--isolation", "required")
+
+        answer = self.research(
+            TWO_LANE_GOAL, "--parent", "B1", "--isolation", "required",
+        )
+
+        self.assertEqual("B1.1", answer["do"]["id"])
+
+    def test_another_packs_parentless_do_takes_the_same_goal_unchanged(self):
+        self.goal_file.write_text(TWO_LANE_GOAL, encoding="utf-8")
+
+        answer = self.callable("do", "--pack", CODE_PACK, "--isolation", "required")
+
+        self.assertEqual("B1", answer["do"]["id"])
+
+    def test_the_count_moves_with_the_marker_and_with_the_items(self):
+        """The can-fail direction: copies beside the tree, never the tree.
+
+        Four of the cases above are absence assertions, and an absence
+        assertion is worth exactly what the counter's sensitivity is worth.
+        One item added to the passing goal lifts it over the door's line,
+        and a heading that drops the marker word drops the count to zero.
+        """
+
+        self.assertEqual(1, tickets_mint.subquestion_count(ONE_LANE_GOAL))
+        self.assertEqual(2, tickets_mint.subquestion_count(TWO_LANE_GOAL))
+        self.assertEqual(
+            0,
+            tickets_mint.subquestion_count(
+                TWO_LANE_GOAL.replace("Sub-questions", "Coverage")
+            ),
+        )
 
 
 class TypedArtifactGrammarTest(unittest.TestCase):

--- a/tests/test_ticket_callables.py
+++ b/tests/test_ticket_callables.py
@@ -446,7 +446,9 @@ class RepairRoundAdmissionTest(CallableSinkTest):
         ).isoformat().replace("+00:00", "Z")
 
     def test_a_runtime_callables_repair_round_admits_and_dispatches(self):
-        frame_id = self.callable("frame-open")["frame_open"]["id"]
+        frame_id = self.callable(
+            "frame-open", "--shape", "do > judge",
+        )["frame_open"]["id"]
         command = f'"{sys.executable}" -c "raise SystemExit(3)"'
         done = json.dumps({"form": "command", "value": command}, sort_keys=True)
 

--- a/tests/test_ticket_frames.py
+++ b/tests/test_ticket_frames.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 import io
 import json
 import os
+import re
 import sys
 import tempfile
 import unittest
@@ -23,12 +24,15 @@ from pathlib import Path
 from unittest import mock
 
 from tests._repo_root import ROOT
-from scripts import orchflows, state_root, tickets
+from scripts import orchflows, orchflows_scaffold, state_root, tickets
 from scripts.tickets_mint import DO_EXECUTOR
 from scripts.tickets_format import (
     _parse_frontmatter, _sections, _set_frontmatter_field, ticket_defects,
 )
 from scripts.tickets_store import UTC_STAMP
+from scripts.tickets_shape_line import (
+    GRAMMAR_TOKENS, RESERVED_NAMES, SHAPE_GRAMMAR,
+)
 
 DOC_PACK = "orch-content-pack"
 GOAL = "Deliver the migration wave.\nAnd say what it cost.\n"
@@ -642,6 +646,51 @@ class SavedWorkflowShapeTest(unittest.TestCase):
                 stripped[name] = body.replace(" --workflow " + name, "")
                 self.assertIn(name, _planless(stripped))
 
+    def test_the_scaffolded_workflow_states_a_plan(self):
+        """`orchflows new workflow` writes a body the door would accept.
+
+        The skeleton is the first `frame-open` line most authors ever run,
+        and it is generated, not shipped -- so the glob above cannot see
+        it. Same check, same set: a scaffold that regressed to a planless
+        line would hand every new author a command this tree refuses.
+        """
+
+        name = "scaffolded-flow"
+        body = dict(orchflows_scaffold.files_for("workflow", name))["SKILL.md"]
+        self.assertEqual(set(), _planless({name: body}))
+        self.assertEqual(
+            {name},
+            _planless({name: body.replace(" --workflow " + name, "")}),
+        )
+
+
+class ShapeGrammarOwnerTest(unittest.TestCase):
+    """One grammar, stated as prose and echoed as notation.
+
+    `docs/vocabulary.md`'s shape-line paragraph defines it; `SHAPE_GRAMMAR`
+    is the line a refusal prints, and it points at that owner rather than
+    redefining it. Nothing but agreement holds the two together, so this
+    reads the anchors each must carry -- the parser's own tokens and its
+    reserved names, backticked, never a sentence -- and a construct one
+    side grows or loses alone lands here.
+    """
+
+    def test_the_prose_and_the_printed_notation_carry_the_same_anchors(self):
+        self.assertEqual([], _adrift(_shape_line_prose(), SHAPE_GRAMMAR))
+
+    def test_a_construct_dropped_from_either_side_is_caught(self):
+        """The can-fail direction, on copies: neither file is touched."""
+
+        prose = _shape_line_prose()
+        self.assertEqual(
+            ["notation:*"],
+            _adrift(prose, SHAPE_GRAMMAR.replace("`a[*]`", "`a`")),
+        )
+        self.assertEqual(
+            ["prose:judge"],
+            _adrift(prose.replace("`judge` are", "judge are"), SHAPE_GRAMMAR),
+        )
+
 
 def _planless(bodies: dict, flag: str = "--workflow") -> set:
     """The workflows whose root `frame-open` line names no plan.
@@ -660,6 +709,35 @@ def _planless(bodies: dict, flag: str = "--workflow") -> set:
             if not flag or (flag not in line and "--shape" not in line):
                 named.add(name)
     return named
+
+
+def _shape_line_prose() -> str:
+    """The vocabulary's shape-line paragraph: the grammar's owner.
+
+    Sliced on the bolded term and the next term's bullet, so the anchor
+    the check leans on is a heading-grade one; a paragraph that moved
+    reddens here rather than quietly matching nothing.
+    """
+
+    text = (ROOT / "docs" / "vocabulary.md").read_text(encoding="utf-8")
+    start = text.index("A **shape line**")
+    return text[start:text.index("\n- **", start)]
+
+
+def _adrift(prose: str, notation: str) -> list:
+    """`['<side>:<anchor>']` for every anchor a side fails to carry.
+
+    Tokens are looked for inside the backticked spans, names as whole
+    spans: `> judge` carries the token but is not the reserved name.
+    """
+
+    missing = []
+    for side, text in (("prose", prose), ("notation", notation)):
+        spans = re.findall(r"`([^`]+)`", " ".join(text.split()))
+        joined = " ".join(spans)
+        missing.extend(f"{side}:{t}" for t in GRAMMAR_TOKENS if t not in joined)
+        missing.extend(f"{side}:{n}" for n in RESERVED_NAMES if n not in spans)
+    return sorted(missing)
 
 
 def _ticket(extra: str) -> str:

--- a/tests/test_ticket_frames.py
+++ b/tests/test_ticket_frames.py
@@ -22,6 +22,7 @@ from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from unittest import mock
 
+from tests._repo_root import ROOT
 from scripts import orchflows, state_root, tickets
 from scripts.tickets_mint import DO_EXECUTOR
 from scripts.tickets_format import (
@@ -32,6 +33,9 @@ from scripts.tickets_store import UTC_STAMP
 DOC_PACK = "orch-content-pack"
 GOAL = "Deliver the migration wave.\nAnd say what it cost.\n"
 FIXED_NOW = "2026-08-31T12:00:00Z"
+# Every root frame states its wave plan at open, so every fixture that opens
+# one carries a lawful line.
+SHAPE = "outline > [do, do] > judge"
 
 
 class FrameSinkTest(unittest.TestCase):
@@ -94,6 +98,8 @@ class FrameSinkTest(unittest.TestCase):
         return answer
 
     def frame(self, *arguments, run=None) -> dict:
+        if not {"--shape", "--workflow", "--parent"} & set(arguments):
+            arguments = ("--shape", SHAPE, *arguments)
         opened = self.call(
             "frame-open", run or self.RUN, "--goal-file", str(self.goal_file),
             *arguments,
@@ -181,6 +187,165 @@ class FrameShapeTest(FrameSinkTest):
         )
 
 
+class FrameShapeLineTest(FrameSinkTest):
+    """The wave plan a root frame states before its first dispatch.
+
+    A shape is worth a command's refusal only where writing none is the
+    cheap path: an unplanned root is exactly the frame nobody can audit
+    later, so it never gets minted. Everything after the open is printed,
+    not enforced -- the plan is intent, and work that outgrows it is the
+    ordinary case, not a defect.
+    """
+
+    def open_shapeless(self, *arguments, run=None):
+        """`frame-open` with no default line injected, for the refusals."""
+
+        return self.call(
+            "frame-open", run or self.RUN, "--goal-file", str(self.goal_file),
+            *arguments, expect_error=True,
+        )
+
+    def test_a_root_frame_with_no_plan_is_refused_before_anything_is_minted(self):
+        refused = self.open_shapeless()
+
+        self.assertIn('--shape "<line>"', refused["error"])
+        self.assertIn("--workflow NAME", refused["error"])
+        # The grammar, in the one line the refusal prints.
+        for notation in ("`a > b`", "`[a, b]`", "`a[*]`", "`do`, `outline`, `judge`"):
+            self.assertIn(notation, refused["error"])
+        self.assertFalse(self.run_dir().exists())
+
+    def test_one_ticket_is_the_worker_lane_and_the_refusal_says_which_command(self):
+        refused = self.open_shapeless("--shape", "do")
+
+        self.assertEqual(
+            "one ticket is the worker lane: run tickets.py do", refused["error"],
+        )
+        self.assertFalse(self.run_dir().exists())
+
+    def test_the_direct_lane_opens_no_frame_at_all(self):
+        refused = self.open_shapeless("--shape", "direct")
+
+        self.assertIn("direct opens no frame", refused["error"])
+        self.assertFalse(self.run_dir().exists())
+
+    def test_an_unparseable_line_names_the_first_token_that_does_not_belong(self):
+        """Where, not merely that: a hand-written line's author cannot
+        derive the position of the mistake from a bare rejection."""
+
+        for line, token in (
+            ("draft judge", "judge"),
+            ("draft > > judge", ">"),
+            ("draft >", ">"),
+            ("draft, judge", ","),
+            ("draft[3]", "3"),
+            ("[draft, [judge]]", "["),
+            ("draft > judge!", "!"),
+        ):
+            with self.subTest(shape=line):
+                refused = self.open_shapeless("--shape", line)
+                self.assertIn(f"does not parse at `{token}`", refused["error"])
+                self.assertFalse(self.run_dir().exists())
+
+    def test_a_lawful_line_of_every_construct_opens_the_frame(self):
+        """Waves, a parallel wave, an outline-decided count, and a free name
+        -- `do` is lawful inside a line and refused only as the whole of it."""
+
+        for index, line in enumerate((
+            "outline > [do, do] > judge",
+            "draft[*] > judge",
+            "[draft, review] > assemble",
+            "one-off_pass.2",
+            "do > judge",
+        )):
+            with self.subTest(shape=line):
+                frame = self.frame("--shape", line, run=f"shaperun{index}")
+                self.assertEqual(line, frame["shape"])
+
+    def test_a_saved_workflows_name_stands_in_for_the_line(self):
+        frame = self.frame("--workflow", "self-improve")
+
+        self.assertEqual("workflow:self-improve", frame["shape"])
+        self.assertIn(
+            "shape: workflow:self-improve",
+            _sections(self.ticket_text("B1"))["Report"],
+        )
+
+    def test_an_explicit_line_outranks_the_workflow_it_was_written_beside(self):
+        frame = self.frame("--shape", SHAPE, "--workflow", "self-improve")
+
+        self.assertEqual(SHAPE, frame["shape"])
+
+    def test_a_called_frame_is_already_a_wave_of_its_callers_plan(self):
+        parent = self.frame()
+
+        child = self.frame("--parent", parent["id"])
+
+        self.assertIsNone(child["shape"])
+        self.assertEqual("", _sections(self.ticket_text("B1.1"))["Report"].strip())
+
+    def test_the_shape_is_the_frames_first_record_on_the_result_channel(self):
+        frame = self.frame()
+
+        self.journal(frame, "wave 1: two drafts out", "wave-1")
+
+        journal = _sections(self.ticket_text("B1"))["Report"]
+        # Written through `result`, so it carries that channel's attribution
+        # rather than a hand-placed line, and it is there before wave one.
+        self.assertIn("### Written by `B1`", journal)
+        self.assertIn(f"shape: {SHAPE}", journal)
+        self.assertLess(
+            journal.index(f"shape: {SHAPE}"),
+            journal.index("wave 1: two drafts out"),
+        )
+
+    def test_a_second_record_may_not_reuse_the_shape_record_id(self):
+        """The record id is `shape`, and `result` fences one per id."""
+
+        frame = self.frame()
+
+        answer = self.call(
+            "result", self.RUN, frame["id"],
+            "--assignment-seal", frame["assignment_seal"],
+            "--dispatch-id", frame["dispatch_id"],
+            "--record-id", "shape", "--by", frame["journal_by"],
+            "--text", "shape: something else", expect_error=True,
+        )
+        self.assertIn("error", answer)
+
+    def test_the_close_prints_the_plan_beside_what_was_actually_minted(self):
+        frame = self.frame()
+        self.callable("do", frame["id"])
+
+        closed = self.call(
+            "frame-close", self.RUN, frame["id"], "--status", "complete",
+        )["frame_close"]
+
+        self.assertEqual(SHAPE, closed["shape"])
+        self.assertIn(
+            f"shape {SHAPE}; frame closed complete over 1 do and 0 judge "
+            "children;",
+            _sections(self.ticket_text("B1"))["Report"],
+        )
+
+    def test_a_plan_the_work_outgrew_prints_and_never_refuses(self):
+        """Drift is reported to the person holding both, not blocked."""
+
+        frame = self.frame("--shape", "draft > judge")
+        self.journal(frame, "unjudged: the user reads the draft", "wave-1")
+
+        closed = self.call(
+            "frame-close", self.RUN, frame["id"], "--status", "limited",
+        )["frame_close"]
+
+        self.assertEqual("limited", closed["status"])
+        self.assertEqual("draft > judge", closed["shape"])
+        self.assertIn(
+            "shape draft > judge; frame closed limited over 0 do and 0 judge",
+            _sections(self.ticket_text("B1"))["Report"],
+        )
+
+
 class FrameJournalTest(FrameSinkTest):
     """The journal is the driver's working memory, and it rides `result`."""
 
@@ -265,8 +430,10 @@ class FrameCloseTest(FrameSinkTest):
         self.assertEqual(
             "complete", _parse_frontmatter(self.ticket_text("B1"))["status"],
         )
+        self.assertEqual(SHAPE, closed["shape"])
         self.assertIn(
-            "frame closed complete over 2 do-children; judged by B1.3.",
+            f"shape {SHAPE}; frame closed complete over 2 do and 1 judge "
+            "children; judged by B1.3.",
             _sections(self.ticket_text("B1"))["Report"],
         )
 
@@ -414,6 +581,19 @@ class ResumeTest(FrameSinkTest):
         self.assertEqual(1, len(remaining))
         self.assertTrue(remaining[0].startswith("B1 "), remaining)
 
+    def test_the_shape_record_alone_is_not_a_wave_anybody_wrote(self):
+        """`resume`'s journal column answers "has this driver written a wave
+        down". `frame-open` files the shape before any wave exists, so a
+        column that counted it would read `yes` for every open frame."""
+
+        frame = self.frame()
+        self._hold_open_at("B1", "2026-08-31T11:30:00Z")
+        self.assertIn("no ", self._resume("--now", FIXED_NOW).splitlines()[1])
+
+        self.journal(frame, "wave 1: one draft out", "wave-1")
+
+        self.assertIn("yes ", self._resume("--now", FIXED_NOW).splitlines()[1])
+
     def test_another_projects_run_is_not_this_projects_to_resume(self):
         self.frame()
         identity = Path(self.temporary.name) / "runs" / self.RUN / "run.json"
@@ -427,6 +607,59 @@ class ResumeTest(FrameSinkTest):
         self.assertEqual(
             "no open frames for this project\n", self._resume(),
         )
+
+
+class SavedWorkflowShapeTest(unittest.TestCase):
+    """Every shipped workflow's root `frame-open` states a plan.
+
+    These bodies are the worked examples a driver copies, so one that
+    opened a planless root would be a refusal in the wild the first time
+    anybody ran it -- and worse, a reader would learn the wrong command.
+    A saved workflow names `--workflow`: its body *is* the plan.
+    """
+
+    def setUp(self):
+        self.bodies = {
+            path.parent.name: path.read_text(encoding="utf-8")
+            for path in sorted(
+                (ROOT / "example-workflows").glob("*/SKILL.md")
+            )
+        }
+        self.assertTrue(self.bodies)
+
+    def test_every_root_frame_open_line_states_a_plan(self):
+        self.assertEqual([], sorted(_planless(self.bodies)))
+
+    def test_dropping_the_flag_from_a_copy_fails_the_check(self):
+        """The can-fail direction (rules/verification.md §8) on copies built
+        beside the tree: one workflow's text at a time, mutated in memory."""
+
+        for name, body in self.bodies.items():
+            if name not in _planless({name: body}, flag=""):
+                continue  # this body opens no root frame to strip
+            with self.subTest(workflow=name):
+                stripped = dict(self.bodies)
+                stripped[name] = body.replace(" --workflow " + name, "")
+                self.assertIn(name, _planless(stripped))
+
+
+def _planless(bodies: dict, flag: str = "--workflow") -> set:
+    """The workflows whose root `frame-open` line names no plan.
+
+    A `--parent` frame is a wave of its caller's shape and owes none, so it
+    is not one of these; `flag=""` asks the weaker question "does this body
+    open a root frame at all", which is what the can-fail case needs to
+    know before it strips anything.
+    """
+
+    named = set()
+    for name, body in bodies.items():
+        for line in body.splitlines():
+            if "tickets.py frame-open" not in line or "--parent" in line:
+                continue
+            if not flag or (flag not in line and "--shape" not in line):
+                named.add(name)
+    return named
 
 
 def _ticket(extra: str) -> str:


### PR DESCRIPTION
## Summary

Routing was not dynamic: a 2026-09-02 audit of six live sessions found the lane named before work in zero of eight tasks, `team` run serially, `plan` unused, and one research ticket carrying five sub-questions that came back as a single-lane packet. Prose alone ("name the lane in one line before working") did not hold, so this makes the plan a door.

- `tickets.py frame-open --shape "<line>"` is required on an ad-hoc root frame; `--workflow NAME` stands in for a saved workflow. A lone `do` is refused to the worker lane, `direct` opens no frame, an unparseable line names its first bad token. The shape is the frame's first journal record and `frame-close` prints it beside the census it actually minted.
- `docs/vocabulary.md`'s routing-shape entry owns the grammar (`>` waves, `[a, b]` parallel, `name[*]` outline-decided, reserved `do`/`outline`/`judge`) and the three-question procedure for choosing one; `SHAPE_GRAMMAR` in `scripts/tickets_shape_line.py` echoes it under an anchor-set test.
- A worker-lane research `do` (no `--parent`) whose goal lists two or more numbered sub-questions is refused before any write. Keyed on the pack's declared adapter, since machinery may not name packs.
- Host block: "write the run's shape line before the first dispatch", team-lane example carries `--shape`, 400/400 words, both pin tests re-anchored. Scaffold and the six saved workflows name `--workflow`.

Run `20260902T063500Z-shape-line`: shape `do[shape-door, research-cut-door] > judge`, two parallel workers, one judge (8 findings, 1 blocking), one repair, frame closed complete. Five required checks exit 0 at the tip, uncached.

Successors: an unknown `--workflow` name still opens a frame; `tickets_mint.py`, `tickets_frame.py`, `tests/test_ticket_frames.py` sit over the warn-only 500-line presumption.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
