### PR TITLE
Remove the stdlib-only rule for ring items; per-item requirements and orchflows env

### DIFF
--- a/.orchflows/skills/super-research/references/evidence.md
+++ b/.orchflows/skills/super-research/references/evidence.md
@@ -248,6 +248,9 @@ adapter added. Stack Exchange compressed its answer only when asked
 argues the cold X/Instagram surfaces are fingerprint-gated at the TLS layer,
 and that a browser-matched ClientHello — chosen once, never rotated on a
 block — might be a lawful persistent identity where stdlib's is flagged on
-the first packet. This delivery holds the pure-stdlib line: the identity
-stays `super-research/0.1` over urllib's own handshake, the gated origins
-stay typed losses, and the law change is the user's call, not a sweep's.
+the first packet. This delivery held the pure-stdlib line: the identity
+stays `super-research/0.1` over urllib's own handshake and the gated origins
+stay typed losses. The line itself was lifted on 2026-09-02 — a ring item
+declares its own dependencies (`docs/custom-workflow-authoring.md`,
+Dependencies) — so a browser-matched transport is now an ordinary
+dependency decision for this item, still the user's call, not a sweep's.

--- a/.orchflows/skills/super-research/references/internals.md
+++ b/.orchflows/skills/super-research/references/internals.md
@@ -5,8 +5,9 @@ two laws a reader has to be told, and what the package refuses.
 
 ## Layout
 
-`scripts/super_research/`, standard library only on the Python 3.9 floor, no I/O
-at import time. The module set is not the one the frozen spec's affected surfaces
+`scripts/super_research/`, on the Python 3.9 floor, importing nothing beyond the
+standard library and what a `requirements.txt` beside the item declares (none
+today), no I/O at import time. The module set is not the one the frozen spec's affected surfaces
 list: `ledger.py`, `ordering.py` and `pacing.py` were split out of `runner.py`,
 `probes.py` and `smoke.py` out of `cli.py`, and `routes.py` out of
 `transport.py`, after the spec froze.

