### PR TITLE
Set installed Codex subagent limit to 15

### DIFF
--- a/installer/foundation.py
+++ b/installer/foundation.py
@@ -97,7 +97,7 @@ AUTO_REMOVE_KINDS = frozenset(
         "frontend-asset",
     )
 ) | GROK_AUTO_REMOVE_KINDS
-CODEX_MAX_THREADS = 20
+CODEX_MAX_THREADS = 15
 CODEX_MAX_DEPTH = 1
 GROK_MAX_CONCURRENT = 20
 # Grok's own cap, not a house choice: a subagent that calls

--- a/tests/test_installer_cases/planning/scoped_hosts.py
+++ b/tests/test_installer_cases/planning/scoped_hosts.py
@@ -338,7 +338,7 @@ class TestScopedHostConfiguration(unittest.TestCase):
             self.assertEqual("1", claude["env"]["EXISTING"])
             self.assertEqual("20", claude["env"]["CLAUDE_CODE_MAX_TOOL_USE_CONCURRENCY"])
             codex = install.tomllib.loads(configs["codex-config"].content)
-            self.assertEqual(20, codex["agents"]["max_threads"])
+            self.assertEqual(15, codex["agents"]["max_threads"])
             self.assertEqual(1, codex["agents"]["max_depth"])
             self.assertTrue(codex["agents"]["custom"])
             self.assertEqual(1, codex["other"]["value"])
@@ -702,7 +702,7 @@ class TestScopedHostConfiguration(unittest.TestCase):
         )
         parsed = install.tomllib.loads(rendered)
 
-        self.assertEqual(20, parsed["agents"]["max_threads"])
+        self.assertEqual(15, parsed["agents"]["max_threads"])
         self.assertEqual(1, parsed["agents"]["max_depth"])
         self.assertEqual(3, details["previous"]["agents.max_threads"])
         self.assertEqual(2, details["previous"]["agents.max_depth"])


### PR DESCRIPTION
Changes the installer-managed agents.max_threads setting from 20 to 15 and updates the existing installer expectations. The setting is a supported alias for the concurrent spawned-agent limit in the official Codex configuration reference.

Validation: all five required repository checks passed. Reinstalled locally and verified agents.max_threads = 15.