### PR TITLE
Require illustrated storyboards before video production

### DIFF
--- a/example-workflows/orchflows-videos/references/admission.md
+++ b/example-workflows/orchflows-videos/references/admission.md
@@ -43,8 +43,9 @@ starting packet, not a globally popular-short ranking or an accepted future revi
 
 Pin the renderer before direction. Both creative helpers select explicit Git
 semantics and isolated making/review with the identical expanded video chain.
-Direction produces a NEW committed Markdown plan and independent review; its
-[verifier](creative.md) binds that commit's bytes and review. Production receives
+Direction produces a NEW committed plan, illustrated panels/contact sheet and
+editable layout source with independent visual review; its [handoff](creative.md)
+separates semantic acceptance from document/review integrity. Production receives
 that accepted identity, actual findings, research, constraints, timing assumptions
 and gaps. Missing review or exhausted repair retains partial artifacts, never acceptance.
 

--- a/example-workflows/orchflows-videos/references/creative.md
+++ b/example-workflows/orchflows-videos/references/creative.md
@@ -1,7 +1,8 @@
 # Direction Git handoff
 
-Direction fixes an original Markdown script/storyboard in the video's Git
-repository before rendering. Its isolated maker and independent judge stamp
+Direction fixes an original Markdown script, static illustrated panels/contact
+sheet and editable layout source in the video's Git repository before final-video
+rendering. Its isolated maker and independent judge stamp
 orchflows-marketing-videos, expanding exactly orch-code, short-videos,
 orchflows-marketing-videos in the public owner's scope. Production consumes the
 accepted commit, not a mutable path or an unreviewed repair.
@@ -10,10 +11,21 @@ Goal carries the complete brief; Context preserves research identities, dated
 observations/gaps, renderer pins, voice/citation requirements, permissions,
 authoring-owner pointer and bound. The direction contains the timed beat plan,
 claim/source and asset/rights ledgers, research-to-choice rationale and unresolved
-production questions. Its acceptance says nothing about future playback or hearing.
+production questions. List repository-relative paths for the illustrated assets,
+editable source and restoration/render instructions in the direction document.
+Commit them with the plan so the reviewed Git identity fixes the complete handoff;
+uncommitted illustrations or missing source leave direction incomplete. Build
+panels from reusable layout components compatible with the pinned renderer, so
+production animates the reviewed type, cards and connectors instead of redrawing
+them. The brief determines hooks, examples, scene count and duration.
+Its acceptance says nothing about future playback or hearing.
 
 Before closing, inspect the actual independent review ticket: it must review the
 exact direction commit with the maker's ordered pins and no blocking findings.
+Confirm the judge inspected the listed panels/contact sheet at target display
+size and checked the editable source, brief and canonical subject relationships.
+Record inspected paths, scale and coverage in that review. Missing illustrated
+assets/source or unavailable visual inspection cannot yield accepted direction.
 Freeze a JSON snapshot with artifact (git:<full commit>), standards (ordered
 objects with name and digest), blockers (empty for accepted direction), and
 review_identity (the actual review ticket/findings locator). Record its SHA256.
@@ -26,6 +38,10 @@ children with the fixed commit, repository-relative Markdown path, committed blo
 SHA256, review snapshot/hash and the three exact maker standard digests:
 
     <resolved-interpreter> <package>/scripts/verify_direction.py --project <workspace> --commit <full-commit> --path <direction.md> --sha256 <blob-sha256> --review <snapshot.json> --review-sha256 <snapshot-sha256> --digests <orch-code-digest> <short-videos-digest> <marketing-digest>
+
+The probe binds the document bytes and review snapshot to the commit; it does not
+inspect linked assets, readability, approval or the truth of review claims.
+The semantic checks above remain required before freezing the snapshot.
 
 Retain absent/corrupt and actual readings. It checks committed bytes and review
 binding; changed direction or pins require a fresh independent review. Pass the

--- a/example-workflows/orchflows-videos/references/renderer.md
+++ b/example-workflows/orchflows-videos/references/renderer.md
@@ -15,6 +15,10 @@ Use `node render.cjs 1 output/final.mp4` for the silent technical tracer or
 `npm run studio` provides local playback; output/final.mp4.png is a sampled still,
 not a contact sheet or evidence of motion. Extend index.tsx into the approved
 film; the sample two-node graphic is deliberately only a render boundary.