--- a/.orchflows/skills/super-research/scripts/super_research/__init__.py
+++ b/.orchflows/skills/super-research/scripts/super_research/__init__.py
@@ -1,7 +1,8 @@
 """Keyless-first acquisition core for the ``super-research`` skill.
 
-Reliability bar: standard library only on the Python 3.9 floor, and no
-I/O of any kind at import time. Every network touch is funnelled through
+Reliability bar: the Python 3.9 floor, nothing imported beyond the
+standard library and what ``requirements.txt`` beside the item declares,
+and no I/O of any kind at import time. Every network touch is funnelled through
 ``super_research.transport``, which re-exports the route constants
 ``super_research.routes`` declares and so stays the one address they are
 reached at; tests reach the seams by injecting an offline opener.

--- a/.orchflows/skills/super-research/tests/test_dependency_boundary.py
+++ b/.orchflows/skills/super-research/tests/test_dependency_boundary.py
@@ -24,9 +24,10 @@ module is caught here rather than at the first live read.
 
 *The imports.* Every intra-package edge among the core modules, and every
 top-level module the package takes from outside itself. The second list is
-then resolved against this interpreter's own standard library, so "3.9 stdlib
-only" is answered by where the module actually comes from and not by a name
-anybody recognized.
+then resolved against this interpreter's own standard library, and whatever
+does not resolve there must be declared in the item's ``requirements.txt``:
+"nothing undeclared, on the 3.9 floor" is answered by where each module
+actually comes from and not by a name anybody recognized.
 
 *The surfaces that would let it run something instead of read something.*
 Dynamic import, computed dispatch, an SDK, a browser driver, a media
@@ -59,14 +60,15 @@ from .test_dependency_boundary_cases.module_set import (
 )
 from .test_dependency_boundary_cases.runner_dispatch import RunnerDispatchTest
 from .test_dependency_boundary_cases.source_roster import RosterIsReadOffTheSourceTest
-from .test_dependency_boundary_cases.standard_library import (
-    StandardLibraryOnlyTest,
+from .test_dependency_boundary_cases.declared_dependencies import (
+    DeclaredDependenciesOnlyTest,
     TheHostMirrorResolvesFromAnyCheckoutTest,
 )
 
 
 __all__ = (
     "BoundaryOracleCanFailTest",
+    "DeclaredDependenciesOnlyTest",
     "IntraPackageImportTest",
     "LossVocabularyIsReadOffTheSourceTest",
     "ModuleSetTest",
@@ -74,7 +76,6 @@ __all__ = (
     "PrivateSupportOwnershipTest",
     "RosterIsReadOffTheSourceTest",
     "RunnerDispatchTest",
-    "StandardLibraryOnlyTest",
     "TheHostMirrorResolvesFromAnyCheckoutTest",
     "ThisSuiteCountsItsOwnModuleSetTest",
 )

--- a/.orchflows/skills/super-research/tests/test_dependency_boundary_cases/declared_dependencies.py
+++ b/.orchflows/skills/super-research/tests/test_dependency_boundary_cases/declared_dependencies.py
@@ -1,4 +1,4 @@
-"""Standard-library and host-mirror boundary checks."""
+"""Declared-dependency and host-mirror boundary checks."""
 
 import sys
 import unittest
@@ -14,13 +14,23 @@ from .support import (
     STANDARD_LIBRARY_IMPORTS,
     THIRD_PARTY_SURFACES,
     absolute_imports,
+    declared_import_names,
     imports_naming,
     outside_the_standard_library,
     package_sources,
 )
 
-class StandardLibraryOnlyTest(unittest.TestCase):
-    """Criterion 2, dependency half: nothing outside the 3.9 standard library."""
+class DeclaredDependenciesOnlyTest(unittest.TestCase):
+    """Criterion 2, dependency half: nothing undeclared, on the 3.9 floor.
+
+    The stdlib-only bar was lifted on 2026-09-02 (`docs/custom-workflow-
+    authoring.md`, Dependencies): a ring item uses the libraries it needs and
+    declares them in `requirements.txt` beside its manifest. What survives is
+    the enumeration -- every module the package takes from outside itself is
+    spelled out, and every one the interpreter does not answer from its own
+    standard library has to be one the declaration accounts for. An import
+    that is neither is a dependency nobody promised to install.
+    """
 
     def test_the_package_takes_exactly_these_modules_from_outside_itself(self):
         taken = set()
@@ -29,8 +39,14 @@ class StandardLibraryOnlyTest(unittest.TestCase):
 
         self.assertEqual(tuple(sorted(taken)), STANDARD_LIBRARY_IMPORTS)
 
-    def test_every_one_of_them_resolves_inside_this_interpreters_own_stdlib(self):
-        self.assertEqual(outside_the_standard_library(STANDARD_LIBRARY_IMPORTS), [])
+    def test_every_one_outside_the_stdlib_is_declared_beside_the_manifest(self):
+        undeclared = [
+            (name, origin)
+            for name, origin in outside_the_standard_library(STANDARD_LIBRARY_IMPORTS)
+            if name not in declared_import_names()
+        ]
+
+        self.assertEqual(undeclared, [])
 
     def test_the_floor_this_was_resolved_against_is_the_declared_one(self):
         # The resolution above is a fact about the interpreter that ran it, so

--- a/.orchflows/skills/super-research/tests/test_dependency_boundary_cases/support.py
+++ b/.orchflows/skills/super-research/tests/test_dependency_boundary_cases/support.py
@@ -174,22 +174,18 @@ DYNAMIC_IMPORT_MODULES = (
 COMPUTED_NAMES = ("eval", "exec", "compile", "__import__", "globals", "locals", "vars")
 ATTRIBUTE_NAMES = ("getattr", "setattr", "delattr")
 
-# The spec's non-goals, by the name each would be imported under. Checked
-# against imports rather than against text: `adapters/__init__.py` says "asked
-# for fewer requests" in a warning, and a scan that read prose would call that
-# an HTTP client.
+# The spec's non-goals, by the name each would be imported under: a browser
+# driver, a media downloader, or a platform SDK is a surface that runs
+# something or signs in, and the package reads. Checked against imports
+# rather than against text: `adapters/__init__.py` says "asked for fewer
+# requests" in a warning, and a scan that read prose would call that an HTTP
+# client. Plain HTTP clients and HTML parsers left this list on 2026-09-02
+# with the stdlib-only bar: they are ordinary dependencies an item declares.
 THIRD_PARTY_SURFACES = (
     "selenium",
     "playwright",
     "pyppeteer",
     "webdriver",
-    "requests",
-    "httpx",
-    "aiohttp",
-    "urllib3",
-    "bs4",
-    "lxml",
-    "html5lib",
     "yt_dlp",
     "youtube_dl",
     "googleapiclient",
@@ -198,6 +194,14 @@ THIRD_PARTY_SURFACES = (
     "instaloader",
     "snscrape",
 )
+
+# The item's own dependency declaration, pip's format, beside its manifest.
+# Absent means "nothing declared", and every import outside the standard
+# library is then undeclared. A distribution's import name is not always its
+# requirement name (`beautifulsoup4` imports as `bs4`); `IMPORT_NAMES` maps
+# the ones this item adopts, and a name missing from it fails the check.
+DECLARED_REQUIREMENTS = TESTS_DIR.parent / "requirements.txt"
+IMPORT_NAMES = {}
 
 # Strings that could become a command rather than a url.
 SHELL_SPELLINGS = ("sh -c", "/bin/", "cmd.exe", "powershell", "javascript:", "data:")
@@ -371,13 +375,31 @@ def branch_targets(path, function_name):
     return tuple(rows)
 
 
+def declared_import_names():
+    """Every import name the item's ``requirements.txt`` accounts for."""
+
+    if not DECLARED_REQUIREMENTS.is_file():
+        return set()
+    names = set()
+    for raw in DECLARED_REQUIREMENTS.read_text(encoding="utf-8-sig").splitlines():
+        line = raw.split("#", 1)[0].strip()
+        if not line:
+            continue
+        requirement = line.split(";", 1)[0]
+        for separator in ("==", ">=", "<=", "~=", "!=", ">", "<", "[", " "):
+            requirement = requirement.split(separator, 1)[0]
+        distribution = requirement.strip().lower().replace("-", "_").replace(".", "_")
+        names.add(IMPORT_NAMES.get(distribution, distribution))
+    return names
+
+
 def outside_the_standard_library(names):
     """Every name this interpreter does not answer out of its own stdlib.
 
     Resolved rather than recognized. A third-party module answers from
     site-packages and a missing one answers not at all; both are outside, and
-    the pair is what "standard library only" means on the 3.9 floor this suite
-    runs on.
+    each must then be declared in the item's ``requirements.txt`` on the 3.9
+    floor this suite runs on.
     """
 
     outside = []

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1,8 +1,8 @@
 # Architecture
 
 Ceiling: 925 whitespace-delimited words. Terms are
-[the vocabulary](docs/vocabulary.md)'s. Raised from 850 for the ring
-family's five owner modules.
+[the vocabulary](docs/vocabulary.md)'s; raised from 850 for the ring
+family's owner modules.
 
 ## Four tiers
 
@@ -31,7 +31,8 @@ family's five owner modules.
   library terms; `documentation.md` documentation design and the
   reading order; each remaining file its named subject.
 - [`scripts/`](scripts/) owns repository automation. Programs use Python
