### PR TITLE
Default Codex planner and worker to Astra

### DIFF
--- a/hosts/codex.json
+++ b/hosts/codex.json
@@ -39,8 +39,8 @@
       "binding": {
         "agent_type": "orch_planner",
         "fork_turns": "none",
-        "model": "gpt-5.6-sol",
-        "model_reasoning_effort": "ultra"
+        "model": "gpt-6-astra",
+        "model_reasoning_effort": "high"
       }
     },
     "worker": {
@@ -48,8 +48,8 @@
       "binding": {
         "agent_type": "orch_worker",
         "fork_turns": "none",
-        "model": "gpt-5.6-luna",
-        "model_reasoning_effort": "xhigh",
+        "model": "gpt-6-astra",
+        "model_reasoning_effort": "low",
         "service_tier": "fast"
       }
     }

--- a/installer/host_adapters/codex.json
+++ b/installer/host_adapters/codex.json
@@ -60,8 +60,8 @@
         "binding": {
           "agent_type": "orch_planner",
           "fork_turns": "none",
-          "model": "gpt-5.6-sol",
-          "model_reasoning_effort": "ultra"
+          "model": "gpt-6-astra",
+          "model_reasoning_effort": "high"
         },
         "name": "orch-planner"
       },
@@ -69,8 +69,8 @@
         "binding": {
           "agent_type": "orch_worker",
           "fork_turns": "none",
-          "model": "gpt-5.6-luna",
-          "model_reasoning_effort": "xhigh",
+          "model": "gpt-6-astra",
+          "model_reasoning_effort": "low",
           "service_tier": "fast"
         },
         "name": "orch-worker"
@@ -79,5 +79,5 @@
     "schema_version": 1
   },
   "source": "hosts/codex.json",
-  "source_sha256": "a358a949d3dff680dfd158db2fe4aa2000fe9fe3f0fefd56732b0a5c756c0dd4"
+  "source_sha256": "895348a117c9dc4204b63402a749a72aab31f0ec928bf080c02183c4d5e7169e"
 }

--- a/tests/test_dispatch_launch.py
+++ b/tests/test_dispatch_launch.py
@@ -77,7 +77,7 @@ class LaunchResolutionTest(unittest.TestCase):
 
     def test_the_effort_is_the_one_this_host_spells_however_it_spells_it(self):
         for host, role, expected in (
-            ("claude", "worker", "high"), ("codex", "planner", "ultra"),
+            ("claude", "worker", "high"), ("codex", "planner", "high"),
             ("grok", "worker", "high"),
         ):
             with self.subTest(host=host, role=role):

--- a/tests/test_dispatch_launch_command.py
+++ b/tests/test_dispatch_launch_command.py
@@ -255,7 +255,8 @@ class DispatchLaunchTest(unittest.TestCase):
 
         self.assertEqual("spawn_agent", result["launch"]["verb"])
         self.assertEqual("orch_worker", result["launch"]["agent"])
-        self.assertEqual("gpt-5.6-luna", result["launch"]["model"])
+        self.assertEqual("gpt-6-astra", result["launch"]["model"])
+        self.assertEqual("low", result["launch"]["effort"])
         self.assertEqual("fast", result["launch"]["fields"]["service_tier"])
 
     def test_a_sealed_profile_override_resolves_the_planner_binding(self):

--- a/tests/test_installer_cases/planning/scoped_hosts.py
+++ b/tests/test_installer_cases/planning/scoped_hosts.py
@@ -95,16 +95,26 @@ class HostAdapterRenderingTest(unittest.TestCase):
             adapters = Path(tmp) / "adapters"
             render_hosts.render_all(install.HOSTS_DIR, adapters)
             rendered_profiles = install.load_role_profiles(adapters)
-        expected_worker_bindings = {
-            "codex": {"model": "gpt-5.6-luna", "model_reasoning_effort": "xhigh"},
+        expected_role_bindings = {
+            "codex": {
+                "planner": {"model": "gpt-6-astra", "model_reasoning_effort": "high"},
+                "worker": {"model": "gpt-6-astra", "model_reasoning_effort": "low"},
+            },
             "claude": {"model": "claude-opus-5", "effort": "high"},
             "grok": {"model": "grok-4.6", "effort": "high"},
         }
-        for host, binding in expected_worker_bindings.items():
+        for host, expected in expected_role_bindings.items():
             with self.subTest(host=host):
-                actual = rendered_profiles["orch-worker"][host]
-                for field, value in binding.items():
-                    self.assertEqual(value, actual[field])
+                if host == "codex":
+                    for role, binding in expected.items():
+                        with self.subTest(role=role):
+                            actual = rendered_profiles[f"orch-{role}"][host]
+                            for field, value in binding.items():
+                                self.assertEqual(value, actual[field])
+                else:
+                    actual = rendered_profiles["orch-worker"][host]
+                    for field, value in expected.items():
+                        self.assertEqual(value, actual[field])
 
     def test_host_profile_and_authoring_prose_point_to_the_data_owner(self):
         profiles = install.PROFILES_MD.read_text(encoding="utf-8")
@@ -114,7 +124,7 @@ class HostAdapterRenderingTest(unittest.TestCase):
 
         self.assertIn("host records beside this file", profiles)
         self.assertNotIn("| Profile |", profiles)
-        for binding in ("gpt-5.6-sol", "claude-fable-5-1", "grok-4.6"):
+        for binding in ("gpt-6-astra", "claude-fable-5-1", "grok-4.6"):
             self.assertNotIn(binding, profiles)
         self.assertIn("../hosts/", authoring)
         self.assertNotIn("A Claude adapter keeps", authoring)
@@ -347,8 +357,8 @@ class TestScopedHostConfiguration(unittest.TestCase):
                 self.assertIn(parsed["name"], {"orch_planner", "orch_worker"})
                 self.assertIn("developer_instructions", parsed)
                 if parsed["name"] == "orch_worker":
-                    self.assertEqual("gpt-5.6-luna", parsed["model"])
-                    self.assertEqual("xhigh", parsed["model_reasoning_effort"])
+                    self.assertEqual("gpt-6-astra", parsed["model"])
+                    self.assertEqual("low", parsed["model_reasoning_effort"])
 
     def test_user_plan_writes_claude_adapters_and_codex_skill_stubs(self):
         with tempfile.TemporaryDirectory() as tmp:


### PR DESCRIPTION
Codex Orchflows planner and worker subagents currently default to Sol Ultra and Luna Xhigh. This changes the canonical Codex host bindings to gpt-6-astra with high reasoning effort for orch-planner and low reasoning effort for orch-worker.

Regenerates the Codex installer adapter and updates existing dispatch/installer regression expectations for both roles. Other host bindings and the worker service tier are unchanged.

Validation: 112 targeted dispatch/installer/regeneration tests passed (2 skipped). All five required checks passed on the integrated source: validator, module tests, serial compatibility, installation dry run, and git diff --check. Regenerated artifacts passed the no-cache drift check. GitHub checks must pass before merge.