+Preserve the accepted storyboard's editable layout components when introducing
+the scaffold: integrate its renderer setup without overwriting reviewed source.
+Animate those same typography, card and connector components; compare changed
+layouts with the fixed panels at target display size before full rendering.
 
 The renderer supports 1–120 seconds at 30 fps, rounding fractional durations to
 the nearest frame. Animation derives from useCurrentFrame; a shared camera

--- a/example-workflows/orchflows-videos/standards/orchflows-marketing-videos/STANDARD.md
+++ b/example-workflows/orchflows-videos/standards/orchflows-marketing-videos/STANDARD.md
@@ -19,8 +19,16 @@ bound. Composition preserves the identity and meaning of its constituent work;
 parallel branches and their join remain distinguishable. Select only concepts
 needed for this brief instead of requiring a product taxonomy in every short.
 
-Default to clean black/dark modern compositions, restrained teal for creating
-and violet for review, minimal readable text and concise narration when used.
+A neutral favorite-coding-agent anchor connects the viewer's existing tool to
+Orchflows without implying one required vendor. For flowcharts, default to a
+vertical spine with teal /orch-do and violet /orch-judge cards; role and effort
+badges remain readable beside durable ticket context. Fanout and join connectors
+make branch ownership and recombination intelligible. Product claims about
+routing, profiles and effort trace to current canonical routing/profile sources;
+a selected model or cost example is not a universal capability or savings claim.
+
+Default to clean black/dark modern compositions, minimal readable text and
+concise narration when used.
 Brief-specific art direction may override these preferences while retaining a
 consistent semantic grammar. Camera movement reveals a relevant relationship;
 retain recognizable anchors and readable settled scales. A zoom-out is optional,

--- a/example-workflows/orchflows-videos/workflows/video-direction/SKILL.md
+++ b/example-workflows/orchflows-videos/workflows/video-direction/SKILL.md
@@ -4,24 +4,22 @@ description: Fix an original, evidence-informed script and storyboard before vid
 disable-model-invocation: true
 ---
 
-Require: subject, audience, intent, duration in 1-120 seconds, brand and assets
-(explicit none allowed), cited research artifact identity with dated observations
-and gaps, selected renderer constraints and dependency identity, rights/provider
-limits, Git workspace, brief voice and citation constraints, per-call bound and outside direction verifier. Carry these
-semantic inputs in Goal and Context; missing required inputs return partial
-evidence and named gaps without making an accepted direction.
+Require: subject, audience, intent, 1-120s duration, brand/assets (none explicit),
+cited research identity with dated observations/gaps, pinned renderer constraints
+and dependencies, rights/providers, Git workspace, voice/citation constraints,
+per-call bound and outside verifier. Carry these in Goal/Context; missing inputs
+return partial evidence and named gaps, never accepted direction.
 
     tickets.py frame-open <run> --goal-file <direction-goal> --workflow video-direction
 
-This private journal fixes the message independently before orchflows-videos hands
-it to production. [Creative handoff](../../references/creative.md) describes
-the document; quality belongs to the shared video standard. Preserve the supplied
-authoring-owner pointer in every governed downstream Context.
+Read [creative handoff](../../references/creative.md) for the fixed production
+record. Preserve the authoring-owner pointer in downstream Context.
 
-**Make.** Use `orch-do` for one original script/storyboard answering the brief's
-throughline. Transfer all Require inputs through the carriers above. Separate
-provisional timing from measured audio, and explain which observations informed
-the choices for this subject and audience.
+**Make.** Use `orch-do` for an original script, illustrated panels/contact sheet
+and editable layout source committed together. Carry all Require inputs;
+distinguish provisional timing from measured audio and justify creative choices.
+Review the actual assets/source at that commit, including target-display panel
+and join inspection.
 
     tickets.py do <run> --parent <frame> --standard orchflows-marketing-videos --goal-file <script-goal>
       --context-file <direction-context> --workspace <workspace>
@@ -36,13 +34,20 @@ Repairs preserve the brief, pins and evidence and address the fixed findings.
 An exhausted review or unavailable required evidence returns the latest direction commit
 as partial, independent findings and gaps; no accepted identity is inferred.
 
+**Present.** Show reviewed panels/contact sheet, direction, commit, findings and
+gaps before full rendering. Pause only for requested user approval, recording its
+covered identity; otherwise continue authorized end-to-end work. Independent
+review is not user approval.
+
 Never: copy reference scripts or assets without rights; turn observed metrics