-  3.9+, Windows and POSIX, then no network. An unprefixed family module is
+  3.9+, its standard library alone (the library's floor, not a ring
+  item's), Windows and POSIX, then no network. An unprefixed family module is
   the public command and import facade; same-family helpers own internal concerns.
   `tickets_format.py` owns syntax, closed parsers, the pack registry;
   `tickets_markdown.py` semantic payload parsing and byte preservation;
@@ -58,8 +59,9 @@ family's five owner modules.
   it and spell no root of their own. `rings_trust.py` owns the never-portable
   trust ledger. `orchflows.py` is the ring and resume command surface over
   `orchflows_home.py` (home layout, the committed/regenerable line, pins),
-  `orchflows_scaffold.py` (`new` skeletons) and `orchflows_adapters.py`
-  (generated inert host adapters).
+  `orchflows_scaffold.py` (`new` skeletons), `orchflows_adapters.py`
+  (generated inert host adapters) and `orchflows_envs.py` (per-item
+  declared environments).
 - [`tools/validate.py`](tools/validate.py) owns mechanical library-text
   admission; [`tools/check_source_sizes.py`](tools/check_source_sizes.py)
   the warn-only executable-source size report.
@@ -83,7 +85,7 @@ family's five owner modules.
   `~/.orchflows/runtime`, and the planning/application/uninstall modules the
   immutable frontend at `~/.orchflows/ui`. User installation is the sole scope,
   creating or reusing both; replacement is staged and
-  probed before an owned prior generation moves. A script module shared with the
+  probed before an owned generation moves. A script module shared with the
   reader is carried in two layouts and must be listed for both — flat `bin/`
   through `installer/inventory.py`, the reader package through
   `installer/planning_support.py` — or the reader fails at first import.
@@ -97,13 +99,13 @@ family's five owner modules.
   build. Its browser dependency direction is `shell -> catalog -> feature ->
   shared`, with one named reuse edge: the Now view renders the Workflows-owned
   [`SummaryFlow`](reader/web/src/features/workflows/view/SummaryFlow.tsx)
-  flowchart and stylesheet rather than paralleling it.
+  flowchart and stylesheet.
 - [`DESIGN.md`](DESIGN.md) owns non-normative rationale; [`README.md`](README.md)
   is the human entry surface, not an owner of agent law.
 
 ## Runtime routing pins
 
-Helper membership derives from code, not inventoried here. Two
+Helper membership derives from code. Two
 non-derivable facts: `scripts/cutcheck.py` owns cut-defect
 detection over issued ticket sets; `scripts/tickets.py` owns
 the public ticket facade, the one root,
@@ -111,7 +113,7 @@ immutable run identity (`opened_at`, installed version, source commit),
 immutable terminal timing (`terminal_at`, terminal ticket, `elapsed_ms`).
 Its `dispatch` owns one launch and its `land` one return, each a single
 transaction over the granular operations, which stay public for recovery.
-`tickets.py help` is operator-only: it answers usage requests.
+`tickets.py help` is operator-only.
 
 The reader family keeps one closed boundary: `reader/scripts/ui_api.py` owns
 route assembly, query validation, shared JSON ETags and closed failures,
@@ -129,8 +131,7 @@ readiness facts and causal explanations.
   [`scripts/state_root.py`](scripts/state_root.py). Research evidence lives in
   the sink's `research/` tree.
 - `.orch/` holds tracked `canary/` fixtures and legacy generated `bin/`
-  scripts named by project receipts; cleanup stays receipt-driven through
-  uninstall.
+  scripts named by project receipts, cleaned up through uninstall.
 
 ## Dependency direction
 
@@ -142,5 +143,5 @@ Packs depend on contracts and may name callable skills. Generic skills
 never name a pack or domain. A workflow calls skills and
 scripts; no skill depends on a workflow. A lower layer
 may link the law or contract binding it; a rule never depends on
-package internals for its meaning. Shared packages never name project packages;
+package internals. Shared packages never name project packages;
 project packages may name visible ones.

--- a/README.md
+++ b/README.md
@@ -31,7 +31,9 @@ This is a user install, the only installation scope. It creates or reuses
 environment used by installed commands even when installation starts from
 an active project environment. Runtime dependencies are declared in
 `requirements-runtime.txt`, with exact hashes for the local UI server and its
-transitive closure.
+transitive closure. A custom skill, pack or workflow declares its own in a
+`requirements.txt` beside it, and `orchflows sync` builds each one its own
+environment.
 Dry runs create nothing, and user uninstall retains the private runtime for
 explicit manual cleanup.
 

--- a/docs/custom-workflow-authoring.md
+++ b/docs/custom-workflow-authoring.md
@@ -79,6 +79,24 @@ drives inside a frame you spawn an agent for, unless you decide otherwise for
 that bundle. The convention costs a spawn and buys the same containment a
 sealed child prompt has.
 
+## Dependencies
+
+The standard-library floor belongs to the library, not to what you author
+on it: [ARCHITECTURE.md](../ARCHITECTURE.md)'s scripts tier states it,
+and a ring item is outside it. Use the libraries the work needs. Declare
+them in one `requirements.txt` beside the item's manifest, pip's own
+format, pinned the way you would pin anything you mean to reproduce.
+`orchflows sync` builds one environment per declaring item under
+`~/.orchflows/envs/<kind>/<name>/`, rebuilds it when the file changes, and
+skips an untrusted project item — installing its packages runs its content,
+which is exactly what trust grants. `orchflows env <kind> <name>` prints the
+interpreter the item's scripts run through: its own environment when it
+declares one, else the interpreter the library's own scripts use. Write that
+command into the item's prose, never a path — an environment is
+machine-local, regenerable, ignored by the home ring's `.gitignore`, and
+never installed under `~/.orchflows/lib/`. An item that declares nothing
+runs as it always did, and what it imports is its own suite's claim to make.
+
 ## The five flows
 
 - **Create** — `orchflows new {skill|pack|workflow} <name>` scaffolds into the

--- a/scripts/orchflows.py
+++ b/scripts/orchflows.py
@@ -1,13 +1,15 @@
 #!/usr/bin/env python3
 """The ring commands, and the one question a returning driver asks.
 
-Six ring verbs over ``scripts/rings.py``'s one resolution order, plus
+Seven ring verbs over ``scripts/rings.py``'s one resolution order, plus
 ``resume``:
 
-    orchflows sync [--project]         make a ring whole and render its adapters
+    orchflows sync [--project]         make a ring whole, render its adapters,
+                                       build every declared item environment
     orchflows add <git-url>@<pin>      pin one external bundle
     orchflows new {skill|pack|workflow} <name>
     orchflows list [--kind K]          every item resolvable from here
+    orchflows env <kind> <name>        the interpreter an item's scripts run through
     orchflows trust [--once] <bundle>  allow one project ring's content
     orchflows untrust <bundle>         withdraw both halves of that grant
     orchflows resume [--now <iso>]     this project's open workflow frames
@@ -29,12 +31,13 @@ from pathlib import Path
 
 if __package__:
     from . import (
-        console, orchflows_adapters, orchflows_home, orchflows_scaffold,
-        rings, rings_trust, state_root,
+        console, orchflows_adapters, orchflows_envs, orchflows_home,
+        orchflows_scaffold, rings, rings_trust, state_root,
     )
 else:  # pragma: no cover - direct/installed flat script path
     import console
     import orchflows_adapters
+    import orchflows_envs
     import orchflows_home
     import orchflows_scaffold
     import rings
@@ -138,6 +141,7 @@ def cmd_sync(args) -> int:
         detail = f" ({record['detail']})" if record.get("detail") else ""
         print(f"import {record['name']} @ {record['pin']}: {record['action']}{detail}")
     _report(orchflows_adapters.write("home"))
+    _report_envs()
     return 0
 
 
@@ -156,6 +160,7 @@ def _sync_project() -> int:
     project = bundle.parent
     print(f"project ring: {bundle}")
     _report(orchflows_adapters.write("project", project=project, start=project))
+    _report_envs()
     return 0
 
 
@@ -164,6 +169,30 @@ def _report(result: dict) -> None:
         print(f"adapter {path}")
     for path in result["removed"]:
         print(f"removed {path}")
+
+
+def _report_envs() -> None:
+    """Build every declared item environment resolvable from here, and say so.
+
+    Both ``sync`` forms end here: an environment is machine-local under the
+    home ring whichever ring declared it, and the inventory is the same
+    resolver a launch reads, so what is built is what can run.
+    """
+
+    for outcome in orchflows_envs.sync(rings.inventory()):
+        if outcome["action"] == "skipped":
+            print(f"env {outcome['kind']} '{outcome['name']}': skipped; {outcome['detail']}")
+        else:
+            print(
+                f"env {outcome['kind']} '{outcome['name']}': "
+                f"{outcome['action']} {outcome['interpreter']}"
+            )
+
+
+def cmd_env(args) -> int:
+    record = orchflows_envs.resolve_interpreter(args.kind, args.name)
+    print(record["interpreter"])
+    return 0
 
 
 def cmd_add(args) -> int:
@@ -258,6 +287,12 @@ def _parser() -> argparse.ArgumentParser:
     created.add_argument("kind", choices=rings.KINDS)
     created.add_argument("name")
     created.set_defaults(handler=cmd_new)
+    environment = subparsers.add_parser(
+        "env", help="the interpreter an item's scripts run through", allow_abbrev=False,
+    )
+    environment.add_argument("kind", choices=rings.KINDS)
+    environment.add_argument("name")
+    environment.set_defaults(handler=cmd_env)
     trusted = subparsers.add_parser("trust", help="allow one project bundle", allow_abbrev=False)
     trusted.add_argument("--once", action="store_true", help="allow one use, record nothing standing")
     trusted.add_argument("bundle")

--- a/scripts/orchflows_envs.py
+++ b/scripts/orchflows_envs.py
@@ -1,0 +1,277 @@
+#!/usr/bin/env python3
+"""One private Python environment per ring item that declares dependencies.
+
+The standard-library floor is the library's own: ``scripts/``, ``tools/``
+and the installer import nothing outside Python 3.9's standard library. A
+ring item -- a custom skill, pack or workflow -- is outside that floor and
+uses whatever libraries it needs. It declares them in one ``requirements.txt``
+beside its manifest, pip's own format, and this module builds the
+environment that file describes at ``~/.orchflows/envs/<kind>/<name>/``:
+created when absent, reused while the file's digest matches the stamp the
+build left, rebuilt when the file changes. An item that declares nothing
+runs on the interpreter this process already runs on -- the private runtime
+once installed -- exactly as before.
+
+Building an environment runs the item's content: pip resolves and executes
+what the file names. That is what trust grants, so an untrusted project
+ring item is skipped here and named with its remedy rather than installed.
+
+Stdlib only, cross-platform, Python 3.9 and up. The only network reach is
+pip's own, inside ``build``, and a caller may inject another builder.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import shutil
+import subprocess
+import sys
+import venv
+from pathlib import Path
+from typing import Callable, Dict, List, Optional
+
+try:
+    from scripts import rings
+except ImportError:  # pragma: no cover - direct/installed flat script path
+    import rings
+
+
+REQUIREMENTS_NAME = "requirements.txt"
+ENVS_DIR = "envs"
+STAMP_NAME = "orchflows-env.json"
+STAMP_SCHEMA = 1
+ACTIONS = ("create", "reuse", "refresh")
+UNTRUSTED_REMEDY = (
+    "{kind} '{name}' declares dependencies, and building them runs its "
+    "content; trust its bundle first: orchflows trust {bundle}"
+)
+UNBUILT_REMEDY = (
+    "{kind} '{name}' declares dependencies but its environment is not built; "
+    "run: orchflows sync"
+)
+
+
+def requirements_of(item_dir) -> Optional[Path]:
+    """The item's dependency declaration beside its manifest, or ``None``."""
+
+    candidate = Path(item_dir) / REQUIREMENTS_NAME
+    return candidate if candidate.is_file() else None
+
+
+def requirement_lines(requirements: Path) -> List[str]:
+    """The file's requirement lines: comments and blank lines stripped."""
+
+    lines = []
+    for raw in requirements.read_text(encoding="utf-8-sig").splitlines():
+        line = raw.split("#", 1)[0].strip()
+        if line:
+            lines.append(line)
+    return lines
+
+
+def env_home(kind: str, name: str, home=None) -> Path:
+    """Where this item's environment lives, under the home ring."""
+
+    root = Path(home) if home is not None else rings.home_ring()
+    return root / ENVS_DIR / rings.kind_of(kind) / rings.item_name(name)
+
+
+def interpreter(env: Path) -> Path:
+    """The interpreter inside one environment, on this platform."""
+
+    if os.name == "nt":
+        return Path(env) / "Scripts" / "python.exe"
+    return Path(env) / "bin" / "python"
+
+
+def digest(requirements: Path) -> str:
+    return hashlib.sha256(Path(requirements).read_bytes()).hexdigest()
+
+
+def read_stamp(env: Path) -> Optional[dict]:
+    """The stamp a successful build left, or ``None`` for anything else."""
+
+    try:
+        loaded = json.loads((Path(env) / STAMP_NAME).read_text(encoding="utf-8"))
+    except (OSError, UnicodeDecodeError, ValueError):
+        return None
+    if not isinstance(loaded, dict) or loaded.get("schema") != STAMP_SCHEMA:
+        return None
+    if not isinstance(loaded.get("requirements_sha256"), str):
+        return None
+    return loaded
+
+
+def action(env: Path, requirements: Path) -> str:
+    """``create``, ``reuse`` or ``refresh``, from the stamp and the file alone."""
+
+    stamp = read_stamp(env)
+    if stamp is None or not interpreter(env).is_file():
+        return "create"
+    if stamp["requirements_sha256"] == digest(requirements):
+        return "reuse"
+    return "refresh"
+
+
+def build(env: Path, requirements: Path) -> None:
+    """Create the environment the way ``python -m venv`` would, then pip.
+
+    Symlinks on POSIX for the same reason the private runtime uses them: a
+    copied interpreter's ``libpython`` reference dangles. pip is bootstrapped
+    only when there is something to install, so a declaration that is all
+    comments costs a bare venv and no network.
+    """
+
+    lines = requirement_lines(requirements)
+    venv.EnvBuilder(
+        symlinks=os.name != "nt", with_pip=bool(lines), clear=True
+    ).create(env)
+    if not lines:
+        return
+    installed = subprocess.run(
+        [
+            str(interpreter(env)),
+            "-m",
+            "pip",
+            "install",
+            "--disable-pip-version-check",
+            "--requirement",
+            str(requirements),
+        ],
+        check=False,
+    )
+    if installed.returncode != 0:
+        raise RuntimeError(
+            f"dependency installation failed for {requirements} (pip exit "
+            f"{installed.returncode})"
+        )
+
+
+def ensure(
+    kind: str,
+    name: str,
+    item_dir,
+    *,
+    home=None,
+    builder: Optional[Callable[[Path, Path], None]] = None,
+) -> Dict[str, object]:
+    """Make one item's environment match its declaration, and say what happened.
+
+    A failed build leaves no stamp and no half-built directory behind, so the
+    next ``sync`` sees ``create`` rather than trusting a broken tree.
+    """
+
+    kind = rings.kind_of(kind)
+    name = rings.item_name(name)
+    requirements = requirements_of(item_dir)
+    if requirements is None:
+        raise ValueError(f"{kind} '{name}' declares no {REQUIREMENTS_NAME}")
+    env = env_home(kind, name, home)
+    decided = action(env, requirements)
+    if decided != "reuse":
+        env.parent.mkdir(parents=True, exist_ok=True)
+        try:
+            (builder or build)(env, requirements)
+            stamp = {
+                "schema": STAMP_SCHEMA,
+                "kind": kind,
+                "name": name,
+                "requirements": str(requirements),
+                "requirements_sha256": digest(requirements),
+            }
+            (env / STAMP_NAME).write_text(
+                json.dumps(stamp, sort_keys=True) + "\n", encoding="utf-8"
+            )
+        except Exception:
+            shutil.rmtree(env, ignore_errors=True)
+            raise
+    return {
+        "kind": kind,
+        "name": name,
+        "action": decided,
+        "env": str(env),
+        "interpreter": str(interpreter(env)),
+        "requirements": str(requirements),
+    }
+
+
+def resolve_interpreter(kind: str, name: str, *, home=None, **overrides) -> Dict[str, object]:
+    """The interpreter one item's scripts run through, resolved as dispatch would.
+
+    Its own environment when it declares one and that environment is built;
+    this process's interpreter when it declares nothing. A declared but
+    unbuilt environment is refused with the ``sync`` remedy rather than
+    answered with an interpreter that lacks what the item imports.
+    """
+
+    record = rings.resolve(kind, name, **overrides)
+    item_dir = Path(str(record["dir"]))
+    requirements = requirements_of(item_dir)
+    if requirements is None:
+        return {
+            "kind": record["kind"],
+            "name": record["name"],
+            "interpreter": sys.executable,
+            "declares": False,
+            "env": None,
+        }
+    env = env_home(str(record["kind"]), str(record["name"]), home)
+    if read_stamp(env) is None or not interpreter(env).is_file():
+        raise rings.RingError(
+            "env-unbuilt",
+            UNBUILT_REMEDY.format(kind=record["kind"], name=record["name"]),
+        )
+    return {
+        "kind": record["kind"],
+        "name": record["name"],
+        "interpreter": str(interpreter(env)),
+        "declares": True,
+        "env": str(env),
+    }
+
+
+def sync(
+    records: List[Dict[str, object]],
+    *,
+    home=None,
+    builder: Optional[Callable[[Path, Path], None]] = None,
+) -> List[Dict[str, object]]:
+    """Every declaring item in one inventory, built or named with its remedy.
+
+    ``records`` is ``rings.inventory``'s output: the same resolver dispatch
+    uses, so an environment built here is one a launch can reach, and a
+    reserved or shadowed item costs nothing. Untrusted project items are
+    reported, never built.
+    """
+
+    outcomes = []
+    for record in records:
+        if record.get("reserved"):
+            continue
+        item_dir = Path(str(record["dir"]))
+        if requirements_of(item_dir) is None:
+            continue
+        kind = str(record["kind"])
+        name = str(record["name"])
+        if record.get("trust") == "untrusted":
+            outcomes.append({
+                "kind": kind,
+                "name": name,
+                "action": "skipped",
+                "detail": UNTRUSTED_REMEDY.format(
+                    kind=kind, name=name, bundle=item_dir.parent.parent,
+                ),
+            })
+            continue
+        outcomes.append(ensure(kind, name, item_dir, home=home, builder=builder))
+    return outcomes
+
+
+__all__ = (
+    "ACTIONS", "ENVS_DIR", "REQUIREMENTS_NAME", "STAMP_NAME", "STAMP_SCHEMA",
+    "UNBUILT_REMEDY", "UNTRUSTED_REMEDY", "action", "build", "digest",
+    "ensure", "env_home", "interpreter", "read_stamp", "requirement_lines",
+    "requirements_of", "resolve_interpreter", "sync",
+)

--- a/scripts/orchflows_home.py
+++ b/scripts/orchflows_home.py
@@ -41,9 +41,11 @@ RECEIPT_FILENAME = "receipt.json"
 GITIGNORE_START = "# BEGIN ORCHFLOWS MANAGED IGNORES"
 GITIGNORE_END = "# END ORCHFLOWS MANAGED IGNORES"
 # Regenerable or machine-local, in that order: the installed library and its
-# runtime, the browser distribution, scratch trees, the pinned clones the
-# lock restores, the trust ledger that must never travel (P2), and the state
-# trees that are heavy or per-run rather than history. `state/friction/` and
+# runtime, the per-item environments `orchflows_envs.py` rebuilds from each
+# item's committed `requirements.txt`, the browser distribution, scratch
+# trees, the pinned clones the lock restores, the trust ledger that must
+# never travel (P2), and the state trees that are heavy or per-run rather
+# than history. `state/friction/` and
 # `state/runs/` are deliberately absent: they are the sync value.
 # The six sink subdirectory names are `state_root.py`'s owners -- its
 # `tickets_root` function for the one with a root already, its five new
@@ -61,6 +63,7 @@ SINK_MANAGED_SUBPATHS = (
 MANAGED_IGNORES = (
     "lib/",
     "runtime/",
+    "envs/",
     "ui/",
     "tmp/",
     "worktrees/",

--- a/tests/serial_compat_manifest.json
+++ b/tests/serial_compat_manifest.json
@@ -1,6 +1,6 @@
 {
  "discovery": {
-  "count": 2182,
+  "count": 2196,
   "identities": [
    "test_affected_tests.TestDiscoveryCache.test_a_new_commit_is_a_new_key_and_is_discovered_again",
    "test_affected_tests.TestDiscoveryCache.test_a_tree_that_cannot_answer_for_a_commit_falls_back_and_says_so",
@@ -683,6 +683,20 @@
    "test_orchflows_cli.SyncTests.test_the_gitignore_covers_the_regenerable_half_and_keeps_the_history",
    "test_orchflows_cli.TrustCommandTests.test_trust_and_untrust_move_the_ledger_and_nothing_else",
    "test_orchflows_cli.TrustCommandTests.test_trust_once_is_spent_and_says_so",
+   "test_orchflows_envs.DeclarationTests.test_requirement_lines_drop_comments_and_blanks",
+   "test_orchflows_envs.DeclarationTests.test_the_declaration_is_one_requirements_file_beside_the_manifest",
+   "test_orchflows_envs.DeclarationTests.test_the_environment_lives_under_the_home_ring_by_kind_and_name",
+   "test_orchflows_envs.EnsureTests.test_a_comment_only_declaration_builds_a_bare_venv_without_pip",
+   "test_orchflows_envs.EnsureTests.test_a_failed_build_leaves_no_stamp_and_no_directory",
+   "test_orchflows_envs.EnsureTests.test_a_stamp_without_an_interpreter_is_not_a_built_environment",
+   "test_orchflows_envs.EnsureTests.test_an_item_that_declares_nothing_has_no_environment_to_ensure",
+   "test_orchflows_envs.EnsureTests.test_create_then_reuse_then_refresh_follow_the_files_digest",
+   "test_orchflows_envs.EnvCommandTests.test_env_prints_the_items_own_interpreter_once_sync_built_it",
+   "test_orchflows_envs.EnvCommandTests.test_env_prints_this_interpreter_for_an_item_that_declares_nothing",
+   "test_orchflows_envs.EnvCommandTests.test_env_refuses_a_declared_but_unbuilt_environment_with_the_sync_remedy",
+   "test_orchflows_envs.SyncTests.test_an_untrusted_project_item_is_named_with_its_remedy_and_never_built",
+   "test_orchflows_envs.SyncTests.test_sync_builds_declaring_items_and_passes_the_silent_ones",
+   "test_orchflows_envs.SyncTests.test_the_home_gitignore_covers_the_environments",
    "test_packs.PackResolutionTests.test_a_bundle_edit_invalidates_the_remembered_grant",
    "test_packs.PackResolutionTests.test_a_pack_relative_signature_contract_feeds_no_digest",
    "test_packs.PackResolutionTests.test_a_referenced_byte_changes_the_digest",
@@ -2185,7 +2199,7 @@
    "tests.test_workspace_cases.start_cases.TestTheStampPreservesTheTicketsByteDomain.test_only_the_two_stamped_lines_differ_from_the_prior_bytes",
    "tests.test_workspace_cases.start_cases.TestTicketsPayloadIsGradedNotItsExitStatus.test_an_error_payload_returned_at_exit_zero_is_a_failure"
   ],
-  "sha256": "b8356cbc5f3c6dcd44024d433a24e76ff05095fcf434e3d6b2e698a9fa27cc8d"
+  "sha256": "e88851b1873d3ba02195230178a4fc511bc7863bbebc181c8d03c08b083e9c71"
  },
  "mutation_owners": [
   {
@@ -3984,6 +3998,22 @@
   {
    "module": "tests.test_orchflows_cli",
    "owner": "_home",
+   "restoration": "selected-module-boundary",
+   "seams": [
+    "environment"
+   ]
+  },
+  {
+   "module": "tests.test_orchflows_envs",
+   "owner": "EnvCommandTests.test_env_prints_the_items_own_interpreter_once_sync_built_it",
+   "restoration": "selected-module-boundary",
+   "seams": [
+    "monkeypatch"
+   ]
+  },
+  {
+   "module": "tests.test_orchflows_envs",
+   "owner": "_world",
    "restoration": "selected-module-boundary",
    "seams": [
     "environment"

--- a/tests/test_orchflows_envs.py
+++ b/tests/test_orchflows_envs.py
@@ -1,0 +1,249 @@
+"""Per-item environments: declared beside the manifest, built by sync, resolved by env."""
+
+from __future__ import annotations
+
+import contextlib
+import io
+import json
+import os
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+from scripts import orchflows, orchflows_envs, rings, rings_trust, state_root
+
+
+@contextlib.contextmanager
+def _world():
+    """A home ring and a project ring under one temporary root, the sink moved."""
+
+    with tempfile.TemporaryDirectory(prefix="orchflows-envs-") as tmp:
+        root = Path(tmp).resolve()
+        home = root / "home"
+        project = root / "project"
+        for kind_dir in rings.RING_DIRS.values():
+            (home / kind_dir).mkdir(parents=True, exist_ok=True)
+            (project / rings.BUNDLE_DIR / kind_dir).mkdir(parents=True, exist_ok=True)
+        with patch.dict(os.environ, {state_root.ENV_VAR: str(home / "state")}):
+            yield {"root": root, "home": home, "project": project}
+
+
+def _item(directory: Path, kind: str, name: str, requirements=None) -> Path:
+    manifest = directory / name / rings.MANIFESTS[kind]
+    manifest.parent.mkdir(parents=True, exist_ok=True)
+    manifest.write_bytes(f"---\nname: {name}\n---\n\nbody\n".encode("utf-8"))
+    if requirements is not None:
+        (manifest.parent / orchflows_envs.REQUIREMENTS_NAME).write_bytes(
+            requirements.encode("utf-8")
+        )
+    return manifest.parent
+
+
+def _fake_builder(calls):
+    """A builder that records its calls and leaves an interpreter behind."""
+
+    def build(env: Path, requirements: Path) -> None:
+        calls.append((env, requirements))
+        target = orchflows_envs.interpreter(env)
+        target.parent.mkdir(parents=True, exist_ok=True)
+        target.write_bytes(b"")
+
+    return build
+
+
+def _run(*argv):
+    out, err = io.StringIO(), io.StringIO()
+    with contextlib.redirect_stdout(out), contextlib.redirect_stderr(err):
+        code = orchflows.main(list(argv))
+    return code, out.getvalue(), err.getvalue()
+
+
+class DeclarationTests(unittest.TestCase):
+    def test_the_declaration_is_one_requirements_file_beside_the_manifest(self):
+        with _world() as world:
+            declaring = _item(world["home"] / "skills", "skill", "fetcher", "requests==2.32.3\n")
+            silent = _item(world["home"] / "skills", "skill", "quiet")
+
+            self.assertEqual(
+                declaring / orchflows_envs.REQUIREMENTS_NAME,
+                orchflows_envs.requirements_of(declaring),
+            )
+            self.assertIsNone(orchflows_envs.requirements_of(silent))
+
+    def test_requirement_lines_drop_comments_and_blanks(self):
+        with _world() as world:
+            item = _item(
+                world["home"] / "skills", "skill", "fetcher",
+                "# pinned on 2026-09-02\n\nrequests==2.32.3  # http\n   \nlxml==5.3.0\n",
+            )
+
+            self.assertEqual(
+                ["requests==2.32.3", "lxml==5.3.0"],
+                orchflows_envs.requirement_lines(orchflows_envs.requirements_of(item)),
+            )
+
+    def test_the_environment_lives_under_the_home_ring_by_kind_and_name(self):
+        with _world() as world:
+            env = orchflows_envs.env_home("skill", "fetcher", world["home"])
+
+            self.assertEqual(world["home"] / "envs" / "skill" / "fetcher", env)
+            self.assertIn("envs", orchflows_envs.interpreter(env).parts)
+
+
+class EnsureTests(unittest.TestCase):
+    def test_create_then_reuse_then_refresh_follow_the_files_digest(self):
+        with _world() as world:
+            item = _item(world["home"] / "skills", "skill", "fetcher", "requests==2.32.3\n")
+            calls = []
+            builder = _fake_builder(calls)
+
+            first = orchflows_envs.ensure("skill", "fetcher", item, home=world["home"], builder=builder)
+            second = orchflows_envs.ensure("skill", "fetcher", item, home=world["home"], builder=builder)
+            (item / orchflows_envs.REQUIREMENTS_NAME).write_bytes(b"requests==2.32.4\n")
+            third = orchflows_envs.ensure("skill", "fetcher", item, home=world["home"], builder=builder)
+
+            self.assertEqual(["create", "reuse", "refresh"], [first["action"], second["action"], third["action"]])
+            self.assertEqual(2, len(calls))
+            stamp = json.loads((Path(third["env"]) / orchflows_envs.STAMP_NAME).read_text(encoding="utf-8"))
+            self.assertEqual(orchflows_envs.digest(item / orchflows_envs.REQUIREMENTS_NAME), stamp["requirements_sha256"])
+            self.assertEqual(str(orchflows_envs.interpreter(Path(third["env"]))), third["interpreter"])
+
+    def test_a_stamp_without_an_interpreter_is_not_a_built_environment(self):
+        with _world() as world:
+            item = _item(world["home"] / "skills", "skill", "fetcher", "requests==2.32.3\n")
+            env = orchflows_envs.env_home("skill", "fetcher", world["home"])
+            env.mkdir(parents=True)
+            (env / orchflows_envs.STAMP_NAME).write_text(
+                json.dumps({"schema": orchflows_envs.STAMP_SCHEMA, "requirements_sha256": orchflows_envs.digest(item / "requirements.txt")}),
+                encoding="utf-8",
+            )
+
+            self.assertEqual("create", orchflows_envs.action(env, item / "requirements.txt"))
+
+    def test_a_failed_build_leaves_no_stamp_and_no_directory(self):
+        with _world() as world:
+            item = _item(world["home"] / "skills", "skill", "fetcher", "requests==2.32.3\n")
+
+            def failing(env: Path, requirements: Path) -> None:
+                orchflows_envs.interpreter(env).parent.mkdir(parents=True, exist_ok=True)
+                raise RuntimeError("pip exit 1")
+
+            with self.assertRaises(RuntimeError):
+                orchflows_envs.ensure("skill", "fetcher", item, home=world["home"], builder=failing)
+
+            env = orchflows_envs.env_home("skill", "fetcher", world["home"])
+            self.assertFalse(env.exists())
+            self.assertEqual("create", orchflows_envs.action(env, item / "requirements.txt"))
+
+    def test_an_item_that_declares_nothing_has_no_environment_to_ensure(self):
+        with _world() as world:
+            item = _item(world["home"] / "skills", "skill", "quiet")
+
+            with self.assertRaises(ValueError):
+                orchflows_envs.ensure("skill", "quiet", item, home=world["home"], builder=_fake_builder([]))
+
+    def test_a_comment_only_declaration_builds_a_bare_venv_without_pip(self):
+        # The one real build: no requirement lines means no pip bootstrap and
+        # no network, so it is cheap enough to run here and it proves the
+        # builder makes an interpreter the stamp can stand behind.
+        with _world() as world:
+            item = _item(world["home"] / "skills", "skill", "bare", "# nothing yet\n")
+
+            record = orchflows_envs.ensure("skill", "bare", item, home=world["home"])
+
+            self.assertEqual("create", record["action"])
+            self.assertTrue(Path(record["interpreter"]).is_file(), record)
+            self.assertIsNotNone(orchflows_envs.read_stamp(Path(record["env"])))
+
+
+class SyncTests(unittest.TestCase):
+    def test_sync_builds_declaring_items_and_passes_the_silent_ones(self):
+        with _world() as world:
+            _item(world["home"] / "skills", "skill", "fetcher", "requests==2.32.3\n")
+            _item(world["home"] / "skills", "skill", "quiet")
+            _item(world["home"] / "packs", "pack", "tabular", "pandas==2.2.3\n")
+            calls = []
+
+            outcomes = orchflows_envs.sync(
+                rings.inventory(home=world["home"], lib=world["root"] / "nolib", start=world["root"]),
+                home=world["home"], builder=_fake_builder(calls),
+            )
+
+            self.assertEqual(
+                [("pack", "tabular", "create"), ("skill", "fetcher", "create")],
+                sorted((o["kind"], o["name"], o["action"]) for o in outcomes),
+            )
+            self.assertEqual(2, len(calls))
+
+    def test_an_untrusted_project_item_is_named_with_its_remedy_and_never_built(self):
+        with _world() as world:
+            bundle = world["project"] / rings.BUNDLE_DIR
+            _item(bundle / "skills", "skill", "fetcher", "requests==2.32.3\n")
+            calls = []
+
+            outcomes = orchflows_envs.sync(
+                rings.inventory(project=bundle, home=world["home"], lib=world["root"] / "nolib", start=world["root"]),
+                home=world["home"], builder=_fake_builder(calls),
+            )
+
+            self.assertEqual([], calls)
+            self.assertEqual(1, len(outcomes), outcomes)
+            self.assertEqual("skipped", outcomes[0]["action"])
+            self.assertIn(f"orchflows trust {bundle}", outcomes[0]["detail"])
+
+            rings_trust.grant(bundle)
+            outcomes = orchflows_envs.sync(
+                rings.inventory(project=bundle, home=world["home"], lib=world["root"] / "nolib", start=world["root"]),
+                home=world["home"], builder=_fake_builder(calls),
+            )
+            self.assertEqual("create", outcomes[0]["action"])
+            self.assertEqual(1, len(calls))
+
+    def test_the_home_gitignore_covers_the_environments(self):
+        from scripts import orchflows_home
+
+        self.assertIn(f"{orchflows_envs.ENVS_DIR}/", orchflows_home.MANAGED_IGNORES)
+
+
+class EnvCommandTests(unittest.TestCase):
+    def test_env_prints_this_interpreter_for_an_item_that_declares_nothing(self):
+        with _world() as world:
+            _item(world["home"] / "skills", "skill", "quiet")
+
+            code, out, err = _run("env", "skill", "quiet")
+
+            self.assertEqual(0, code, err)
+            self.assertEqual(sys.executable, out.strip())
+
+    def test_env_refuses_a_declared_but_unbuilt_environment_with_the_sync_remedy(self):
+        with _world() as world:
+            _item(world["home"] / "skills", "skill", "fetcher", "requests==2.32.3\n")
+
+            code, out, err = _run("env", "skill", "fetcher")
+
+            self.assertEqual(1, code, out)
+            self.assertIn("orchflows sync", err)
+
+    def test_env_prints_the_items_own_interpreter_once_sync_built_it(self):
+        with _world() as world:
+            item = _item(world["home"] / "skills", "skill", "fetcher", "requests==2.32.3\n")
+            with patch.object(orchflows_envs, "build", _fake_builder([])):
+                code, out, err = _run("sync")
+            self.assertEqual(0, code, err)
+            self.assertIn("env skill 'fetcher': create", out)
+
+            code, out, err = _run("env", "skill", "fetcher")
+
+            self.assertEqual(0, code, err)
+            expected = orchflows_envs.interpreter(orchflows_envs.env_home("skill", "fetcher", world["home"]))
+            self.assertEqual(str(expected), out.strip())
+            self.assertEqual(
+                str(item / orchflows_envs.REQUIREMENTS_NAME),
+                orchflows_envs.read_stamp(expected.parent.parent)["requirements"],
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- The stdlib-only floor is now stated once as the library's own (ARCHITECTURE.md scripts tier) and no longer binds custom ring items.
- New `docs/custom-workflow-authoring.md` `## Dependencies`: a ring item declares its libraries in `requirements.txt` beside its manifest.
- New `scripts/orchflows_envs.py`: `orchflows sync` builds one environment per declaring item under `~/.orchflows/envs/<kind>/<name>/` (digest-stamped create/reuse/refresh, untrusted project items skipped with the trust remedy); new `orchflows env <kind> <name>` prints the interpreter an item's scripts run through; `envs/` joins the home ring's managed ignores.
- super-research item: `StandardLibraryOnlyTest` becomes `DeclaredDependenciesOnlyTest` (nothing undeclared on the 3.9 floor); plain HTTP clients and parsers leave the banned-import list, drivers/downloaders/SDKs stay banned.

## Verification
- `tools/run_required.py --no-cache`: all five checks green.
- super-research suite on a real Python 3.9: 1479 tests OK.
- Serial-compat manifest regenerated; the two new seams ruled `selected-module-boundary`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