-into causal promises; render inside this journal; or call a script's acceptance
+into causal promises; render the final video inside this journal (static storyboard
+rendering is required); or call a script's acceptance
 proof of rendered motion or heard audio quality.
 
 Return: `tickets.py frame-close <run> <frame> --done <direction-verifier>` over
 the accepted `git:` identity (absent until independently accepted), latest partial
 direction commit identity, independent `findings:` lines and review identities, shared
-standard pins, production handoff and gaps (`[]` when empty). The caller passes
+standard pins, production handoff including illustrated assets and editable source,
+presentation/approval evidence where applicable, and gaps (`[]` when empty). The caller passes
 this fixed record to production; the verifier checks that document and review
 evidence outside the children.

--- a/example-workflows/orchflows-videos/workflows/video-production/SKILL.md
+++ b/example-workflows/orchflows-videos/workflows/video-production/SKILL.md
@@ -4,23 +4,25 @@ description: Render an independently accepted video direction into a fixed proje
 disable-model-invocation: true
 ---
 
-Require: an independently accepted script/storyboard Git commit identity and its
-findings identity; brief with duration, audience, intent, message and brand; pinned
-renderer decision; assets, rights and provider constraints; git workspace;
-authoring-owner pointer; per-call bound. Inputs are semantic documents, not a
-particular creative workflow's file layout.
+Require: independently accepted direction Git commit containing script,
+illustrated panels/contact sheet and editable source; findings identity; brief
+(duration, audience, intent, message, brand); pinned renderer; assets/rights/providers;
+Git workspace; authoring-owner pointer; per-call bound. Accept semantic documents,
+not a prescribed file layout.
 
     tickets.py frame-open <run> --goal-file <production-goal> --workflow video-production
       --context-file <production-context>
 
-Carry the accepted direction commit, findings, brief, renderer decision, constraints and
-authoring-owner into governed Context. Read [review](../../references/review.md)
-when preparing the production and review goals and the outside probe command.
-Resolve its delivery settings before making; unresolved rights remain gaps and
-permit only the authorized evaluation scope.
+Carry Require inputs into governed Context. Read [review](../../references/review.md)
+for production/review goals and the outside probe. Resolve delivery settings;
+unresolved rights permit only authorized evaluation and remain gaps.
 
 Keep this helper in the orchflows-videos owner scope. Making, review and repairs
 share direction's ordered orch-code, short-videos, orchflows-marketing-videos pins.
+
+Reuse direction's layout components in animation, preserving typography,
+cards and relationships. Check significant design changes against accepted direction
+within existing review allowance and requested user approval.
 
 Make through `orch-do`, applying the rendering method inside the isolated call:
 

--- a/standards/short-videos/STANDARD.md
+++ b/standards/short-videos/STANDARD.md
@@ -26,6 +26,15 @@ must not copy a reference's signature expression or imply asset permission.
 Dated observations identify inspected positions and limits; unsupported creative
 choices are design hypotheses. Direction acceptance proves no rendered quality.
 
+Illustrated storyboards show the intended composition, not only a text outline.
+Panels cover important visual states and joins with enough views to explain the
+film; no fixed panel count applies. Each identifies timing, visible action,
+narration or explicit silence, focal point and transition purpose. Essential
+text, badges and relationships remain legible at the target display size;
+inspect dense panels at that scale, not only enlarged on an authoring canvas.
+Static direction evidence establishes layout and planned continuity, never
+motion, measured speech timing or heard quality.
+
 ## Realization
 
 Hierarchy, concise type, contrast against the moving background and placement-


### PR DESCRIPTION
Video direction previously allowed a text-only storyboard, leaving composition and phone-size readability unresolved until rendering. Require illustrated panels and editable layout source, independently review and present them before full rendering, and reuse the reviewed layouts in production. Approval pauses follow the user brief.

General storyboard quality lives in short-videos; Orchflows-specific vertical diagrams, role/effort labels and durable ticket visuals live in the marketing narrowing. Existing review policy and audiovisual evidence boundaries are preserved.

Validation: independent authoring review had no findings; 44 affected tests and all five uncached required repository checks passed. The seven-file delta passed a trial against customized home packages and was installed with unrelated bytes preserved. No new film or audiovisual acceptance is claimed.
